### PR TITLE
Don't panic on error

### DIFF
--- a/integration/kubeseal_test.go
+++ b/integration/kubeseal_test.go
@@ -284,3 +284,23 @@ var _ = Describe("kubeseal --verify", func() {
 	})
 
 })
+
+var _ = Describe("kubeseal --cert", func() {
+	var input io.Reader
+	var output *bytes.Buffer
+	var args []string
+
+	BeforeEach(func() {
+		args = []string{"--cert", "/?this/file/cannot/possibly/exist/right?"}
+		output = &bytes.Buffer{}
+	})
+
+	JustBeforeEach(func() {
+		err := runKubeseal(args, input, ioutil.Discard, runAppWithStderr(output))
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should return an error", func() {
+		Expect(output.String()).Should(MatchRegexp("^error:.*no such file or directory"))
+	})
+})


### PR DESCRIPTION
Currently when `kubeseal` wants to report an error, we just `panic` from main, which is ugly.
This change also weaves CLI flags into a `run` function so that we can test that in isolation.