### PR TITLE
Add --raw flag for encrypting individual items ad-hoc

### DIFF
--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -421,12 +421,7 @@ func run(w io.Writer, controllerNs, controllerName, certFile string, printVersio
 			return fmt.Errorf("must provide the --name flag with --raw")
 		}
 
-		toEncrypt := make([]byte, base64.StdEncoding.DecodedLen(len(data)))
-		_, err = base64.StdEncoding.Decode(toEncrypt, data)
-		if err != nil {
-			return err
-		}
-		out, err := crypto.HybridEncrypt(rand.Reader, pubKey, toEncrypt, []byte(fmt.Sprintf("%s/%s", ns, *secretName)))
+		out, err := crypto.HybridEncrypt(rand.Reader, pubKey, data, []byte(fmt.Sprintf("%s/%s", ns, *secretName)))
 		if err != nil {
 			return err
 		}

--- a/cmd/kubeseal/main_test.go
+++ b/cmd/kubeseal/main_test.go
@@ -303,7 +303,7 @@ func TestMergeInto(t *testing.T) {
 
 func TestVersion(t *testing.T) {
 	var buf strings.Builder
-	err := run(&buf, "", "", "", "", true, false, false, false, false, "")
+	err := run(&buf, "", "", "", "", true, false, false, false, false, nil, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -315,7 +315,7 @@ func TestVersion(t *testing.T) {
 
 func TestMainError(t *testing.T) {
 	const badFileName = "/?this/file/cannot/possibly/exist/can/it?"
-	err := run(ioutil.Discard, "", "", "", badFileName, false, false, false, false, false, "")
+	err := run(ioutil.Discard, "", "", "", badFileName, false, false, false, false, false, nil, "")
 
 	if err == nil || !os.IsNotExist(err) {
 		t.Fatalf("expecting not exist error, got: %v", err)

--- a/cmd/kubeseal/main_test.go
+++ b/cmd/kubeseal/main_test.go
@@ -303,7 +303,7 @@ func TestMergeInto(t *testing.T) {
 
 func TestVersion(t *testing.T) {
 	var buf strings.Builder
-	err := run(&buf, "", "", "", true, false, false, false, "")
+	err := run(&buf, "", "", "", "", true, false, false, false, false, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -315,7 +315,7 @@ func TestVersion(t *testing.T) {
 
 func TestMainError(t *testing.T) {
 	const badFileName = "/?this/file/cannot/possibly/exist/can/it?"
-	err := run(ioutil.Discard, "", "", badFileName, false, false, false, false, "")
+	err := run(ioutil.Discard, "", "", "", badFileName, false, false, false, false, false, "")
 
 	if err == nil || !os.IsNotExist(err) {
 		t.Fatalf("expecting not exist error, got: %v", err)


### PR DESCRIPTION
Continuation of #163.

* added tests
* added support for scopes (cluster-wide, ...)
* added explicit `--from-file=/dev/stdin` flag instead of implicitly using stdin to expect data while all other commands expect a Secret. 

Closes #162