### PR TITLE
Drop support for go1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 
 go:
   - '1.12'
-  - '1.9'
+  - '1.11'
 
 services:
   - docker


### PR DESCRIPTION
So we can drop vendoring and still enjoy reproducible builds with go.mod
(with `GOPROXY="https://proxy.golang.org"`); in another PR