### PR TITLE
Fix spec.data validation regex

### DIFF
--- a/sealedsecret-crd.jsonnet
+++ b/sealedsecret-crd.jsonnet
@@ -28,7 +28,7 @@ local crd = {
             properties: {
               data: {
                 type: "string",
-                pattern: "^[^A-Za-z0-9+/=]*$", // base64
+                pattern: "^[A-Za-z0-9+/=]*$", // base64
               },
             },
           },


### PR DESCRIPTION
Rather embarrassing fix for a completely incorrect regex in the
CRD validation schema.

Fixes #71