### PR TITLE
Support for namespace wide secrets

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -114,7 +114,7 @@ func signKey(r io.Reader, key *rsa.PrivateKey) (*x509.Certificate, error) {
 			CommonName: *myCN,
 		},
 		BasicConstraintsValid: true,
-		IsCA: true,
+		IsCA:                  true,
 	}
 
 	data, err := x509.CreateCertificate(r, &cert, &cert, &key.PublicKey, key)

--- a/integration/controller_test.go
+++ b/integration/controller_test.go
@@ -261,7 +261,6 @@ var _ = Describe("create", func() {
 			var ns2 string
 			BeforeEach(func() {
 				ns2 = createNsOrDie(c, "create")
-				ss.Namespace = ns2
 			})
 			BeforeEach(func() {
 				var err error
@@ -272,6 +271,7 @@ var _ = Describe("create", func() {
 
 				fmt.Fprintf(GinkgoWriter, "Re-sealing secret %#v", s)
 				ss, err = ssv1alpha1.NewSealedSecret(scheme.Codecs, pubKey, s)
+				ss.Namespace = ns2
 				Expect(err).NotTo(HaveOccurred())
 			})
 			AfterEach(func() {
@@ -317,7 +317,6 @@ var _ = Describe("create", func() {
 			var ns2 string
 			BeforeEach(func() {
 				ns2 = createNsOrDie(c, "create")
-				ss.Namespace = ns2
 			})
 			BeforeEach(func() {
 				var err error
@@ -328,6 +327,7 @@ var _ = Describe("create", func() {
 
 				fmt.Fprintf(GinkgoWriter, "Re-sealing secret %#v", s)
 				ss, err = ssv1alpha1.NewSealedSecret(scheme.Codecs, pubKey, s)
+				ss.Namespace = ns2
 				Expect(err).NotTo(HaveOccurred())
 			})
 			AfterEach(func() {

--- a/integration/controller_test.go
+++ b/integration/controller_test.go
@@ -231,7 +231,7 @@ var _ = Describe("create", func() {
 			// the SealedSecret (once implemented)
 		})
 
-		Context("With cluster-wide annotation", func() {
+		Context("With wrong name and cluster-wide annotation", func() {
 			const secretName2 = "not-testsecret"
 			BeforeEach(func() {
 				var err error
@@ -254,6 +254,91 @@ var _ = Describe("create", func() {
 				Eventually(func() (*v1.Secret, error) {
 					return c.Secrets(ns).Get(secretName2, metav1.GetOptions{})
 				}).Should(WithTransform(getData, Equal(expected)))
+			})
+		})
+
+		Context("With wrong namespace and cluster-wide annotation", func() {
+			var ns2 string
+			BeforeEach(func() {
+				ns2 = createNsOrDie(c, "create")
+				ss.Namespace = ns2
+			})
+			BeforeEach(func() {
+				var err error
+
+				s.Annotations = map[string]string{
+					ssv1alpha1.SealedSecretClusterWideAnnotation: "true",
+				}
+
+				fmt.Fprintf(GinkgoWriter, "Re-sealing secret %#v", s)
+				ss, err = ssv1alpha1.NewSealedSecret(scheme.Codecs, pubKey, s)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			AfterEach(func() {
+				deleteNsOrDie(c, ns2)
+			})
+			It("should produce expected Secret", func() {
+				expected := map[string][]byte{
+					"foo": []byte("bar"),
+				}
+				Eventually(func() (*v1.Secret, error) {
+					return c.Secrets(ns2).Get(secretName, metav1.GetOptions{})
+				}).Should(WithTransform(getData, Equal(expected)))
+			})
+		})
+
+		Context("With wrong name and namespace-wide annotation", func() {
+			const secretName2 = "not-testsecret"
+			BeforeEach(func() {
+				var err error
+
+				s.Annotations = map[string]string{
+					ssv1alpha1.SealedSecretNamespaceWideAnnotation: "true",
+				}
+
+				fmt.Fprintf(GinkgoWriter, "Re-sealing secret %#v", s)
+				ss, err = ssv1alpha1.NewSealedSecret(scheme.Codecs, pubKey, s)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			BeforeEach(func() {
+				ss.Name = secretName2
+			})
+			It("should produce expected Secret", func() {
+				expected := map[string][]byte{
+					"foo": []byte("bar"),
+				}
+				Eventually(func() (*v1.Secret, error) {
+					return c.Secrets(ns).Get(secretName2, metav1.GetOptions{})
+				}).Should(WithTransform(getData, Equal(expected)))
+			})
+		})
+
+		Context("With wrong namespace and namespace-wide annotation", func() {
+			var ns2 string
+			BeforeEach(func() {
+				ns2 = createNsOrDie(c, "create")
+				ss.Namespace = ns2
+			})
+			BeforeEach(func() {
+				var err error
+
+				s.Annotations = map[string]string{
+					ssv1alpha1.SealedSecretNamespaceWideAnnotation: "true",
+				}
+
+				fmt.Fprintf(GinkgoWriter, "Re-sealing secret %#v", s)
+				ss, err = ssv1alpha1.NewSealedSecret(scheme.Codecs, pubKey, s)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			AfterEach(func() {
+				deleteNsOrDie(c, ns2)
+			})
+
+			It("should *not* produce a Secret", func() {
+				Consistently(func() error {
+					_, err := c.Secrets(ns2).Get(secretName, metav1.GetOptions{})
+					return err
+				}).Should(WithTransform(errors.IsNotFound, Equal(true)))
 			})
 		})
 	})

--- a/pkg/apis/sealed-secrets/v1alpha1/sealedsecret_expansion.go
+++ b/pkg/apis/sealed-secrets/v1alpha1/sealedsecret_expansion.go
@@ -13,13 +13,17 @@ import (
 	"github.com/bitnami-labs/sealed-secrets/pkg/crypto"
 )
 
-func labelFor(o metav1.Object) ([]byte, bool) {
-	label := o.GetAnnotations()[SealedSecretClusterWideAnnotation]
-	if label == "true" {
-		return []byte(""), true
+// Returns labels followed by clusterWide followed by namespaceWide.
+func labelFor(o metav1.Object) ([]byte, bool, bool) {
+	clusterWide := o.GetAnnotations()[SealedSecretClusterWideAnnotation]
+	if clusterWide == "true" {
+		return []byte(""), true, false
 	}
-	label = fmt.Sprintf("%s/%s", o.GetNamespace(), o.GetName())
-	return []byte(label), false
+	namespaceWide := o.GetAnnotations()[SealedSecretNamespaceWideAnnotation]
+	if namespaceWide == "true" {
+		return []byte(fmt.Sprintf("%s", o.GetNamespace())), false, true
+	}
+	return []byte(fmt.Sprintf("%s/%s", o.GetNamespace(), o.GetName())), false, false
 }
 
 // NewSealedSecretV1 creates a new SealedSecret object wrapping the
@@ -44,7 +48,7 @@ func NewSealedSecretV1(codecs runtimeserializer.CodecFactory, pubKey *rsa.Public
 
 	// RSA-OAEP will fail to decrypt unless the same label is used
 	// during decryption.
-	label, clusterWide := labelFor(secret)
+	label, clusterWide, _ := labelFor(secret)
 
 	ciphertext, err := crypto.HybridEncrypt(rand.Reader, pubKey, plaintext, label)
 	if err != nil {
@@ -88,7 +92,7 @@ func NewSealedSecret(codecs runtimeserializer.CodecFactory, pubKey *rsa.PublicKe
 
 	// RSA-OAEP will fail to decrypt unless the same label is used
 	// during decryption.
-	label, clusterWide := labelFor(secret)
+	label, clusterWide, namespaceWide := labelFor(secret)
 
 	for key, value := range secret.Data {
 		ciphertext, err := crypto.HybridEncrypt(rand.Reader, pubKey, value, label)
@@ -100,6 +104,9 @@ func NewSealedSecret(codecs runtimeserializer.CodecFactory, pubKey *rsa.PublicKe
 
 	if clusterWide {
 		s.Annotations = map[string]string{SealedSecretClusterWideAnnotation: "true"}
+	}
+	if namespaceWide {
+		s.Annotations = map[string]string{SealedSecretNamespaceWideAnnotation: "true"}
 	}
 	return s, nil
 }
@@ -113,7 +120,7 @@ func (s *SealedSecret) Unseal(codecs runtimeserializer.CodecFactory, privKey *rs
 	// during encryption.  This check ensures that we can't be
 	// tricked into decrypting a sealed secret into an unexpected
 	// namespace/name.
-	label, _ := labelFor(smeta)
+	label, _, _ := labelFor(smeta)
 
 	var secret v1.Secret
 	if len(s.Spec.EncryptedData) > 0 {

--- a/pkg/apis/sealed-secrets/v1alpha1/sealedsecret_test.go
+++ b/pkg/apis/sealed-secrets/v1alpha1/sealedsecret_test.go
@@ -381,7 +381,8 @@ func TestUnsealingV1Format(t *testing.T) {
 			Name:      "myname",
 			Namespace: "myns",
 			Annotations: map[string]string{
-				SealedSecretClusterWideAnnotation: "true",
+				SealedSecretClusterWideAnnotation:   "true",
+				SealedSecretNamespaceWideAnnotation: "true",
 			},
 		},
 		Data: map[string][]byte{

--- a/pkg/apis/sealed-secrets/v1alpha1/sealedsecret_test.go
+++ b/pkg/apis/sealed-secrets/v1alpha1/sealedsecret_test.go
@@ -34,9 +34,9 @@ func TestLabel(t *testing.T) {
 			Namespace: "myns",
 		},
 	}
-	l, c := labelFor(&s)
+	l, c, _ := labelFor(&s)
 	if c {
-		t.Errorf("Unexpected value for custom: %#v", c)
+		t.Errorf("Unexpected value for cluster wide annotation: %#v", c)
 	}
 	if string(l) != "myns/myname" {
 		t.Errorf("Unexpected label: %#v", l)
@@ -53,9 +53,51 @@ func TestClusterWide(t *testing.T) {
 			},
 		},
 	}
-	l, c := labelFor(&s)
+	l, c, _ := labelFor(&s)
 	if !c {
-		t.Errorf("Unexpected value for custom: %#v", c)
+		t.Errorf("Unexpected value for cluster wide annotation: %#v", c)
+	}
+	if string(l) != "" {
+		t.Errorf("Unexpected label: %#v", l)
+	}
+}
+
+func TestNamespaceWide(t *testing.T) {
+	s := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myname",
+			Namespace: "myns",
+			Annotations: map[string]string{
+				SealedSecretNamespaceWideAnnotation: "true",
+			},
+		},
+	}
+	l, _, n := labelFor(&s)
+	if !n {
+		t.Errorf("Unexpected value for namespace wide annotation: %#v", n)
+	}
+	if string(l) != "myns" {
+		t.Errorf("Unexpected label: %#v", l)
+	}
+}
+
+func TestClusterAndNamespaceWide(t *testing.T) {
+	s := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myname",
+			Namespace: "myns",
+			Annotations: map[string]string{
+				SealedSecretNamespaceWideAnnotation: "true",
+				SealedSecretClusterWideAnnotation:   "true",
+			},
+		},
+	}
+	l, c, n := labelFor(&s)
+	if !c {
+		t.Errorf("Unexpected value for cluster wide annotation: %#v", c)
+	}
+	if n {
+		t.Errorf("Unexpected value for namespace wide annotation: %#v", n)
 	}
 	if string(l) != "" {
 		t.Errorf("Unexpected label: %#v", l)
@@ -234,6 +276,86 @@ func TestSealRoundTripWithMisMatchClusterWide(t *testing.T) {
 	}
 
 	ssecret.ObjectMeta.Annotations[SealedSecretClusterWideAnnotation] = "false"
+
+	_, err = ssecret.Unseal(codecs, key)
+	if err == nil {
+		t.Fatalf("Unseal did not return expected error: %v", err)
+	}
+}
+
+func TestSealRoundTripWithNamespaceWide(t *testing.T) {
+	scheme := runtime.NewScheme()
+	codecs := serializer.NewCodecFactory(scheme)
+
+	SchemeBuilder.AddToScheme(scheme)
+	v1.SchemeBuilder.AddToScheme(scheme)
+
+	rand := testRand()
+	key, err := rsa.GenerateKey(rand, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate test key: %v", err)
+	}
+
+	secret := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myname",
+			Namespace: "myns",
+			Annotations: map[string]string{
+				SealedSecretNamespaceWideAnnotation: "true",
+			},
+		},
+		Data: map[string][]byte{
+			"foo": []byte("bar"),
+		},
+	}
+
+	ssecret, err := NewSealedSecret(codecs, &key.PublicKey, &secret)
+	if err != nil {
+		t.Fatalf("NewSealedSecret returned error: %v", err)
+	}
+
+	secret2, err := ssecret.Unseal(codecs, key)
+	if err != nil {
+		t.Fatalf("Unseal returned error: %v", err)
+	}
+
+	if !reflect.DeepEqual(secret.Data, secret2.Data) {
+		t.Errorf("Unsealed secret != original secret: %v != %v", secret, secret2)
+	}
+}
+
+func TestSealRoundTripWithMisMatchNamespaceWide(t *testing.T) {
+	scheme := runtime.NewScheme()
+	codecs := serializer.NewCodecFactory(scheme)
+
+	SchemeBuilder.AddToScheme(scheme)
+	v1.SchemeBuilder.AddToScheme(scheme)
+
+	rand := testRand()
+	key, err := rsa.GenerateKey(rand, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate test key: %v", err)
+	}
+
+	secret := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myname",
+			Namespace: "myns",
+			Annotations: map[string]string{
+				SealedSecretNamespaceWideAnnotation: "true",
+			},
+		},
+		Data: map[string][]byte{
+			"foo": []byte("bar"),
+		},
+	}
+
+	ssecret, err := NewSealedSecret(codecs, &key.PublicKey, &secret)
+	if err != nil {
+		t.Fatalf("NewSealedSecret returned error: %v", err)
+	}
+
+	ssecret.ObjectMeta.Annotations[SealedSecretNamespaceWideAnnotation] = "false"
 
 	_, err = ssecret.Unseal(codecs, key)
 	if err == nil {

--- a/pkg/apis/sealed-secrets/v1alpha1/types.go
+++ b/pkg/apis/sealed-secrets/v1alpha1/types.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 import (
-	apiv1  "k8s.io/api/core/v1"
+	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -15,8 +15,12 @@ const (
 	annoNs = "sealedsecrets." + GroupName + "/"
 
 	// SealedSecretClusterWideAnnotation is the name for the annotation for
-	// setting the secret to be availible cluster wide.
+	// setting the secret to be available cluster wide.
 	SealedSecretClusterWideAnnotation = annoNs + "cluster-wide"
+
+	// SealedSecretNamespaceWideAnnotation is the name for the annotation for
+	// setting the secret to be available namespace wide.
+	SealedSecretNamespaceWideAnnotation = annoNs + "namespace-wide"
 )
 
 // SealedSecretSpec is the specification of a SealedSecret


### PR DESCRIPTION
Adds annotation `sealedsecrets.bitnami.com/namespace-wide`. The cluster wide annotation takes priority over this, if both are specified the cluster wide annotation wins.

Fixes https://github.com/bitnami-labs/sealed-secrets/issues/89