### PR TITLE
Use official docker image in main Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ KUBECFG = kubecfg -U https://github.com/bitnami-labs/kube-libsonnet/raw/52ba963c
 DOCKER = docker
 GINKGO = ginkgo -p
 
-CONTROLLER_IMAGE = sealed-secrets-controller:latest
+CONTROLLER_IMAGE = quay.io/bitnami/sealed-secrets-controller:latest
 IMAGE_PULL_POLICY = Always
 KUBECONFIG ?= $(HOME)/.kube/config
 


### PR DESCRIPTION
Our CI system pushes the latest build to the `:latest` tag on quay.
It seems natural for users to desire that the controller.yaml file that gets built in master
points to such a build

(see https://github.com/bitnami-labs/sealed-secrets/issues/86#issuecomment-512087928)