### PR TITLE
GoReleaser build and release support v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,12 +13,15 @@
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
 
+# Output from goreleaser
+/dist
+
 /controller
 /kubeseal
 /controller.image
 /*-static
 /controller.yaml
-/sealedsecret-crd.yaml
+/controller-norbac.yaml
 /docker/controller
 *.iml
 .idea

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,11 +1,13 @@
+---
 ## Bitnami Sealed Secrets
 
 release:
-  # Comment out to enable publishing
-  # disable: true
+# # Comment out to enable publishing
+# # disable: true
 
 builds:
-- binary: controller
+- id: controller
+  binary: controller
   main: ./cmd/controller/
   env:
   - CGO_ENABLED=0
@@ -18,7 +20,8 @@ builds:
   ldflags: -X main.VERSION={{.Version}}
   hooks:
     post: make -B controller.yaml controller-norbac.yaml
-- binary: kubeseal
+- id: kubeseal
+  binary: kubeseal
   main: ./cmd/kubeseal/
   env:
   - CGO_ENABLED=0
@@ -56,7 +59,10 @@ dockers:
   # Comment below out to push to configured repository
   # skip_push: true
 
-archive:
+archives:
+- id: kubeseal
+  builds:
+  - kubeseal
   replacements:
     darwin: Darwin
     linux: Linux

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,82 @@
+## Bitnami Sealed Secrets
+
+release:
+  # Comment out to enable publishing
+  # disable: true
+
+builds:
+- binary: controller
+  main: ./cmd/controller/
+  env:
+  - CGO_ENABLED=0
+  goarch:
+  - amd64
+  goos:
+  - linux
+  - darwin
+  - windows
+  ldflags: -X main.VERSION={{.Version}}
+  hooks:
+    post: make -B controller.yaml controller-norbac.yaml
+- binary: kubeseal
+  main: ./cmd/kubeseal/
+  env:
+  - CGO_ENABLED=0
+  goarch:
+  - amd64
+  goos:
+  - linux
+  - darwin
+  - windows
+  ldflags: -X main.VERSION={{.Version}}
+
+# TODO: use upstream formula https://github.com/Homebrew/homebrew-core/blob/master/Formula/kubeseal.rb
+# brew:
+#   github:
+#     owner: bitnami-labs
+#     name: sealed-secrets
+#   homepage: "https://github.com/bitnami-labs/sealed-secrets/"
+#   description: "A Kubernetes controller and tool for one-way encrypted Secrets"
+#   skip_upload: true
+#   # Replace with existing brew formula
+#   test: |
+#     system "#{bin}/program --version"
+
+dockers:
+- goarch: amd64
+  goos: linux
+  binaries:
+  - controller
+  dockerfile: ./docker/Dockerfile
+  image_templates:
+  - quay.io/bitnami-labs/sealed-secrets-controller:latest
+  - quay.io/bitnami-labs/sealed-secrets-controller:latest-amd64
+  - quay.io/bitnami-labs/sealed-secrets-controller:{{ .Version }}
+  - quay.io/bitnami-labs/sealed-secrets-controller:{{ .Version }}-amd64
+  # Comment below out to push to configured repository
+  # skip_push: true
+
+archive:
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+  format_overrides:
+  - goos: windows
+    format: zip
+  files:
+  - controller.yaml
+  - controller-norbac.yaml
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  name_template: "{{ .FullCommit }}"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,10 @@ script:
   - ./$EXE_NAME --help || test $? -eq 2
   - |
     if [ "$TRAVIS_OS_NAME" = linux ]; then
-      make controller.yaml controller-norbac.yaml CONTROLLER_IMAGE=$CONTROLLER_IMAGE
+      # `controller.image` target builds the Docker image.
+      # This is not required for and breaks GoReleaser so the specific make target was added here.
+      # Replace this section with `make snapshot` to perform a full build + package via GoReleaser.
+      make controller.image controller.yaml controller-norbac.yaml CONTROLLER_IMAGE=$CONTROLLER_IMAGE
     fi
   - |
     if [ "$INT_KVERS" != "" ]; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing
+
+## Installation from source
+
+If you just want the latest client tool, it can be installed into
+`$GOPATH/bin` with:
+
+```sh
+$ go get github.com/bitnami-labs/sealed-secrets/cmd/kubeseal
+```
+
+## Developing
+
+To be able to develop on this project, you need to have the following tools installed:
+* make
+* [Ginkgo](https://onsi.github.io/ginkgo/)
+* [Minikube](https://github.com/kubernetes/minikube)
+* [kubecfg](https://github.com/ksonnet/kubecfg)
+* [goreleaser](https://github.com/goreleaser/goreleaser)
+* Go
+
+First fork the repo.  
+Then clone the repo using `go get` to preserve paths and add your fork as a remote:
+```sh
+$ go get github.com/bitnami-labs/sealed-secrets
+$ cd $GOPATH/src/github.com/bitnami-labs/sealed-secrets # GOPATH is $HOME/go by default.
+
+$ git remote rename origin upstream
+$ git remote add origin <FORK_URL>
+```
+
+To build the `kubeseal` and `controller` binaries:
+```sh
+$ make
+```
+
+To build everything; binaries, archives, docker images with `goreleaser`:
+```sh
+$ make snapshot
+```
+
+To run the unit tests:
+```bash
+$ make test
+```
+
+To run the integration tests:
+* Start Minikube
+* Build the controller for Linux, so that it can be run within a Docker image - edit the Makefile to add 
+`GOOS=linux GOARCH=amd64` to `%-static`, and then run `make controller.yaml`
+* Alter `controller.yaml` so that `imagePullPolicy: Never`, to ensure that the image you've just built will be
+used by Kubernetes
+* Add the sealed-secret CRD and controller to Kubernetes - `kubectl apply -f controller.yaml`
+* Revert any changes made to the Makefile to build the Linux controller
+* Remove the binaries which were possibly built for another OS - `make clean`
+* Rebuild the binaries for your OS - `make`
+* Run the integration tests - `make integrationtest`
+

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
 GO = go
 GO_FLAGS =
 GOFMT = gofmt
+GORELEASER = goreleaser
 
 KUBECFG = kubecfg -U https://github.com/bitnami-labs/kube-libsonnet/raw/52ba963ca44f7a4960aeae9ee0fbee44726e481f
 DOCKER = docker
 GINKGO = ginkgo -p
 
-CONTROLLER_IMAGE = sealed-secrets-controller:latest
+# + is not a permitted character in image tags and '+dirty' is not passed in to goreleaser breaking snapshots
+CONTROLLER_IMAGE = $(subst +dirty,,quay.io/bitnami-labs/sealed-secrets-controller:$(VERSION))
 KUBECONFIG ?= $(HOME)/.kube/config
 
 # TODO: Simplify this once ./... ignores ./vendor
@@ -57,9 +59,9 @@ controller.image: docker/Dockerfile docker/controller
 	$(KUBECFG) show -V CONTROLLER_IMAGE=$(CONTROLLER_IMAGE) -o yaml $< > $@.tmp
 	mv $@.tmp $@
 
-controller.yaml: controller.jsonnet controller.image controller-norbac.jsonnet
+controller.yaml: controller.jsonnet controller-norbac.jsonnet
 
-controller-norbac.yaml: controller-norbac.jsonnet controller.image
+controller-norbac.yaml: controller-norbac.jsonnet
 
 test:
 	$(GO) test $(GO_FLAGS) $(GO_PACKAGES)
@@ -81,5 +83,15 @@ clean:
 	$(RM) *-static
 	$(RM) controller*.yaml
 	$(RM) docker/controller
+	$(RM) -r dist/
+
+release: clean ## Generate a release, but don't publish to GitHub.
+	$(GORELEASER) --skip-validate --skip-publish
+
+publish: clean ## Generate a release, and publish to GitHub.
+	$(GORELEASER)
+
+snapshot: clean ## Generate a snapshot release.
+	$(GORELEASER) --snapshot --skip-validate --skip-publish
 
 .PHONY: all kubeseal controller test clean vet fmt

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 GO = go
 GO_FLAGS =
 GOFMT = gofmt
+# goreleaser >= v0.105.0 required for multiple id support
 GORELEASER = goreleaser
 
 KUBECFG = kubecfg -U https://github.com/bitnami-labs/kube-libsonnet/raw/52ba963ca44f7a4960aeae9ee0fbee44726e481f

--- a/README.md
+++ b/README.md
@@ -11,19 +11,31 @@ decrypted only by the controller running in the target cluster and
 nobody else (not even the original author) is able to obtain the
 original Secret from the SealedSecret.
 
+<br>
+
 ## Installation
+
+There are two parts to installation:
+* [controller](#controller-installation) - container run in Kubernetes cluster 
+* [kubeseal](#kubeseal-installation) - command line utility run locally
 
 See https://github.com/bitnami-labs/sealed-secrets/releases for the latest
 release.
 
+<br>
+
+## Controller Installation 
+
+`controller.yaml` will install the `controller` into `kube-system` namespace, create a service account, necessary RBAC roles and a `SealedSecret` CRD.  
+After a few moments, the `controller` will start, generate a key pair, and be ready for operation.  If it does not, check the `controller` logs.
+
+The key certificate (public key portion) is used for sealing secrets, and will be printed to the `controller` log on startup.
+
+
+### Version <= v0.7.0
+
 ```sh
 $ release=$(curl --silent "https://api.github.com/repos/bitnami-labs/sealed-secrets/releases/latest" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
-
-# Install client-side tool into /usr/local/bin/
-$ GOOS=$(go env GOOS)
-$ GOARCH=$(go env GOARCH)
-$ wget https://github.com/bitnami-labs/sealed-secrets/releases/download/$release/kubeseal-$GOOS-$GOARCH
-$ sudo install -m 755 kubeseal-$GOOS-$GOARCH /usr/local/bin/kubeseal
 
 # Note:  If installing on a GKE cluster, a ClusterRoleBinding may be needed to successfully deploy the controller in the final command.  Replace <your-email> with a valid email, and then deploy the cluster role binding:
 $ USER_EMAIL=<your-email>
@@ -35,50 +47,95 @@ $ kubectl apply -f https://github.com/bitnami-labs/sealed-secrets/releases/downl
 $ kubectl apply -f https://github.com/bitnami-labs/sealed-secrets/releases/download/$release/sealedsecret-crd.yaml
 ```
 
-`controller.yaml` will create the `SealedSecret` resource and install the controller
-into `kube-system` namespace, create a service account and necessary
-RBAC roles.
 
-After a few moments, the controller will start, generate a key pair,
-and be ready for operation.  If it does not, check the controller
-logs.
+### Version => v0.8.0
 
-The key certificate (public key portion) is used for sealing secrets,
-and needs to be available wherever `kubeseal` is going to be
-used. The certificate is not secret information, although you need to
-ensure you are using the correct file.
-
-`kubeseal` will fetch the certificate from the controller at runtime
-(requires secure access to the Kubernetes API server), which is
-convenient for interactive use.  The recommended automation workflow
-is to store the certificate to local disk with
-`kubeseal --fetch-cert >mycert.pem`,
-and use it offline with `kubeseal --cert mycert.pem`.
-The certificate is also printed to the controller log on startup.
-
-### Installation from source
-
-If you just want the latest client tool, it can be installed into
-`$GOPATH/bin` with:
+**This is a new process that will be available from v0.8.0 onwards or if you build from master with GoReleaser - see [CONTRIBUTING.md](CONTRIBUTING.md)**
 
 ```sh
-% go get github.com/bitnami-labs/sealed-secrets/cmd/kubeseal
+# Note:  If installing on a GKE cluster, a ClusterRoleBinding may be needed to successfully deploy the controller in the final command.  Replace <your-email> with a valid email, and then deploy the cluster role binding:
+$ USER_EMAIL=<your-email>
+$ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=$USER_EMAIL
+
+# get latest release version
+$ release=$(curl --silent "https://api.github.com/repos/bitnami-labs/sealed-secrets/releases/latest" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
+
+# Download release
+$ wget https://github.com/bitnami-labs/sealed-secrets/releases/download/$release/sealed-secrets_$release_$(uname)_$(uname -m).tar.gz
+
+# Extract release
+$ tar -zxvf sealed-secrets_$release_$(uname)_$(uname -m).tar.gz
+
+# For clusters with RBAC
+$ kubectl apply -f controller.yaml
+
+# For clusters without RBAC
+$ kubectl apply -f controller-norbac.yaml
 ```
 
-For a more complete development environment, clone the repository and
-use the Makefile:
+### Saving key certificate - Recommended
+
+The public cert can be commited to git and supplied as an argument to `kubeseal` instead of requiring cluster access. For example: `kubeseal --cert mycert.pem`
 
 ```sh
-% git clone https://github.com/bitnami-labs/sealed-secrets.git
-% cd sealed-secrets
-
-# Build client-side tool and controller binaries
-% make
+# Save public cert to file (if using port-forward or other method to expose the controller)
+$ kubeseal --fetch-cert > mycert.pem
 ```
 
-## Usage
+<br>
+
+## Kubeseal Installation 
+
+### Version <= v0.7.0
+
+```sh
+$ release=$(curl --silent "https://api.github.com/repos/bitnami-labs/sealed-secrets/releases/latest" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
+
+# Install client-side tool into /usr/local/bin/
+$ GOOS=$(go env GOOS)
+$ GOARCH=$(go env GOARCH)
+$ wget https://github.com/bitnami-labs/sealed-secrets/releases/download/$release/kubeseal-$GOOS-$GOARCH
+$ sudo install -m 755 kubeseal-$GOOS-$GOARCH /usr/local/bin/kubeseal
+```
+
+
+### Version >= v0.8.0
+
+**This is a new process that will be available from v0.8.0 onwards or if you build from master with GoReleaser - see [CONTRIBUTING.md](CONTRIBUTING.md)**
+
+MacOS: 
+```sh
+$ brew install kubeseal
+```
+
+Linux:
+```sh
+# get latest release version
+$ release=$(curl --silent "https://api.github.com/repos/bitnami-labs/sealed-secrets/releases/latest" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
+
+# Download release
+$ wget https://github.com/bitnami-labs/sealed-secrets/releases/download/$release/sealed-secrets_$release_$(uname)_$(uname -m).tar.gz
+
+# Extract release
+$ tar -zxvf sealed-secrets_$release_$(uname)_$(uname -m).tar.gz
+
+# Install in path (if required)
+$ sudo install -m 755 kubeseal /usr/local/bin/kubeseal
+```
+
+Windows:
+- download latest [release](https://github.com/bitnami-labs/sealed-secrets/releases/latest)
+- extract archive
+
+<br>
+
+## Client usage 
 
 **WARNING**: A bug in the current version is limiting secrets to use the "opaque" type. If you need to use another secret type (eg: `kubernetes.io/dockerconfigjson`), please use kubeseal from release 0.5.1 until [#86](https://github.com/bitnami-labs/sealed-secrets/issues/86) and [#92](https://github.com/bitnami-labs/sealed-secrets/issues/92) are resolved.
+
+`kubeseal` will fetch the certificate from the controller at runtime (requires secure access to the Kubernetes API server), which is convenient for interactive use.  
+The recommended automation workflow is to store the certificate to local disk and use it offline with `kubeseal --cert mycert.pem`. See [Saving key certificate](#saving-key-certificate---recommended)
+
 
 ```sh
 # Create a json/yaml-encoded Secret somehow:
@@ -88,29 +145,21 @@ $ kubectl create secret generic mysecret --dry-run --from-literal=foo=bar -o jso
 # This is the important bit:
 $ kubeseal <mysecret.json >mysealedsecret.json
 
-# mysealedsecret.json is safe to upload to github, post to twitter,
-# etc.  Eventually:
+# mysealedsecret.json is safe to upload to github, post to twitter, etc. Eventually:
 $ kubectl create -f mysealedsecret.json
 
 # Profit!
 $ kubectl get secret mysecret
 ```
 
-Note the `SealedSecret` and `Secret` must have *the same namespace and
-name*.  This is a feature to prevent other users on the same cluster
-from re-using your sealed secrets.  `kubeseal` reads the namespace
-from the input secret, accepts an explicit `--namespace` arg, and uses
-the `kubectl` default namespace (in that order). Any labels,
-annotations, etc on the original `Secret` are preserved, but not
-automatically reflected in the `SealedSecret`.
+Note the `SealedSecret` and `Secret` must have *the same namespace and name*.  This is a feature to prevent other users on the same cluster from re-using your sealed secrets.  
+`kubeseal` reads the namespace from the input secret, accepts an explicit `--namespace` arg, and uses the `kubectl` default namespace (in that order). Any labels, annotations, etc on the original `Secret` are preserved, but not automatically reflected in the `SealedSecret`.
 
-By design, this scheme *does not authenticate the user*.  In other
-words, *anyone* can create a `SealedSecret` containing any `Secret`
-they like (provided the namespace/name matches).  It is up to your
-existing config management workflow, cluster RBAC rules, etc to ensure
-that only the intended `SealedSecret` is uploaded to the cluster.  The
-only change from existing Kubernetes is that the *contents* of the
-`Secret` are now hidden while outside the cluster.
+By design, this scheme *does not authenticate the user*.  In other words, *anyone* can create a `SealedSecret` containing any `Secret` they like (provided the namespace/name matches).  
+It is up to your existing config management workflow, cluster RBAC rules, etc to ensure that only the intended `SealedSecret` is uploaded to the cluster.  
+The only change from existing Kubernetes is that the *contents* of the `Secret` are now hidden while outside the cluster.
+
+<br>
 
 ## Details
 
@@ -142,36 +191,13 @@ namespace/name is used as the OAEP input parameter, ensuring that the
 The generated `Secret` is marked as "owned" by the `SealedSecret` and
 will be garbage collected if the `SealedSecret` is deleted.
 
-## Developing
-To be able to develop on this project, you need to have the following tools installed:
-* make
-* [Ginkgo](https://onsi.github.io/ginkgo/)
-* [Minikube](https://github.com/kubernetes/minikube)
-* [kubecfg](https://github.com/ksonnet/kubecfg)
-* Go
+<br>
 
-To build the `kubeseal` and controller binaries, run:
-```bash
-$ make
-```
+## Contributing
 
-To run the unit tests:
-```bash
-$ make test
-```
+See [CONTRIBUTING.md](CONTRIBUTING.md)
 
-To run the integration tests:
-* Start Minikube
-* Build the controller for Linux, so that it can be run within a Docker image - edit the Makefile to add 
-`GOOS=linux GOARCH=amd64` to `%-static`, and then run `make controller.yaml `
-* Alter `controller.yaml` so that `imagePullPolicy: Never`, to ensure that the image you've just built will be
-used by Kubernetes
-* Add the sealed-secret CRD and controller to Kubernetes - `kubectl apply -f controller.yaml`
-* Revert any changes made to the Makefile to build the Linux controller
-* Remove the binaries which were possibly built for another OS - `make clean`
-* Rebuild the binaries for your OS - `make`
-* Run the integration tests - `make integrationtest`
-
+<br>
 
 ## FAQ
 


### PR DESCRIPTION
Simplified build (and release?) per #134.
Not automatically hooked into Travis (yet).

**Binaries tested with `--version`:**
- linux (docker images as well)
- windows

**Binaries not tested:**
- darwin (don't have mac)

**Build and Publish tested:**
- Create [GitHub Token](https://goreleaser.com/environment/)
- `git commit`
- `git tag v0.80 && git push`
- `make publish`
- single archive per platform contains both `controller` and `kubeseal` binaries, plus kubernetes yaml's
- locally docker images are created

**Not Tested:**
- docker image push

**Build fork/dirty/etc:** (assuming merged, patch on upstream)
```
make snapshot
```
This results in binaries, archives and docker images tagged with full git commit hash.

**To Do:**
- [x] TODO: comment added for brew to change to [published formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/kubeseal.rb)
- [x] confirm ok publishing archive instead of binaries
- [x] yamls added to archive
- [x] DOCS update and simplification
- At a future time remove references to v0.7.0 installation processes