### PR TITLE
Travis make vet precondition Go version bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ install:
 script:
   - make
   - make test
-  - if [[ ${TRAVIS_GO_VERSION}.0 =~ ^1\.10\. ]]; then make vet; fi
+  - if [[ ${TRAVIS_GO_VERSION}.0 =~ ^1\.12\. ]]; then make vet; fi
   - make kubeseal-static
   - EXE_NAME=kubeseal-$(go env GOOS)-$(go env GOARCH)
   - cp kubeseal-static $EXE_NAME
@@ -127,7 +127,7 @@ deploy:
     - controller.yaml
     - controller-norbac.yaml
   on:
-    condition: ${TRAVIS_GO_VERSION}.0 =~ ^1\.10\.
+    condition: ${TRAVIS_GO_VERSION}.0 =~ ^1\.12\.
     tags: true
   provider: releases
   skip_cleanup: true


### PR DESCRIPTION
Don't know original reasoning for only running `make vet` on current targeted Go version.
Could probably be simplified to just `- make vet` and run with either 1.12 or 1.11.
