### PR TITLE
GoReleaser build and release support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,12 +13,15 @@
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
 
+# Output from goreleaser
+/dist
+
 /controller
 /kubeseal
 /controller.image
 /*-static
 /controller.yaml
-/sealedsecret-crd.yaml
+/controller-norbac.yaml
 /docker/controller
 *.iml
 .idea

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,82 @@
+## Bitnami Sealed Secrets
+
+release:
+  # Comment out to enable publishing
+  disable: true
+
+builds:
+- binary: controller
+  main: ./cmd/controller/
+  env:
+  - CGO_ENABLED=0
+  goarch:
+  - amd64
+  goos:
+  - linux
+  - darwin
+  - windows
+  ldflags: -X main.VERSION={{.Version}}
+  hooks:
+    post: make -B controller.yaml controller-norbac.yaml
+- binary: kubeseal
+  main: ./cmd/kubeseal/
+  env:
+  - CGO_ENABLED=0
+  goarch:
+  - amd64
+  goos:
+  - linux
+  - darwin
+  - windows
+  ldflags: -X main.VERSION={{.Version}}
+
+# TODO: use upstream formula https://github.com/Homebrew/homebrew-core/blob/master/Formula/kubeseal.rb
+# brew:
+#   github:
+#     owner: bitnami-labs
+#     name: sealed-secrets
+#   homepage: "https://github.com/bitnami-labs/sealed-secrets/"
+#   description: "A Kubernetes controller and tool for one-way encrypted Secrets"
+#   skip_upload: true
+#   # Replace with existing brew formula
+#   test: |
+#     system "#{bin}/program --version"
+
+dockers:
+- goarch: amd64
+  goos: linux
+  binaries:
+  - controller
+  dockerfile: ./docker/Dockerfile
+  image_templates:
+  - quay.io/bitnami-labs/sealed-secrets-controller:latest
+  - quay.io/bitnami-labs/sealed-secrets-controller:latest-amd64
+  - quay.io/bitnami-labs/sealed-secrets-controller:{{ .Version }}
+  - quay.io/bitnami-labs/sealed-secrets-controller:{{ .Version }}-amd64
+  # Comment below out to push to configured repository
+  skip_push: true
+
+archive:
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+  format_overrides:
+  - goos: windows
+    format: zip
+  files:
+  - controller.yaml
+  - controller-norbac.yaml
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  name_template: "{{ .FullCommit }}"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ script:
   - ./$EXE_NAME --help || test $? -eq 2
   - |
     if [ "$TRAVIS_OS_NAME" = linux ]; then
-      make controller.yaml controller-norbac.yaml CONTROLLER_IMAGE=$CONTROLLER_IMAGE
+      make controller.image controller.yaml controller-norbac.yaml CONTROLLER_IMAGE=$CONTROLLER_IMAGE
     fi
   - |
     if [ "$INT_KVERS" != "" ]; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing
+
+## Installation from source
+
+If you just want the latest client tool, it can be installed into
+`$GOPATH/bin` with:
+
+```sh
+$ go get github.com/bitnami-labs/sealed-secrets/cmd/kubeseal
+```
+
+## Developing
+
+To be able to develop on this project, you need to have the following tools installed:
+* make
+* [Ginkgo](https://onsi.github.io/ginkgo/)
+* [Minikube](https://github.com/kubernetes/minikube)
+* [kubecfg](https://github.com/ksonnet/kubecfg)
+* [goreleaser](https://github.com/goreleaser/goreleaser)
+* Go
+
+First fork the repo.  
+Then clone the repo using `go get` to preserve paths and add your fork as a remote:
+```sh
+$ go get github.com/bitnami-labs/sealed-secrets
+$ cd $GOPATH/src/github.com/bitnami-labs/sealed-secrets # GOPATH is $HOME/go by default.
+
+$ git remote rename origin upstream
+$ git remote add origin <FORK_URL>
+```
+
+To build the `kubeseal` and `controller` binaries:
+```sh
+$ make
+```
+
+To build everything; binaries, archives, docker images with `goreleaser`:
+```sh
+$ make snapshot
+```
+
+To run the unit tests:
+```bash
+$ make test
+```
+
+To run the integration tests:
+* Start Minikube
+* Build the controller for Linux, so that it can be run within a Docker image - edit the Makefile to add 
+`GOOS=linux GOARCH=amd64` to `%-static`, and then run `make controller.yaml`
+* Alter `controller.yaml` so that `imagePullPolicy: Never`, to ensure that the image you've just built will be
+used by Kubernetes
+* Add the sealed-secret CRD and controller to Kubernetes - `kubectl apply -f controller.yaml`
+* Revert any changes made to the Makefile to build the Linux controller
+* Remove the binaries which were possibly built for another OS - `make clean`
+* Rebuild the binaries for your OS - `make`
+* Run the integration tests - `make integrationtest`
+

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
 GO = go
 GO_FLAGS =
 GOFMT = gofmt
+GORELEASER = goreleaser
 
 KUBECFG = kubecfg -U https://github.com/bitnami-labs/kube-libsonnet/raw/52ba963ca44f7a4960aeae9ee0fbee44726e481f
 DOCKER = docker
 GINKGO = ginkgo -p
 
-CONTROLLER_IMAGE = sealed-secrets-controller:latest
+# + is not a permitted character in image tags and '+dirty' is not passed in to goreleaser breaking snapshots
+CONTROLLER_IMAGE = $(subst +dirty,,quay.io/bitnami-labs/sealed-secrets-controller:$(VERSION))
 KUBECONFIG ?= $(HOME)/.kube/config
 
 # TODO: Simplify this once ./... ignores ./vendor
@@ -57,9 +59,10 @@ controller.image: docker/Dockerfile docker/controller
 	$(KUBECFG) show -V CONTROLLER_IMAGE=$(CONTROLLER_IMAGE) -o yaml $< > $@.tmp
 	mv $@.tmp $@
 
-controller.yaml: controller.jsonnet controller.image controller-norbac.jsonnet
+controller.yaml: controller.jsonnet controller-norbac.jsonnet
 
-controller-norbac.yaml: controller-norbac.jsonnet controller.image
+# This could be removed as the %.yaml above will generate this
+controller-norbac.yaml: controller-norbac.jsonnet
 
 test:
 	$(GO) test $(GO_FLAGS) $(GO_PACKAGES)
@@ -81,5 +84,15 @@ clean:
 	$(RM) *-static
 	$(RM) controller*.yaml
 	$(RM) docker/controller
+	$(RM) -r dist/
+
+release: clean ## Generate a release, but don't publish to GitHub.
+	$(GORELEASER) --skip-validate --skip-publish
+
+publish: clean ## Generate a release, and publish to GitHub.
+	$(GORELEASER)
+
+snapshot: clean ## Generate a snapshot release.
+	$(GORELEASER) --snapshot --skip-validate --skip-publish
 
 .PHONY: all kubeseal controller test clean vet fmt

--- a/README.md
+++ b/README.md
@@ -11,72 +11,93 @@ decrypted only by the controller running in the target cluster and
 nobody else (not even the original author) is able to obtain the
 original Secret from the SealedSecret.
 
+<br>
+
 ## Installation
+
+There are two parts to installation:
+* [controller](#controller-installation) 
+* [kubeseal](#kubeseal-installation)
 
 See https://github.com/bitnami-labs/sealed-secrets/releases for the latest
 release.
 
+<br>
+
+## Controller Installation
+
+`controller.yaml` will install the `controller` into `kube-system` namespace, create a service account, necessary RBAC roles and a `SealedSecret` CRD.  
+After a few moments, the `controller` will start, generate a key pair, and be ready for operation.  If it does not, check the `controller` logs.
+
+The key certificate (public key portion) is used for sealing secrets, and will be printed to the `controller` log on startup.
+
 ```sh
-$ release=$(curl --silent "https://api.github.com/repos/bitnami-labs/sealed-secrets/releases/latest" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
-
-# Install client-side tool into /usr/local/bin/
-$ GOOS=$(go env GOOS)
-$ GOARCH=$(go env GOARCH)
-$ wget https://github.com/bitnami-labs/sealed-secrets/releases/download/$release/kubeseal-$GOOS-$GOARCH
-$ sudo install -m 755 kubeseal-$GOOS-$GOARCH /usr/local/bin/kubeseal
-
 # Note:  If installing on a GKE cluster, a ClusterRoleBinding may be needed to successfully deploy the controller in the final command.  Replace <your-email> with a valid email, and then deploy the cluster role binding:
 $ USER_EMAIL=<your-email>
 $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=$USER_EMAIL
 
-# Install SealedSecret CRD, server-side controller into kube-system namespace (by default)
-$ kubectl create -f https://github.com/bitnami-labs/sealed-secrets/releases/download/$release/controller.yaml
+# get latest release version
+$ release=$(curl --silent "https://api.github.com/repos/bitnami-labs/sealed-secrets/releases/latest" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
+
+# Download release
+$ wget https://github.com/bitnami-labs/sealed-secrets/releases/download/$release/sealed-secrets_$release_$(uname)_$(uname -m).tar.gz
+
+# Extract release
+$ tar -zxvf sealed-secrets_$release_$(uname)_$(uname -m).tar.gz
+
+# For clusters with RBAC
+$ kubectl apply -f controller.yaml
+
+# For clusters without RBAC
+$ kubectl apply -f controller-norbac.yaml
 ```
 
-`controller.yaml` will create the `SealedSecret` resource and install the controller
-into `kube-system` namespace, create a service account and necessary
-RBAC roles.
+### Saving key certificate - Recommended
 
-After a few moments, the controller will start, generate a key pair,
-and be ready for operation.  If it does not, check the controller
-logs.
-
-The key certificate (public key portion) is used for sealing secrets,
-and needs to be available wherever `kubeseal` is going to be
-used. The certificate is not secret information, although you need to
-ensure you are using the correct file.
-
-`kubeseal` will fetch the certificate from the controller at runtime
-(requires secure access to the Kubernetes API server), which is
-convenient for interactive use.  The recommended automation workflow
-is to store the certificate to local disk with
-`kubeseal --fetch-cert >mycert.pem`,
-and use it offline with `kubeseal --cert mycert.pem`.
-The certificate is also printed to the controller log on startup.
-
-### Installation from source
-
-If you just want the latest client tool, it can be installed into
-`$GOPATH/bin` with:
+The public cert can be commited to git and supplied as an argument to `kubeseal` instead of requiring cluster access. For example: `kubeseal --cert mycert.pem`
 
 ```sh
-% go get github.com/bitnami-labs/sealed-secrets/cmd/kubeseal
+# Save public cert to file (if using port-forward or other method to expose the controller)
+$ kubeseal --fetch-cert > mycert.pem
 ```
 
-For a more complete development environment, clone the repository and
-use the Makefile:
+<br>
 
+## Kubeseal Installation
+
+MacOS: 
 ```sh
-% git clone https://github.com/bitnami-labs/sealed-secrets.git
-% cd sealed-secrets
-
-# Build client-side tool and controller binaries
-% make
+$ brew install kubeseal
 ```
 
-## Usage
+Linux:
+```sh
+# get latest release version
+$ release=$(curl --silent "https://api.github.com/repos/bitnami-labs/sealed-secrets/releases/latest" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
+
+# Download release
+$ wget https://github.com/bitnami-labs/sealed-secrets/releases/download/$release/sealed-secrets_$release_$(uname)_$(uname -m).tar.gz
+
+# Extract release
+$ tar -zxvf sealed-secrets_$release_$(uname)_$(uname -m).tar.gz
+
+# Install in path (if required)
+$ sudo install -m 755 kubeseal /usr/local/bin/kubeseal
+```
+
+Windows:
+- download latest [release](https://github.com/bitnami-labs/sealed-secrets/releases/latest)
+- extract archive
+
+<br>
+
+## Client usage 
 
 **WARNING**: A bug in the current version is limiting secrets to use the "opaque" type. If you need to use another secret type (eg: `kubernetes.io/dockerconfigjson`), please use kubeseal from release 0.5.1 until [#86](https://github.com/bitnami-labs/sealed-secrets/issues/86) and [#92](https://github.com/bitnami-labs/sealed-secrets/issues/92) are resolved.
+
+`kubeseal` will fetch the certificate from the controller at runtime (requires secure access to the Kubernetes API server), which is convenient for interactive use.  
+The recommended automation workflow is to store the certificate to local disk and use it offline with `kubeseal --cert mycert.pem`. See [Saving key certificate](#saving-key-certificate---recommended)
+
 
 ```sh
 # Create a json/yaml-encoded Secret somehow:
@@ -86,29 +107,21 @@ $ kubectl create secret generic mysecret --dry-run --from-literal=foo=bar -o jso
 # This is the important bit:
 $ kubeseal <mysecret.json >mysealedsecret.json
 
-# mysealedsecret.json is safe to upload to github, post to twitter,
-# etc.  Eventually:
+# mysealedsecret.json is safe to upload to github, post to twitter, etc. Eventually:
 $ kubectl create -f mysealedsecret.json
 
 # Profit!
 $ kubectl get secret mysecret
 ```
 
-Note the `SealedSecret` and `Secret` must have *the same namespace and
-name*.  This is a feature to prevent other users on the same cluster
-from re-using your sealed secrets.  `kubeseal` reads the namespace
-from the input secret, accepts an explicit `--namespace` arg, and uses
-the `kubectl` default namespace (in that order). Any labels,
-annotations, etc on the original `Secret` are preserved, but not
-automatically reflected in the `SealedSecret`.
+Note the `SealedSecret` and `Secret` must have *the same namespace and name*.  This is a feature to prevent other users on the same cluster from re-using your sealed secrets.  
+`kubeseal` reads the namespace from the input secret, accepts an explicit `--namespace` arg, and uses the `kubectl` default namespace (in that order). Any labels, annotations, etc on the original `Secret` are preserved, but not automatically reflected in the `SealedSecret`.
 
-By design, this scheme *does not authenticate the user*.  In other
-words, *anyone* can create a `SealedSecret` containing any `Secret`
-they like (provided the namespace/name matches).  It is up to your
-existing config management workflow, cluster RBAC rules, etc to ensure
-that only the intended `SealedSecret` is uploaded to the cluster.  The
-only change from existing Kubernetes is that the *contents* of the
-`Secret` are now hidden while outside the cluster.
+By design, this scheme *does not authenticate the user*.  In other words, *anyone* can create a `SealedSecret` containing any `Secret` they like (provided the namespace/name matches).  
+It is up to your existing config management workflow, cluster RBAC rules, etc to ensure that only the intended `SealedSecret` is uploaded to the cluster.  
+The only change from existing Kubernetes is that the *contents* of the `Secret` are now hidden while outside the cluster.
+
+<br>
 
 ## Details
 
@@ -140,36 +153,13 @@ namespace/name is used as the OAEP input parameter, ensuring that the
 The generated `Secret` is marked as "owned" by the `SealedSecret` and
 will be garbage collected if the `SealedSecret` is deleted.
 
-## Developing
-To be able to develop on this project, you need to have the following tools installed:
-* make
-* [Ginkgo](https://onsi.github.io/ginkgo/)
-* [Minikube](https://github.com/kubernetes/minikube)
-* [kubecfg](https://github.com/ksonnet/kubecfg)
-* Go
+<br>
 
-To build the `kubeseal` and controller binaries, run:
-```bash
-$ make
-```
+## Contributing
 
-To run the unit tests:
-```bash
-$ make test
-```
+See [CONTRIBUTING.md](CONTRIBUTING.md)
 
-To run the integration tests:
-* Start Minikube
-* Build the controller for Linux, so that it can be run within a Docker image - edit the Makefile to add 
-`GOOS=linux GOARCH=amd64` to `%-static`, and then run `make controller.yaml `
-* Alter `controller.yaml` so that `imagePullPolicy: Never`, to ensure that the image you've just built will be
-used by Kubernetes
-* Add the sealed-secret CRD and controller to Kubernetes - `kubectl apply -f controller.yaml`
-* Revert any changes made to the Makefile to build the Linux controller
-* Remove the binaries which were possibly built for another OS - `make clean`
-* Rebuild the binaries for your OS - `make`
-* Run the integration tests - `make integrationtest`
-
+<br>
 
 ## FAQ
 

--- a/controller-norbac.jsonnet
+++ b/controller-norbac.jsonnet
@@ -1,50 +1,50 @@
 // Minimal required deployment for a functional controller.
-local kube = import "kube.libsonnet";
+local kube = import 'kube.libsonnet';
 
 local trim = function(str) (
-  if std.startsWith(str, " ") || std.startsWith(str, "\n") then
-  trim(std.substr(str, 1, std.length(str) - 1))
-  else if std.endsWith(str, " ") || std.endsWith(str, "\n") then
-  trim(std.substr(str, 0, std.length(str) - 1))
+  if std.startsWith(str, ' ') || std.startsWith(str, '\n') then
+    trim(std.substr(str, 1, std.length(str) - 1))
+  else if std.endsWith(str, ' ') || std.endsWith(str, '\n') then
+    trim(std.substr(str, 0, std.length(str) - 1))
   else
     str
 );
 
-local namespace = "kube-system";
-local controllerImage = std.extVar("CONTROLLER_IMAGE");
+local namespace = 'kube-system';
+local controllerImage = std.extVar('CONTROLLER_IMAGE');
 
 // This is a bit odd: Downgrade to apps/v1beta1 so we can continue
 // to support k8s v1.6.
 // TODO: re-evaluate sealed-secrets support timeline and/or
 // kube.libsonnet versioned API support.
 local v1beta1_Deployment(name) = kube.Deployment(name) {
-  assert std.assertEqual(super.apiVersion, "apps/v1beta2"),
-  apiVersion: "apps/v1beta1",
+  assert std.assertEqual(super.apiVersion, 'apps/v1beta2'),
+  apiVersion: 'apps/v1beta1',
 };
 
 {
-  crd: kube.CustomResourceDefinition("bitnami.com", "v1alpha1", "SealedSecret"),
+  crd: kube.CustomResourceDefinition('bitnami.com', 'v1alpha1', 'SealedSecret'),
 
-  namespace:: {metadata+: {namespace: namespace}},
+  namespace:: { metadata+: { namespace: namespace } },
 
-  service: kube.Service("sealed-secrets-controller") + $.namespace {
+  service: kube.Service('sealed-secrets-controller') + $.namespace {
     target_pod: $.controller.spec.template,
   },
 
-  controller: v1beta1_Deployment("sealed-secrets-controller") + $.namespace {
+  controller: v1beta1_Deployment('sealed-secrets-controller') + $.namespace {
     spec+: {
       template+: {
         spec+: {
           containers_+: {
-            controller: kube.Container("sealed-secrets-controller") {
+            controller: kube.Container('sealed-secrets-controller') {
               image: controllerImage,
-              command: ["controller"],
+              command: ['controller'],
               readinessProbe: {
-                httpGet: {path: "/healthz", port: "http"},
+                httpGet: { path: '/healthz', port: 'http' },
               },
               livenessProbe: self.readinessProbe,
               ports_+: {
-                http: {containerPort: 8080},
+                http: { containerPort: 8080 },
               },
               securityContext+: {
                 readOnlyRootFilesystem: true,


### PR DESCRIPTION
GoReleaser build and release support

Simplified build (and release?) per #134.
Not automatically hooked into Travis or anything (yet).

**Binaries tested with `--version`:**
- linux (docker images as well)
- windows

**Binaries not tested:**
- darwin (don't have mac)

**Build and Publish tested:**
- Create [GitHub Token](https://goreleaser.com/environment/)
- In `.goreleaser.yml` comment out `release.disable: true`
- `git commit`
- `git tag v0.7.1 && git push`
- `make publish`
- single archive per platform contains both `controller` and `kubeseal` binaries, plus kubernetes yaml's
- locally docker images are created

**Not Tested:**
- docker image push - In `.goreleaser.yml` comment out `docker.skip_push: true`

**Build fork/dirty/etc:** (assuming merged, patch on upstream or blog link below)
```
make snapshot
```
This results in binaries, archives and docker images tagged with full git commit hash.

**To Do:**
- [x] TODO: comment added for brew to change to [published formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/kubeseal.rb)
- [x] confirm ok publishing archive instead of binaries
- [x] yamls added to archive
- [x] DOCS update and simplification

First time using goreleaser so... :)