### PR TITLE
Move k8s compat window forward to 1.13-1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,10 @@ env:
 
 matrix:
   include:
+    - env: INT_KVERS=v1.16.0 INT_SSC_CONF=controller.yaml
     - env: INT_KVERS=v1.15.4 INT_SSC_CONF=controller.yaml
     - env: INT_KVERS=v1.14.1 INT_SSC_CONF=controller.yaml
+    # keep 1.13 until kops moves on
     - env: INT_KVERS=v1.13.5 INT_SSC_CONF=controller.yaml
 
 addons:

--- a/controller-norbac.jsonnet
+++ b/controller-norbac.jsonnet
@@ -3,7 +3,14 @@
 local namespace = 'kube-system';
 
 {
-  kube:: import 'vendor_jsonnet/kube-libsonnet/kube.libsonnet',
+  kube:: (import 'vendor_jsonnet/kube-libsonnet/kube.libsonnet') {
+    // v1beta2 deprecated in k8s 1.16. v1 can be used since 1.9. We currently officially support only >= 1.13
+    // TODO(mkm): remove this override once https://github.com/bitnami-labs/kube-libsonnet/pull/23 lands
+    // and we upgrade kube-libsonnet
+    Deployment(name): super.Deployment(name) {
+      apiVersion: 'apps/v1',
+    },
+  },
   local kube = self.kube,
 
   controllerImage:: std.extVar('CONTROLLER_IMAGE'),


### PR DESCRIPTION
Keep support for 1.13 because who uses kops is still locked to that version (or so I heard).

Manually fix 1.16 compat issue (will inherit kube-libsonnet upstream fix once https://github.com/bitnami-labs/kube-libsonnet/pull/23 lands), also just to show off a nice pattern with jsonnet where you can override your libraries too.

Tested by adding 1.16.0 minikube based integration tests (which did indeed fail before overriding to use v1 Deployments).

Closes #269