### PR TITLE
Turn on key rotation every 30 days

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -40,7 +40,7 @@ var (
 	validFor        = flag.Duration("key-ttl", 10*365*24*time.Hour, "Duration that certificate is valid for.")
 	myCN            = flag.String("my-cn", "", "CN to use in generated certificate.")
 	printVersion    = flag.Bool("version", false, "Print version information and exit")
-	keyRotatePeriod = flag.Duration("rotate-period", 0, "New key generation period (automatic rotation disabled if 0)")
+	keyRotatePeriod = flag.Duration("rotate-period", 30*24*time.Hour, "New key generation period (automatic rotation disabled if 0)")
 	acceptV1Data    = flag.Bool("accept-deprecated-v1-data", false, "Accept deprecated V1 data field")
 
 	// VERSION set from Makefile


### PR DESCRIPTION
All major blocker issues have been already closed (#185, #190) and stakeholders
have been given some time to play with the feature.

Users can easily turn this off by setting an env var, see #234.

I think we're ready to turn this on for everybody.
We have time to improve the efficiency, see #226.

Closes #137