### PR TITLE
Make unsealer ClusterRole naming consistent with other resources

### DIFF
--- a/controller.jsonnet
+++ b/controller.jsonnet
@@ -8,7 +8,7 @@ controller {
 
   account: kube.ServiceAccount('sealed-secrets-controller') + $.namespace,
 
-  unsealerRole: kube.ClusterRole('secrets-unsealer') {
+  unsealerRole: kube.ClusterRole('sealed-secrets-unsealer') {
     rules: [
       {
         apiGroups: ['bitnami.com'],


### PR DESCRIPTION
All sealed-secret kubernetes resources follow the naming scheme sealed-secret-<purpose> except for the secrets-unsealer ClusterRole. Changing to sealed-secrets-unsealer will make all resource naming consistent.