### PR TITLE
--raw requires --name in all cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,9 +309,9 @@ See [Scopes](#scopes):
 ```sh
 $ echo -n foo | kubeseal --raw --from-file=/dev/stdin --namespace bar --name mysecret
 AgBChHUWLMx...
-$ echo -n foo | kubeseal --raw --from-file=/dev/stdin --namespace bar --scope namespace-wide
+$ echo -n foo | kubeseal --raw --from-file=/dev/stdin --namespace bar --scope namespace-wide --name mysecret
 AgAbbFNkM54...
-$ echo -n foo | kubeseal --raw --from-file=/dev/stdin --scope cluster-wide
+$ echo -n foo | kubeseal --raw --from-file=/dev/stdin --scope cluster-wide --name mysecret
 AgAjLKpIYV+...
 ```
 


### PR DESCRIPTION
Though I'm wondering if this is actually a bug given --scope [namespace-wide, cluster-wide] should not require a secret name as an encryption label.