### PR TITLE
Support GKE / change the default controller namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,5 @@
 /kubeseal
 /controller.image
 /*-static
-/controller.yaml
+/controller*.yaml
 /docker/controller

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ script:
       minikube update-context
       minikube status
       while ! kubectl cluster-info; do sleep 3; done
-      kubectl create -f $INT_SSC_CONF
+      kubectl apply -f $INT_SSC_CONF
       kubectl rollout status deployment/sealed-secrets-controller -n sealed-secrets -w
       make integrationtest CONTROLLER_IMAGE=$CONTROLLER_IMAGE
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ script:
       minikube status
       while ! kubectl cluster-info; do sleep 3; done
       kubectl create -f $INT_SSC_CONF
-      kubectl rollout status deployment/sealed-secrets-controller -n kube-system -w
+      kubectl rollout status deployment/sealed-secrets-controller -n sealed-secrets -w
       make integrationtest CONTROLLER_IMAGE=$CONTROLLER_IMAGE
     fi
 

--- a/Makefile
+++ b/Makefile
@@ -54,12 +54,13 @@ controller.image: docker/Dockerfile docker/controller
 	mv $@.tmp $@
 
 %.yaml: %.jsonnet
-	$(KUBECFG) show -V CONTROLLER_IMAGE=$(CONTROLLER_IMAGE) -o yaml $< > $@.tmp
+	cat namespace.yaml > $@.tmp # TODO remove when comments at https://github.com/bitnami-labs/sealed-secrets/pull/99#issuecomment-387962489 resolved
+	$(KUBECFG) show -V CONTROLLER_IMAGE=$(CONTROLLER_IMAGE) -o yaml $< >> $@.tmp
 	mv $@.tmp $@
 
-controller.yaml: controller.jsonnet controller.image controller-norbac.jsonnet
+controller.yaml: controller.jsonnet controller.image controller-norbac.jsonnet namespace.yaml
 
-controller-norbac.yaml: controller-norbac.jsonnet controller.image
+controller-norbac.yaml: controller-norbac.jsonnet controller.image namespace.yaml
 
 test:
 	$(GO) test $(GO_FLAGS) $(GO_PACKAGES)

--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -29,7 +29,7 @@ import (
 var (
 	// TODO: Verify k8s server signature against cert in kube client config.
 	certFile       = flag.String("cert", "", "Certificate / public key to use for encryption. Overrides --controller-*")
-	controllerNs   = flag.String("controller-namespace", metav1.NamespaceSystem, "Namespace of sealed-secrets controller.")
+	controllerNs   = flag.String("controller-namespace", "sealed-secrets", "Namespace of sealed-secrets controller.")
 	controllerName = flag.String("controller-name", "sealed-secrets-controller", "Name of sealed-secrets controller.")
 	outputFormat   = flag.String("format", "json", "Output format for sealed secret. Either json or yaml")
 	dumpCert       = flag.Bool("fetch-cert", false, "Write certificate to stdout.  Useful for later use with --cert")

--- a/controller-norbac.jsonnet
+++ b/controller-norbac.jsonnet
@@ -10,7 +10,7 @@ local trim = function(str) (
     str
 );
 
-local namespace = "kube-system";
+local namespace = "sealed-secrets";
 local controllerImage = std.extVar("CONTROLLER_IMAGE");
 
 // This is a bit odd: Downgrade to apps/v1beta1 so we can continue

--- a/controller-norbac.jsonnet
+++ b/controller-norbac.jsonnet
@@ -25,6 +25,8 @@ local v1beta1_Deployment(name) = kube.Deployment(name) {
 {
   namespace:: {metadata+: {namespace: namespace}},
 
+  ns: kube.Namespace($.namespace.metadata.namespace),
+
   service: kube.Service("sealed-secrets-controller") + $.namespace {
     target_pod: $.controller.spec.template,
   },

--- a/controller-norbac.jsonnet
+++ b/controller-norbac.jsonnet
@@ -25,7 +25,8 @@ local v1beta1_Deployment(name) = kube.Deployment(name) {
 {
   namespace:: {metadata+: {namespace: namespace}},
 
-  ns: kube.Namespace($.namespace.metadata.namespace),
+  // TODO uncomment when comments at https://github.com/bitnami-labs/sealed-secrets/pull/99#issuecomment-387962489 resolved
+  // ns: kube.Namespace($.namespace.metadata.namespace),
 
   service: kube.Service("sealed-secrets-controller") + $.namespace {
     target_pod: $.controller.spec.template,

--- a/integration/controller_test.go
+++ b/integration/controller_test.go
@@ -28,7 +28,7 @@ func getData(s *v1.Secret) map[string][]byte {
 }
 
 func fetchKeys(c corev1.SecretsGetter) (*rsa.PrivateKey, []*x509.Certificate, error) {
-	s, err := c.Secrets("kube-system").Get("sealed-secrets-key", metav1.GetOptions{})
+	s, err := c.Secrets("sealed-secrets").Get("sealed-secrets-key", metav1.GetOptions{})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/namespace.yaml
+++ b/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    name: sealed-secrets
+  name: sealed-secrets


### PR DESCRIPTION
Separating it also means we have a little bit more clarity over access to the encryption private key and it's entirely separate from any system components which might have admin permissions (say, the kubernetes dashboard).

Fixes https://github.com/bitnami-labs/sealed-secrets/issues/90.