### PR TITLE
Make *.jsonnet files self-sufficient

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ export GO111MODULE = off
 GO_FLAGS =
 endif
 
-KUBECFG = kubecfg -U https://github.com/bitnami-labs/kube-libsonnet/raw/52ba963ca44f7a4960aeae9ee0fbee44726e481f
+KUBECFG = kubecfg
 DOCKER = docker
 GINKGO = ginkgo -p
 

--- a/controller-norbac.jsonnet
+++ b/controller-norbac.jsonnet
@@ -1,9 +1,11 @@
 // Minimal required deployment for a functional controller.
-local kube = import 'kube.libsonnet';
 
 local namespace = 'kube-system';
 
 {
+  kube:: import 'https://github.com/bitnami-labs/kube-libsonnet/raw/52ba963ca44f7a4960aeae9ee0fbee44726e481f/kube.libsonnet',
+  local kube = self.kube,
+
   controllerImage:: std.extVar('CONTROLLER_IMAGE'),
   imagePullPolicy:: std.extVar('IMAGE_PULL_POLICY'),
 

--- a/controller.jsonnet
+++ b/controller.jsonnet
@@ -2,9 +2,10 @@
 // See controller-norbac.jsonnet for the bare minimum functionality.
 
 local controller = import 'controller-norbac.jsonnet';
-local kube = import 'kube.libsonnet';
 
 controller {
+  local kube = self.kube,
+
   account: kube.ServiceAccount('sealed-secrets-controller') + $.namespace,
 
   unsealerRole: kube.ClusterRole('secrets-unsealer') {


### PR DESCRIPTION
Currently in order to correctly evaluate the controller*.jsonnet files, you need to specify a kubecfg search path
(usually an URL search path with `-U`). This has the following problems:

1. non self-contained: the controller deployment details depend on how kubecfg is invoked, which might happen outside this project. If we make a new release that relies on some changes in kube.libsonnnet, external users might not know they have to update their `-U` flag, since that string wouldn't part of our versioned artifacts.
2. composes poorly: if somebody imports our controller.jsonnet files in an environment where there already is a kube.libsonnet file, it might not be the one we expect (either different version, or an entirely different files with a name collision)

With this change, you can just point kubecfg to https://raw.githubusercontent.com/bitnami-labs/sealed-secrets/v0.8.1/controller.jsonnet and it will use the right kube.libsonnet.

If you need to override the kube.libsonnet library (e.g. you're testing some change) you can easily override it by creating a new file, importing `controller.jsonnet` and overriding the `kube` field to point to another import.