### PR TITLE
Make sure secret type does not get dropped after sealing and unsealing

### DIFF
--- a/pkg/apis/sealed-secrets/v1alpha1/sealedsecret_expansion.go
+++ b/pkg/apis/sealed-secrets/v1alpha1/sealedsecret_expansion.go
@@ -83,6 +83,7 @@ func NewSealedSecret(codecs runtimeserializer.CodecFactory, pubKey *rsa.PublicKe
 		Spec: SealedSecretSpec{
 			EncryptedData: map[string][]byte{},
 		},
+		Type: secret.Type,
 	}
 
 	// RSA-OAEP will fail to decrypt unless the same label is used
@@ -103,7 +104,7 @@ func NewSealedSecret(codecs runtimeserializer.CodecFactory, pubKey *rsa.PublicKe
 	return s, nil
 }
 
-// Unseal decypts and returns the embedded v1.Secret.
+// Unseal decrypts and returns the embedded v1.Secret.
 func (s *SealedSecret) Unseal(codecs runtimeserializer.CodecFactory, privKey *rsa.PrivateKey) (*v1.Secret, error) {
 	boolTrue := true
 	smeta := s.GetObjectMeta()
@@ -124,6 +125,7 @@ func (s *SealedSecret) Unseal(codecs runtimeserializer.CodecFactory, privKey *rs
 			}
 			secret.Data[key] = plaintext
 		}
+		secret.Type = s.Type
 	} else { // Support decrypting old secrets for backward compatibility
 		plaintext, err := crypto.HybridDecrypt(rand.Reader, privKey, s.Spec.Data, label)
 		if err != nil {

--- a/pkg/apis/sealed-secrets/v1alpha1/types.go
+++ b/pkg/apis/sealed-secrets/v1alpha1/types.go
@@ -38,6 +38,7 @@ type SealedSecret struct {
 
 	Spec SealedSecretSpec `json:"spec"`
 
+	// +optional
 	Type apiv1.SecretType `json:"type,omitempty" protobuf:"bytes,3,opt,name=type,casttype=SecretType"`
 }
 

--- a/pkg/apis/sealed-secrets/v1alpha1/types.go
+++ b/pkg/apis/sealed-secrets/v1alpha1/types.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	apiv1  "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -36,6 +37,8 @@ type SealedSecret struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec SealedSecretSpec `json:"spec"`
+
+	Type apiv1.SecretType `json:"type,omitempty" protobuf:"bytes,3,opt,name=type,casttype=SecretType"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
This addresses #86 and #87, where the secret type is not persisted throughout the sealing/unsealing process. Secret type used to be persisted before v0.6.0 when the whole secret was being sealed, but is now ignored and lost since only secret.Data key-value pairs are being sealed.

Fixes #86
Fixes #87 