### PR TITLE
Add support for bors-ng github bot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -146,6 +146,9 @@ branches:
     - master
     # release tags
     - /^v\d+\.\d+\.\d+.*/
+    # for bors (in particular: don't build "staging.tmp")
+    - staging
+    - trying
 
 notifications:
   email:

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,10 @@
+status = [
+  "continuous-integration/travis-ci/push"
+]
+
+pr_status = [
+  "continuous-integration/travis-ci/pr"
+]
+
+required_approvals = 1
+delete_merged_branches = true


### PR DESCRIPTION
Enforce the "not rocket science" rule.

bors modifies the usual github CI workflow in a subtle but important
way:

With regular github, the CI test (eg: travis-ci) needs to pass before
the Merge button goes green - but the PR might be against a stale
version of master, and the test *does not have to pass against
master+PR*.  There is a github option to enforce this too, but it puts
the work on the user and requires them to rebase against HEAD before
the merge button will go green.

After the PR has been "approved" (*), bors rebases the PR and runs the
CI bot (travis) *again* against master+PR, and only merges if that
passes.  Iow, "approve-for-merge" is separated from "actually-merge".

Subtle, but important :P

See https://graydon.livejournal.com/186550.html for the blog version
of the above.

(*) bors approval is indicated with a `bors r+` github comment.  See
https://bors.tech/documentation/ for other bot commands.