### PR TITLE
Set controller command as image entrypoint

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,4 +3,4 @@ MAINTAINER Angus Lees <gus@inodes.org>
 COPY controller /usr/local/bin/
 
 EXPOSE 8080
-CMD ["controller"]
+ENTRYPOINT ["controller"]


### PR DESCRIPTION
This simple PR modifies the Dockerfile to use the `ENTRYPOINT` instruction instead of `CMD`, as the container's primary purpose is to run the controller. Using an entrypoint is more intuitive to an end-user as they can simply set runtime flags in the pod spec's args.