### PR TITLE
Ensure image pull policy is not Never

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,6 +96,13 @@ script:
       kubectl rollout status deployment/sealed-secrets-controller -n kube-system -w
       make integrationtest CONTROLLER_IMAGE=$CONTROLLER_IMAGE GINKGO="ginkgo -v --randomizeSuites --failOnPending --trace --progress --compilers=2 --nodes=4"
     fi
+  # integration tests required Never pull policy, but release artifacts can't have that
+  # TODO(mkm): cleanup this.
+  - |
+    if [ "$TRAVIS_OS_NAME" = linux ]; then
+      rm -f controller.yaml controller-norbac.yaml
+      make controller.yaml controller-norbac.yaml CONTROLLER_IMAGE=$CONTROLLER_IMAGE
+    fi
 
 after_script: set +e
 


### PR DESCRIPTION
In #181 we made sure the CI was always testing the rigth code during integration tests, but that involved materializing yaml deployment templates that are not suitable for distribution.

This PR rebuilds the yaml files from jsonnet, without the image policy = Never override.

This is what would happen if we released without this PR:
```
NAME                                        READY   STATUS              RESTARTS   AGE
sealed-secrets-controller-b85b85fd5-27f82   0/1     ErrImageNeverPull   0          21m
```