### PR TITLE
Writable /tmp

### DIFF
--- a/controller-norbac.jsonnet
+++ b/controller-norbac.jsonnet
@@ -53,6 +53,16 @@ local v1beta1_Deployment(name) = kube.Deployment(name) {
                 runAsNonRoot: true,
                 runAsUser: 1001,
               },
+              volumeMounts_+: {
+                tmp: {
+                  mountPath: '/tmp',
+                },
+              },
+            },
+          },
+          volumes_+: {
+            tmp: {
+              emptyDir: {},
             },
           },
         },


### PR DESCRIPTION
Our deployment template uses the `readOnlyRootFilesystem` but the k8s `klog` library
likes to write logs in `/tmp`.

Let's mount a writable `/tmp` dir.

Closes #200