### PR TITLE
Switch to kube.libsonnet for generating deployment YAML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ install:
       go get github.com/onsi/ginkgo/ginkgo
     fi
   - |
-    v=0.7.2
+    v=0.8.0
     if ! which kubecfg-$v; then
       wget -O $GOPATH/bin/kubecfg-$v https://github.com/ksonnet/kubecfg/releases/download/v$v/kubecfg-$(go env GOOS)-$(go env GOARCH)
       chmod +x $GOPATH/bin/kubecfg-$v

--- a/controller-norbac.jsonnet
+++ b/controller-norbac.jsonnet
@@ -1,11 +1,5 @@
 // Minimal required deployment for a functional controller.
-local k = import "ksonnet.beta.1/k.libsonnet";
-
-local deployment = k.apps.v1beta1.deployment;
-local container = k.core.v1.container;
-local probe = k.core.v1.probe;
-local service = k.core.v1.service;
-local servicePort = k.core.v1.servicePort;
+local kube = import "kube.libsonnet";
 
 local trim = function(str) (
   if std.startsWith(str, " ") || std.startsWith(str, "\n") then
@@ -17,40 +11,48 @@ local trim = function(str) (
 );
 
 local namespace = "kube-system";
+local controllerImage = std.extVar("CONTROLLER_IMAGE");
 
-local controllerImage = trim(importstr "controller.image");
-local controllerPort = 8080;
-
-local controllerProbe =
-  probe.default() +
-  probe.mixin.httpGet.path("/healthz") +
-  probe.mixin.httpGet.port(controllerPort);
-
-local controllerContainer =
-  container.default("sealed-secrets-controller", controllerImage) +
-  container.command(["controller"]) +
-  container.livenessProbe(controllerProbe) +
-  container.readinessProbe(controllerProbe) +
-  container.securityContext(k.core.v1.podSecurityContext.default()) +
-  container.mixin.securityContext.readOnlyRootFilesystem(true) +
-  container.mixin.securityContext.runAsNonRoot(true) +
-  {securityContext+: {runAsUser: 1001}} +
-  container.helpers.namedPort("http", controllerPort);
-
-local labels = {name: "sealed-secrets-controller"};
-
-local controllerDeployment =
-  deployment.default("sealed-secrets-controller", controllerContainer, namespace) +
-  {spec+: {template+: {metadata: {labels: labels}}}};
-
-local controllerSvc =
-  service.default("sealed-secrets-controller", namespace) +
-  service.spec(k.core.v1.serviceSpec.default()) +
-  service.mixin.spec.selector(labels) +
-  service.mixin.spec.ports([servicePort.default(controllerPort)]);
+// This is a bit odd: Downgrade to apps/v1beta1 so we can continue
+// to support k8s v1.6.
+// TODO: re-evaluate sealed-secrets support timeline and/or
+// kube.libsonnet versioned API support.
+local v1beta1_Deployment(name) = kube.Deployment(name) {
+  assert std.assertEqual(super.apiVersion, "apps/v1beta2"),
+  apiVersion: "apps/v1beta1",
+};
 
 {
-  namespace:: namespace,
-  controller: k.util.prune(controllerDeployment),
-  service: k.util.prune(controllerSvc),
+  namespace:: {metadata+: {namespace: namespace}},
+
+  service: kube.Service("sealed-secrets-controller") + $.namespace {
+    target_pod: $.controller.spec.template,
+  },
+
+  controller: v1beta1_Deployment("sealed-secrets-controller") + $.namespace {
+    spec+: {
+      template+: {
+        spec+: {
+          containers_+: {
+            controller: kube.Container("sealed-secrets-controller") {
+              image: controllerImage,
+              command: ["controller"],
+              readinessProbe: {
+                httpGet: {path: "/healthz", port: "http"},
+              },
+              livenessProbe: self.readinessProbe,
+              ports_+: {
+                http: {containerPort: 8080},
+              },
+              securityContext+: {
+                readOnlyRootFilesystem: true,
+                runAsNonRoot: true,
+                runAsUser: 1001,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
 }

--- a/controller.jsonnet
+++ b/controller.jsonnet
@@ -1,105 +1,61 @@
 // This is the recommended cluster deployment of sealed-secrets.
 // See controller-norbac.jsonnet for the bare minimum functionality.
 
-local k = import "ksonnet.beta.1/k.libsonnet";
+local kube = import "kube.libsonnet";
 local controller = import "controller-norbac.jsonnet";
 
-local objectMeta = k.core.v1.objectMeta;
-local deployment = k.apps.v1beta1.deployment;
-local serviceAccount = k.core.v1.serviceAccount;
-
-local clusterRole(name, rules) = {
-  apiVersion: "rbac.authorization.k8s.io/v1beta1",
-  kind: "ClusterRole",
-  metadata: objectMeta.name(name),
-  rules: rules,
-};
-
-local role(name, namespace, rules) = {
-  apiVersion: "rbac.authorization.k8s.io/v1beta1",
-  kind: "Role",
-  metadata: objectMeta.name(name) + objectMeta.namespace(namespace),
-  rules: rules,
-};
-
-// eg: "apps/v1beta1" -> "apps"
-local apiGroupFromGV(gv) = (
-  local group = std.splitLimit(gv, "/", 1)[0];
-  if group == "v1" then "" else group
-);
-
-local crossGroupRef(target) = {
-  kind: target.kind,
-  apiGroup: apiGroupFromGV(target.apiVersion),
-  name: target.metadata.name,
-};
-
-local clusterRoleBinding(name, role, subjects) = {
-  apiVersion: "rbac.authorization.k8s.io/v1beta1",
-  kind: "ClusterRoleBinding",
-  metadata: objectMeta.name(name),
-  subjects: [
-    crossGroupRef(s) +
-      (if std.objectHas(s.metadata, "namespace") then {namespace: s.metadata.namespace}
-       else {})
-    for s in subjects],
-  roleRef: crossGroupRef(role),
-};
-
-local roleBinding(name, namespace, role, subjects) = {
-  apiVersion: "rbac.authorization.k8s.io/v1beta1",
-  kind: "RoleBinding",
-  metadata: objectMeta.name(name) + objectMeta.namespace(namespace),
-  subjects: [
-    crossGroupRef(s) +
-      (if std.objectHas(s.metadata, "namespace") then {namespace: s.metadata.namespace}
-       else {})
-    for s in subjects],
-  roleRef: crossGroupRef(role),
-};
-
-local namespace = controller.namespace;
-
-local controllerAccount =
-  serviceAccount.default("sealed-secrets-controller", namespace);
-
-local unsealerRole = clusterRole("secrets-unsealer", [
-  {
-    apiGroups: ["bitnami.com"],
-    resources: ["sealedsecrets"],
-    verbs: ["get", "list", "watch"],
-  },
-  {
-    apiGroups: [""],
-    resources: ["secrets"],
-    verbs: ["create", "update", "delete"],  // don't need get
-  },
-]);
-
-local sealKeyRole = role("sealed-secrets-key-admin", namespace, [
-  {
-    apiGroups: [""],
-    resources: ["secrets"],
-    resourceNames: ["sealed-secrets-key"],
-    verbs: ["get"],
-  },
-  {
-    apiGroups: [""],
-    resources: ["secrets"],
-    // Can't limit create by resourceName, because there's no resource yet
-    verbs: ["create"],
-  },
-]);
-
-local unsealerBinding = clusterRoleBinding("sealed-secrets-controller", unsealerRole, [controllerAccount]);
-local unsealKeyBinding = roleBinding("sealed-secrets-controller", namespace, sealKeyRole, [controllerAccount]);
-
 controller + {
-  controller+: deployment.mixin.podSpec.serviceAccountName(
-    controllerAccount.metadata.name),
-  account: k.util.prune(controllerAccount),
-  unsealerRole: unsealerRole,
-  unsealKeyRole: sealKeyRole,
-  unsealerBinding: unsealerBinding,
-  unsealKeyBinding: unsealKeyBinding,
+  account: kube.ServiceAccount("sealed-secrets-controller") + $.namespace,
+
+  unsealerRole: kube.ClusterRole("secrets-unsealer") {
+    rules: [
+      {
+        apiGroups: ["bitnami.com"],
+        resources: ["sealedsecrets"],
+        verbs: ["get", "list", "watch"],
+      },
+      {
+        apiGroups: [""],
+        resources: ["secrets"],
+        verbs: ["create", "update", "delete"],  // don't need get
+      },
+    ],
+  },
+
+  unsealKeyRole: kube.Role("sealed-secrets-key-admin") + $.namespace {
+    rules: [
+      {
+        apiGroups: [""],
+        resources: ["secrets"],
+        resourceNames: ["sealed-secrets-key"],
+        verbs: ["get"],
+      },
+      {
+        apiGroups: [""],
+        resources: ["secrets"],
+        // Can't limit create by resourceName, because there's no resource yet
+        verbs: ["create"],
+      },
+    ],
+  },
+
+  unsealerBinding: kube.ClusterRoleBinding("sealed-secrets-controller") {
+    roleRef_: $.unsealerRole,
+    subjects_+: [$.account],
+  },
+
+  unsealKeyBinding: kube.RoleBinding("sealed-secrets-controller") + $.namespace {
+    roleRef_: $.unsealKeyRole,
+    subjects_+: [$.account],
+  },
+
+  controller+: {
+    spec+: {
+      template+: {
+        spec+: {
+          serviceAccountName: $.account.metadata.name,
+        },
+      },
+    },
+  },
 }

--- a/sealedsecret-crd.jsonnet
+++ b/sealedsecret-crd.jsonnet
@@ -1,25 +1,6 @@
 // CustomResourceDefinition for SealedSecrets. For K8s >= 1.7
-local k = import "ksonnet.beta.1/k.libsonnet";
-
-local objectMeta = k.core.v1.objectMeta;
-
-local crd = {
-  apiVersion: "apiextensions.k8s.io/v1beta1",
-  kind: "CustomResourceDefinition",
-  metadata: objectMeta.name($.spec.names.plural + "." + $.spec.group),
-  spec: {
-    scope: "Namespaced",
-    group: "bitnami.com",
-    version: "v1alpha1",
-    names: {
-      kind: "SealedSecret",
-      singular: "sealedsecret",
-      plural: self.singular + "s",
-      listKind: self.kind + "List",
-    },
-  },
-};
+local kube = import "kube.libsonnet";
 
 {
-  crd: crd,
+  crd: kube.CustomResourceDefinition("bitnami.com", "v1alpha1", "SealedSecret"),
 }

--- a/sealedsecret-tpr.jsonnet
+++ b/sealedsecret-tpr.jsonnet
@@ -1,16 +1,9 @@
 // ThirdPartyResource for SealedSecrets. For K8s <= 1.7
-local k = import "ksonnet.beta.1/k.libsonnet";
-
-local objectMeta = k.core.v1.objectMeta;
-
-local tpr = {
-  apiVersion: "extensions/v1beta1",
-  kind: "ThirdPartyResource",
-  metadata: objectMeta.name("sealed-secret.bitnami.com"),
-  versions: [{name: "v1alpha1"}],
-  description: "A sealed (encrypted) Secret",
-};
+local kube = import "kube.libsonnet";
 
 {
-  tpr: tpr,
+  tpr: kube.ThirdPartyResource("sealed-secret.bitnami.com") {
+    versions_: ["v1alpha1"],
+    description: "A sealed (encrypted) Secret",
+  },
 }


### PR DESCRIPTION
This *should* be a semantic no-op, even though the produced YAML is
not identical (varies in some explicit defaults, names vs numeric
ports, etc)