### PR TITLE
Declare compatibility with Go 1.11 in go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bitnami-labs/sealed-secrets
 
-go 1.12
+go 1.11
 
 require (
 	github.com/bitnami-labs/flagenv v0.0.0-20190607135054-a87af7a1d6fc


### PR DESCRIPTION
We're committed to support the two most recent versions of Go, and we should make that explicit in our go.mod file
too (not only in the travis conf)