### PR TITLE
Update the install guide and add instructions for GKE private cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Create the firewall rule.
 ```bash
 gcloud compute firewall-rules create gke-to-kubeseal-8080 \
   --network "$NETWORK" \
-  --allow "tcp:8443" \
+  --allow "tcp:8080" \
   --source-ranges "$MASTER_IPV4_CIDR" \
   --target-tags "$NETWORK_TARGET_TAG" \
   --priority 1000


### PR DESCRIPTION
I just tried installing kubeseal today and I encountered issues when running the cli against my private GKE cluster. As an addition, I also refined the install guide in the README.md. Let me know if that is needed.