### PR TITLE
Detect the binary version from the buildInfo

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/bitnami-labs/flagenv"
 	"github.com/bitnami-labs/pflagenv"
 	ssv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealed-secrets/v1alpha1"
+	"github.com/bitnami-labs/sealed-secrets/pkg/buildinfo"
 	sealedsecrets "github.com/bitnami-labs/sealed-secrets/pkg/client/clientset/versioned"
 	ssinformers "github.com/bitnami-labs/sealed-secrets/pkg/client/informers/externalversions"
 )
@@ -47,13 +48,15 @@ var (
 	oldGCBehavior = flag.Bool("old-gc-behaviour", false, "Revert to old GC behavior where the controller deletes secrets instead of delegating that to k8s itself.")
 
 	// VERSION set from Makefile
-	VERSION = "UNKNOWN"
+	VERSION = buildinfo.DefaultVersion
 
 	// Selector used to find existing public/private key pairs on startup
 	keySelector = fields.OneTermEqualSelector(SealedSecretsKeyLabel, "active")
 )
 
 func init() {
+	buildinfo.FallbackVersion(&VERSION, buildinfo.DefaultVersion)
+
 	flag.DurationVar(keyRenewPeriod, "rotate-period", defaultKeyRenewPeriod, "")
 	flag.CommandLine.MarkDeprecated("rotate-period", "please use key-renew-period instead")
 

--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/bitnami-labs/sealed-secrets/pkg/buildinfo"
 	"github.com/bitnami-labs/sealed-secrets/pkg/crypto"
 	flag "github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
@@ -58,12 +59,14 @@ var (
 	reEncrypt      bool // re-encrypt command
 
 	// VERSION set from Makefile
-	VERSION = "UNKNOWN"
+	VERSION = buildinfo.DefaultVersion
 
 	clientConfig clientcmd.ClientConfig
 )
 
 func init() {
+	buildinfo.FallbackVersion(&VERSION, buildinfo.DefaultVersion)
+
 	flag.Var(&sealingScope, "scope", "Set the scope of the sealed secret: strict, namespace-wide, cluster-wide. Mandatory for --raw, otherwise the 'sealedsecrets.bitnami.com/cluster-wide' and 'sealedsecrets.bitnami.com/namespace-wide' annotations on the input secret can be used to select the scope.")
 	flag.BoolVar(&reEncrypt, "rotate", false, "")
 	flag.BoolVar(&reEncrypt, "re-encrypt", false, "Re-encrypt the given sealed secret to use the latest cluster key.")

--- a/pkg/buildinfo/version.go
+++ b/pkg/buildinfo/version.go
@@ -1,0 +1,20 @@
+package buildinfo
+
+import "runtime/debug"
+
+// DefaultVersion is the default version string if it's unset
+const DefaultVersion = "UNKNOWN"
+
+// FallbackVersion initializes the automatic version detection
+func FallbackVersion(v *string, unchanged string) {
+	if *v != unchanged {
+		return
+	}
+	b, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	if modv := b.Main.Version; modv != "(devel)" {
+		*v = modv
+	}
+}


### PR DESCRIPTION
Currently `kubeseal --version` works only if the binary is built with `make`.

The README also shows how to build from sources (using the new go mod based `go get`)

See example on:

```
(cd /tmp; GO111MODULE=on go get github.com/mkmik/gobuildversiontest@v0.0.1 && ${GOPATH:-~/go}/bin/gobuildversiontest)
```

More context: https://utcc.utoronto.ca/~cks/space/blog/programming/GoBinaryStructureNotes