### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,14 +236,18 @@ No, the private key is only stored in the Secret managed by the controller (unle
 
 If you do want to make a backup of the encryption private key, it's easy to do from an account with suitable access and:
 
-`kubectl get secret -n kube-system sealed-secrets-key -o yaml >master.key`
+```
+$ kubectl get secret -n kube-system sealed-secrets-key -o yaml >master.key
+```
 
 NOTE: This is the controller's public + private key and should be kept omg-safe!
 
 To restore from a backup after some disaster, just put that secret back before starting the controller - or if the controller was already started, replace the newly-created secret and restart the controller:
 
-`kubectl replace secret -n kube-system sealed-secrets-key master.key`
-`kubectl delete pod -n kube-system -l name=sealed-secrets-controller`
+```
+$ kubectl replace -f master.key
+$ kubectl delete pod -n kube-system -l name=sealed-secrets-controller
+```
 
 - What flags are available for kubeseal?
 


### PR DESCRIPTION
- Fix `kubectl replace` command.
- Format backup and recover SealedSecrets encryption private key shell command to be consistent with the rest README file.