### PR TITLE
Handle items sealed with different keys

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/rsa"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -360,11 +361,9 @@ func (c *Controller) attemptUnseal(ss *ssv1alpha1.SealedSecret) (*corev1.Secret,
 }
 
 func attemptUnseal(ss *ssv1alpha1.SealedSecret, keyRegistry *KeyRegistry) (*corev1.Secret, error) {
-	// TODO(mkm): embed the pubkey fingerprint in each sealed item so we can fetch the right key
-	for _, key := range keyRegistry.keys {
-		if secret, err := ss.Unseal(scheme.Codecs, key.private); err == nil {
-			return secret, nil
-		}
+	privateKeys := map[string]*rsa.PrivateKey{}
+	for k, v := range keyRegistry.keys {
+		privateKeys[k] = v.private
 	}
-	return nil, fmt.Errorf("No key could decrypt secret")
+	return ss.Unseal(scheme.Codecs, privateKeys)
 }

--- a/integration/kubeseal_test.go
+++ b/integration/kubeseal_test.go
@@ -32,7 +32,7 @@ var _ = Describe("kubeseal", func() {
 	var input *v1.Secret
 	var ss *ssv1alpha1.SealedSecret
 	var args []string
-	var privKey *rsa.PrivateKey
+	var privKeys map[string]*rsa.PrivateKey
 	var certs []*x509.Certificate
 	var config *clientcmdapi.Config
 	var kubeconfigFile string
@@ -80,7 +80,7 @@ var _ = Describe("kubeseal", func() {
 		}
 
 		var err error
-		privKey, certs, err = fetchKeys(c)
+		privKeys, certs, err = fetchKeys(c)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -103,7 +103,7 @@ var _ = Describe("kubeseal", func() {
 		})
 
 		It("should contain the right value", func() {
-			s, err := ss.Unseal(scheme.Codecs, privKey)
+			s, err := ss.Unseal(scheme.Codecs, privKeys)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(s.Data).To(HaveKeyWithValue("foo", []byte("bar")))
 		})
@@ -122,7 +122,7 @@ var _ = Describe("kubeseal", func() {
 		})
 
 		It("should qualify the Secret", func() {
-			s, err := ss.Unseal(scheme.Codecs, privKey)
+			s, err := ss.Unseal(scheme.Codecs, privKeys)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(s.GetNamespace()).To(Equal(testNs))
 		})
@@ -139,7 +139,7 @@ var _ = Describe("kubeseal", func() {
 		})
 
 		It("should qualify the Secret", func() {
-			s, err := ss.Unseal(scheme.Codecs, privKey)
+			s, err := ss.Unseal(scheme.Codecs, privKeys)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(s.GetNamespace()).To(Equal(testNs))
 		})
@@ -174,7 +174,7 @@ var _ = Describe("kubeseal", func() {
 		})
 
 		It("should output the right value", func() {
-			s, err := ss.Unseal(scheme.Codecs, privKey)
+			s, err := ss.Unseal(scheme.Codecs, privKeys)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(s.Data).To(HaveKeyWithValue("foo", []byte("bar")))
 		})

--- a/pkg/apis/sealed-secrets/v1alpha1/sealedsecret_expansion.go
+++ b/pkg/apis/sealed-secrets/v1alpha1/sealedsecret_expansion.go
@@ -16,7 +16,7 @@ import (
 
 // SealedSecretExpansion has methods to work with SealedSecrets resources.
 type SealedSecretExpansion interface {
-	Unseal(codecs runtimeserializer.CodecFactory, privKey *rsa.PrivateKey) (*v1.Secret, error)
+	Unseal(codecs runtimeserializer.CodecFactory, privKeys map[string]*rsa.PrivateKey) (*v1.Secret, error)
 }
 
 // Returns labels followed by clusterWide followed by namespaceWide.
@@ -136,7 +136,7 @@ func NewSealedSecret(codecs runtimeserializer.CodecFactory, pubKey *rsa.PublicKe
 }
 
 // Unseal decrypts and returns the embedded v1.Secret.
-func (s *SealedSecret) Unseal(codecs runtimeserializer.CodecFactory, privKey *rsa.PrivateKey) (*v1.Secret, error) {
+func (s *SealedSecret) Unseal(codecs runtimeserializer.CodecFactory, privKeys map[string]*rsa.PrivateKey) (*v1.Secret, error) {
 	boolTrue := true
 	smeta := s.GetObjectMeta()
 
@@ -157,7 +157,7 @@ func (s *SealedSecret) Unseal(codecs runtimeserializer.CodecFactory, privKey *rs
 			if err != nil {
 				return nil, err
 			}
-			plaintext, err := crypto.HybridDecrypt(rand.Reader, privKey, valueBytes, label)
+			plaintext, err := crypto.HybridDecrypt(rand.Reader, privKeys, valueBytes, label)
 			if err != nil {
 				return nil, err
 			}
@@ -165,7 +165,7 @@ func (s *SealedSecret) Unseal(codecs runtimeserializer.CodecFactory, privKey *rs
 		}
 
 	} else { // Support decrypting old secrets for backward compatibility
-		plaintext, err := crypto.HybridDecrypt(rand.Reader, privKey, s.Spec.Data, label)
+		plaintext, err := crypto.HybridDecrypt(rand.Reader, privKeys, s.Spec.Data, label)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Ref #185

This is not the best implementation, but it technically unblocks #185 and lets us incrementally implement a better solution (the current plan is to make kubeseal encode the fingerprint of the public key used to seal the secret in each item).