### PR TITLE
Fix legacy key discovery

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -89,16 +89,16 @@ func initKeyRegistry(client kubernetes.Interface, r io.Reader, namespace, prefix
 		return nil, err
 	}
 	items := secretList.Items
-	if len(items) == 0 {
-		s, err := client.CoreV1().Secrets(namespace).Get(prefix, metav1.GetOptions{})
-		if !errors.IsNotFound(err) {
-			if err != nil {
-				return nil, err
-			}
-			items = append(items, *s)
-			// TODO(mkm): add the label to the legacy secret
+
+	s, err := client.CoreV1().Secrets(namespace).Get(prefix, metav1.GetOptions{})
+	if !errors.IsNotFound(err) {
+		if err != nil {
+			return nil, err
 		}
+		items = append(items, *s)
+		// TODO(mkm): add the label to the legacy secret to simplify discovery and backups.
 	}
+
 	keyRegistry := NewKeyRegistry(client, namespace, prefix, label, keysize)
 	sort.Sort(ssv1alpha1.ByCreationTimestamp(items))
 	for _, secret := range items {


### PR DESCRIPTION
Legacy key discovery is wrong, see #265.

The TODO hints to the fact that the original plan was to label the legacy secret with `sealedsecrets.bitnami.com/sealed-secrets-key` before we create the subsequent ones, however that's brittle because there might be
cases where legacy and new secrets can come to coexist before such label has a chance to be applied (e.g. restores from a backup).

There is no reason why shouldn't just include the legacy secret if it exist.

Closes #265