### PR TITLE
Disable key rotation by default

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -32,7 +32,7 @@ var (
 	validFor        = flag.Duration("key-ttl", 10*365*24*time.Hour, "Duration that certificate is valid for.")
 	myCN            = flag.String("my-cn", "", "CN to use in generated certificate.")
 	printVersion    = flag.Bool("version", false, "Print version information and exit")
-	keyRotatePeriod = flag.Duration("rotate-period", 30*24*time.Hour, "New key generation period")
+	keyRotatePeriod = flag.Duration("rotate-period", 0, "New key generation period (automatic rotation disabled if 0)")
 
 	// VERSION set from Makefile
 	VERSION = "UNKNOWN"
@@ -108,6 +108,9 @@ func initKeyRotation(registry *KeyRegistry, period time.Duration) (func(), error
 		if _, err := registry.generateKey(); err != nil {
 			log.Printf("Failed to generate new key : %v\n", err)
 		}
+	}
+	if period == 0 {
+		return keyGenFunc, nil
 	}
 	return ScheduleJobWithTrigger(period, keyGenFunc), nil
 }

--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -56,7 +56,7 @@ func TestInitKeyRotation(t *testing.T) {
 		t.Fatalf("initKeyRegistry() returned err: %v", err)
 	}
 
-	keyGenTrigger, err := initKeyRotation(registry, time.Hour)
+	keyGenTrigger, err := initKeyRotation(registry, 0)
 	if err != nil {
 		t.Fatalf("initKeyRotation() returned err: %v", err)
 	}
@@ -69,6 +69,39 @@ func TestInitKeyRotation(t *testing.T) {
 	// Test the trigger function
 	// Activates trigger and polls client every 50 ms up to 10s for the appropriate action
 	keyGenTrigger()
+	maxWait := 10 * time.Second
+	endTime := time.Now().Add(maxWait)
+	successful := false
+	for time.Now().Before(endTime) {
+		time.Sleep(50 * time.Millisecond)
+		if hasAction(client, "create", "secrets") {
+			successful = true
+			break
+		}
+	}
+	if !successful {
+		t.Errorf("trigger function failed to activate early key generation")
+	}
+}
+
+func TestInitKeyRotationTick(t *testing.T) {
+	rand := testRand()
+	client := fake.NewSimpleClientset()
+	registry, err := initKeyRegistry(client, rand, "namespace", "prefix", "label", 1024)
+	if err != nil {
+		t.Fatalf("initKeyRegistry() returned err: %v", err)
+	}
+
+	_, err = initKeyRotation(registry, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("initKeyRotation() returned err: %v", err)
+	}
+	if !hasAction(client, "create", "secrets") {
+		t.Errorf("initKeyRotation() failed to generate an initial key")
+	}
+
+	client.ClearActions()
+
 	maxWait := 10 * time.Second
 	endTime := time.Now().Add(maxWait)
 	successful := false


### PR DESCRIPTION
It's premature to enable key-rotation by default. See open issues like #185.
Ref #137

This should unblock the possibility of cutting a release with a lot of important features
and let users who want key-rotation to opt-in and deal with the consequences.