### PR TITLE
Retain existing OwnerReferences

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -190,7 +190,14 @@ func (c *Controller) unseal(key string) error {
 
 	_, err = c.sclient.Secrets(ssecret.GetObjectMeta().GetNamespace()).Create(secret)
 	if err != nil && errors.IsAlreadyExists(err) {
+		// Fetch existing owner references
+		existingSecret, err := c.sclient.Secrets(ssecret.GetObjectMeta().GetNamespace()).Get(secret.GetObjectMeta().GetName(), metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		secret.SetOwnerReferences(append(existingSecret.GetOwnerReferences(), secret.GetOwnerReferences()...))
 		_, err = c.sclient.Secrets(ssecret.GetObjectMeta().GetNamespace()).Update(secret)
+
 	}
 	return err
 }

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -191,7 +191,11 @@ func (c *Controller) unseal(key string) error {
 	}
 
 	_, err = c.sclient.Secrets(ssecret.GetObjectMeta().GetNamespace()).Create(secret)
-	if err != nil && !errors.IsAlreadyExists(err) {
+	if err == nil {
+		// Secret successfully created
+		return nil
+	}
+	if !errors.IsAlreadyExists(err) {
 		// Error wasn't already exists so is real error
 		return err
 	}
@@ -210,6 +214,7 @@ func (c *Controller) updateSecret(newSecret *apiv1.Secret) (*apiv1.Secret, error
 	if err != nil {
 		return nil, fmt.Errorf("failed to read existing secret: %s", err)
 	}
+	existingSecret = existingSecret.DeepCopy()
 	existingSecret.Data = newSecret.Data
 
 	c.updateOwnerReferences(existingSecret, newSecret)

--- a/controller.jsonnet
+++ b/controller.jsonnet
@@ -17,7 +17,7 @@ controller + {
       {
         apiGroups: [""],
         resources: ["secrets"],
-        verbs: ["create", "update", "delete"],  // don't need get
+        verbs: ["create", "update", "delete", "get"],
       },
     ],
   },

--- a/integration/controller_test.go
+++ b/integration/controller_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
+	"time"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -130,7 +131,7 @@ var _ = Describe("create", func() {
 				}
 				Eventually(func() (*v1.Secret, error) {
 					return c.Secrets(ns).Get(secretName, metav1.GetOptions{})
-				}).Should(WithTransform(getData, Equal(expected)))
+				}, 5 * time.Second).Should(WithTransform(getData, Equal(expected)))
 			})
 		})
 


### PR DESCRIPTION
This PR ensures that existing `OwnerReferences` on Secrets managed by the controller are retained when a Secret is reconciled.
When an existing Secret is found, the controller will now merge existing OwnerReferences with its own, ensuring that other controllers can use OwnerReferences safely to track these Secrets.

Fixes #127 