### PR TITLE
Put support for v1 secret format behind feature flag

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -41,6 +41,7 @@ var (
 	myCN            = flag.String("my-cn", "", "CN to use in generated certificate.")
 	printVersion    = flag.Bool("version", false, "Print version information and exit")
 	keyRotatePeriod = flag.Duration("rotate-period", 0, "New key generation period (automatic rotation disabled if 0)")
+	acceptV1Data    = flag.Bool("accept-deprecated-v1-data", false, "Accept deprecated V1 data field")
 
 	// VERSION set from Makefile
 	VERSION = "UNKNOWN"
@@ -227,6 +228,8 @@ func main2() error {
 func main() {
 	flag.Parse()
 	goflag.CommandLine.Parse([]string{})
+
+	ssv1alpha1.AcceptDeprecatedV1Data = *acceptV1Data
 
 	if *printVersion {
 		fmt.Printf("controller version: %s\n", VERSION)


### PR DESCRIPTION
In v0.7.0 (Mar 2018) we introduced per-item encrypted data and we deprecated the old "data" field that encrypted all the items in one blob.

Since then every use of `kubeseal` would have produced sealed secret resources in such new format.

Although it's unlikely that users have many such secrets around it would be unfriendly to just ditch this old format without giving a chance to users to notice whether they are having such secrets or not.

Thus, the deprecation of this old format is gated via a feature flag.
Since it's very unlikely people are going to be affected by this, the default value of the flag is set to break backward compatibility which means that only people who

a) have sealed secrets resources that use the old flag, and
b) cannot just reseal the secrets (with with `kubeseal --rotate`)

would have flip the flag (and thus fiddle with the sealed-secrets controller env vars etc).