### PR TITLE
Adding support for setting imagePullPolicy: Never for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 /controller.image
 /*-static
 /controller.yaml
+/controller-norbac.yaml
 /sealedsecret-crd.yaml
 /docker/controller
 *.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ script:
   - ./$EXE_NAME --help || test $? -eq 2
   - |
     if [ "$TRAVIS_OS_NAME" = linux ]; then
-      make controller.yaml controller-norbac.yaml CONTROLLER_IMAGE=$CONTROLLER_IMAGE
+      make controller.yaml controller-norbac.yaml CONTROLLER_IMAGE=$CONTROLLER_IMAGE IMAGE_PULL_POLICY=Never
     fi
   - |
     if [ "$INT_KVERS" != "" ]; then

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ DOCKER = docker
 GINKGO = ginkgo -p
 
 CONTROLLER_IMAGE = sealed-secrets-controller:latest
+IMAGE_PULL_POLICY = Always
 KUBECONFIG ?= $(HOME)/.kube/config
 
 GO_PACKAGES = ./...
@@ -53,7 +54,7 @@ controller.image: docker/Dockerfile docker/controller
 	mv $@.tmp $@
 
 %.yaml: %.jsonnet
-	$(KUBECFG) show -V CONTROLLER_IMAGE=$(CONTROLLER_IMAGE) -o yaml $< > $@.tmp
+	$(KUBECFG) show -V CONTROLLER_IMAGE=$(CONTROLLER_IMAGE) -V IMAGE_PULL_POLICY=$(IMAGE_PULL_POLICY) -o yaml $< > $@.tmp
 	mv $@.tmp $@
 
 controller.yaml: controller.jsonnet controller.image controller-norbac.jsonnet

--- a/README.md
+++ b/README.md
@@ -167,9 +167,7 @@ $ make test
 To run the integration tests:
 * Start Minikube
 * Build the controller for Linux, so that it can be run within a Docker image - edit the Makefile to add
-`GOOS=linux GOARCH=amd64` to `%-static`, and then run `make controller.yaml `
-* Alter `controller.yaml` so that `imagePullPolicy: Never`, to ensure that the image you've just built will be
-used by Kubernetes
+`GOOS=linux GOARCH=amd64` to `%-static`, and then run `make controller.yaml IMAGE_PULL_POLICY=Never`
 * Add the sealed-secret CRD and controller to Kubernetes - `kubectl apply -f controller.yaml`
 * Revert any changes made to the Makefile to build the Linux controller
 * Remove the binaries which were possibly built for another OS - `make clean`

--- a/controller-norbac.jsonnet
+++ b/controller-norbac.jsonnet
@@ -12,6 +12,7 @@ local trim = function(str) (
 
 local namespace = "kube-system";
 local controllerImage = std.extVar("CONTROLLER_IMAGE");
+local imagePullPolicy = std.extVar("IMAGE_PULL_POLICY");
 
 // This is a bit odd: Downgrade to apps/v1beta1 so we can continue
 // to support k8s v1.6.
@@ -38,6 +39,7 @@ local v1beta1_Deployment(name) = kube.Deployment(name) {
           containers_+: {
             controller: kube.Container("sealed-secrets-controller") {
               image: controllerImage,
+              imagePullPolicy: imagePullPolicy,
               command: ["controller"],
               readinessProbe: {
                 httpGet: {path: "/healthz", port: "http"},


### PR DESCRIPTION
This adds a configuration to the Makefile to pass in a value for imagePullPolicy, so that it doesn't have to be manually modified after it's generated.  