### PR TITLE
Rename --rotate-period to --key-renew-period

### DIFF
--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -64,12 +64,12 @@ func TestInitKeyRotation(t *testing.T) {
 		t.Fatalf("initKeyRegistry() returned err: %v", err)
 	}
 
-	keyGenTrigger, err := initKeyRotation(registry, 0)
+	keyGenTrigger, err := initKeyRenewal(registry, 0)
 	if err != nil {
-		t.Fatalf("initKeyRotation() returned err: %v", err)
+		t.Fatalf("initKeyRenewal() returned err: %v", err)
 	}
 	if !hasAction(client, "create", "secrets") {
-		t.Errorf("initKeyRotation() failed to generate an initial key")
+		t.Errorf("initKeyRenewal() failed to generate an initial key")
 	}
 
 	client.ClearActions()
@@ -100,12 +100,12 @@ func TestInitKeyRotationTick(t *testing.T) {
 		t.Fatalf("initKeyRegistry() returned err: %v", err)
 	}
 
-	_, err = initKeyRotation(registry, 100*time.Millisecond)
+	_, err = initKeyRenewal(registry, 100*time.Millisecond)
 	if err != nil {
-		t.Fatalf("initKeyRotation() returned err: %v", err)
+		t.Fatalf("initKeyRenewal() returned err: %v", err)
 	}
 	if !hasAction(client, "create", "secrets") {
-		t.Errorf("initKeyRotation() failed to generate an initial key")
+		t.Errorf("initKeyRenewal() failed to generate an initial key")
 	}
 
 	client.ClearActions()
@@ -150,16 +150,16 @@ func TestReuseKey(t *testing.T) {
 		t.Fatalf("initKeyRegistry() returned err: %v", err)
 	}
 
-	_, err = initKeyRotation(registry, 0)
+	_, err = initKeyRenewal(registry, 0)
 	if err != nil {
-		t.Fatalf("initKeyRotation() returned err: %v", err)
+		t.Fatalf("initKeyRenewal() returned err: %v", err)
 	}
 	if hasAction(client, "create", "secrets") {
-		t.Errorf("initKeyRotation() should not create a new secret when one already exist and rotation is disabled")
+		t.Errorf("initKeyRenewal() should not create a new secret when one already exist and rotation is disabled")
 	}
 }
 
-func TestRotateStaleKey(t *testing.T) {
+func TestRenewStaleKey(t *testing.T) {
 	rand := testRand()
 	key, err := rsa.GenerateKey(rand, 512)
 	if err != nil {
@@ -191,9 +191,9 @@ func TestRotateStaleKey(t *testing.T) {
 		t.Fatalf("initKeyRegistry() returned err: %v", err)
 	}
 
-	_, err = initKeyRotation(registry, period)
+	_, err = initKeyRenewal(registry, period)
 	if err != nil {
-		t.Fatalf("initKeyRotation() returned err: %v", err)
+		t.Fatalf("initKeyRenewal() returned err: %v", err)
 	}
 
 	client.ClearActions()
@@ -263,11 +263,11 @@ func TestLegacySecret(t *testing.T) {
 		t.Fatalf("initKeyRegistry() returned err: %v", err)
 	}
 
-	_, err = initKeyRotation(registry, 0)
+	_, err = initKeyRenewal(registry, 0)
 	if err != nil {
-		t.Fatalf("initKeyRotation() returned err: %v", err)
+		t.Fatalf("initKeyRenewal() returned err: %v", err)
 	}
 	if hasAction(client, "create", "secrets") {
-		t.Errorf("initKeyRotation() should not create a new secret when one already exist and rotation is disabled")
+		t.Errorf("initKeyRenewal() should not create a new secret when one already exist and rotation is disabled")
 	}
 }

--- a/cmd/controller/server.go
+++ b/cmd/controller/server.go
@@ -64,6 +64,7 @@ func httpserver(cp certProvider, sc secretChecker, sr secretRotator) *http.Serve
 		}
 	})))
 
+	// TODO(mkm): rename to re-encrypt
 	mux.HandleFunc("/v1/rotate", func(w http.ResponseWriter, r *http.Request) {
 		content, err := ioutil.ReadAll(r.Body)
 

--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -46,7 +46,7 @@ var (
 	certFile       = flag.String("cert", "", "Certificate / public key to use for encryption. Overrides --controller-*")
 	controllerNs   = flag.String("controller-namespace", metav1.NamespaceSystem, "Namespace of sealed-secrets controller.")
 	controllerName = flag.String("controller-name", "sealed-secrets-controller", "Name of sealed-secrets controller.")
-	outputFormat   = flag.StringP("format","o", "json", "Output format for sealed secret. Either json or yaml")
+	outputFormat   = flag.StringP("format", "o", "json", "Output format for sealed secret. Either json or yaml")
 	dumpCert       = flag.Bool("fetch-cert", false, "Write certificate to stdout. Useful for later use with --cert")
 	printVersion   = flag.Bool("version", false, "Print version information and exit")
 	validateSecret = flag.Bool("validate", false, "Validate that the sealed secret can be decrypted")


### PR DESCRIPTION
And also rename the internal functions to follow the new clearer terminology.

The readme will be updated contextually to the v0.9.0 release.