### PR TITLE
Fix support for non-strict scopes when using --raw

### DIFF
--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -442,26 +442,13 @@ func run(w io.Writer, secretName, controllerNs, controllerName, certFile string,
 		if err != nil {
 			return err
 		}
-		
-		switch sealingScope {
-		case ssv1alpha1.ClusterWideScope:
-			if len(secretName) != 0 {
-				fmt.Fprintf(w, "Warning: cluster-wide scope specified, ignoring provided secret name: %s\n", secretName)
-			}
-		case ssv1alpha1.NamespaceWideScope:
-			if ns == "" {
-				return fmt.Errorf("must provide the --namespace flag with --raw and namespace-wide scope")
-			}
-			if len(secretName) != 0 {
-				fmt.Fprintf(w, "Warning: namespace-wide scope specified, ignoring provided secret name: %s\n", secretName)
-			}
-		default:
-			if ns == "" {
-				return fmt.Errorf("must provide the --namespace flag with --raw and default (strict) scope")
-			}
-			if secretName == "" {
-				return fmt.Errorf("must provide the --name flag with --raw and default (strict) scope")
-			}
+
+		if ns == "" && sealingScope < ssv1alpha1.ClusterWideScope {
+			return fmt.Errorf("must provide the --namespace flag with --raw and --scope %s", sealingScope.String())
+		}
+
+		if secretName == "" && sealingScope < ssv1alpha1.NamespaceWideScope {
+			return fmt.Errorf("must provide the --name flag with --raw and --scope %s", sealingScope.String())
 		}
 
 		if len(fromFile) == 0 {

--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -53,7 +53,7 @@ var (
 	validateSecret = flag.Bool("validate", false, "Validate that the sealed secret can be decrypted")
 	mergeInto      = flag.String("merge-into", "", "Merge items from secret into an existing sealed secret file, updating the file in-place instead of writing to stdout.")
 	raw            = flag.Bool("raw", false, "Encrypt a raw value passed via the --from-* flags instead of the whole secret object")
-	secretName     = flag.String("name", "", "Name of the sealed secret (required with --raw)")
+	secretName     = flag.String("name", "", "Name of the sealed secret (required with --raw and default (strict) scope)")
 	fromFile       = flag.StringSlice("from-file", nil, "(only with --raw) Secret items can be sourced from files. Pro-tip: you can use /dev/stdin to read pipe input. This flag tries to follow the same syntax as in kubectl")
 	sealingScope   ssv1alpha1.SealingScope
 	reEncrypt      bool // re-encrypt command
@@ -67,7 +67,7 @@ var (
 func init() {
 	buildinfo.FallbackVersion(&VERSION, buildinfo.DefaultVersion)
 
-	flag.Var(&sealingScope, "scope", "Set the scope of the sealed secret: strict, namespace-wide, cluster-wide. Mandatory for --raw, otherwise the 'sealedsecrets.bitnami.com/cluster-wide' and 'sealedsecrets.bitnami.com/namespace-wide' annotations on the input secret can be used to select the scope.")
+	flag.Var(&sealingScope, "scope", "Set the scope of the sealed secret: strict, namespace-wide, cluster-wide (defaults to strict). Mandatory for --raw, otherwise the 'sealedsecrets.bitnami.com/cluster-wide' and 'sealedsecrets.bitnami.com/namespace-wide' annotations on the input secret can be used to select the scope.")
 	flag.BoolVar(&reEncrypt, "rotate", false, "")
 	flag.BoolVar(&reEncrypt, "re-encrypt", false, "Re-encrypt the given sealed secret to use the latest cluster key.")
 	flag.CommandLine.MarkDeprecated("rotate", "please use --re-encrypt instead")
@@ -442,11 +442,26 @@ func run(w io.Writer, secretName, controllerNs, controllerName, certFile string,
 		if err != nil {
 			return err
 		}
-		if ns == "" {
-			return fmt.Errorf("must provide the --namespace flag with --raw")
-		}
-		if secretName == "" {
-			return fmt.Errorf("must provide the --name flag with --raw")
+		
+		switch sealingScope {
+		case ssv1alpha1.ClusterWideScope:
+			if len(secretName) != 0 {
+				fmt.Fprintf(w, "Warning: cluster-wide scope specified, ignoring provided secret name: %s\n", secretName)
+			}
+		case ssv1alpha1.NamespaceWideScope:
+			if ns == "" {
+				return fmt.Errorf("must provide the --namespace flag with --raw and namespace-wide scope")
+			}
+			if len(secretName) != 0 {
+				fmt.Fprintf(w, "Warning: namespace-wide scope specified, ignoring provided secret name: %s\n", secretName)
+			}
+		default:
+			if ns == "" {
+				return fmt.Errorf("must provide the --namespace flag with --raw and default (strict) scope")
+			}
+			if secretName == "" {
+				return fmt.Errorf("must provide the --name flag with --raw and default (strict) scope")
+			}
 		}
 
 		if len(fromFile) == 0 {

--- a/cmd/kubeseal/main_test.go
+++ b/cmd/kubeseal/main_test.go
@@ -343,7 +343,7 @@ func TestRaw(t *testing.T) {
 	fmt.Fprintln(certFile, testCert)
 	certFile.Close()
 
-	if got, want := run(ioutil.Discard, "", "", "", certFile.Name(), false, false, false, false, true, nil, ""), "must provide the --name flag with --raw and default (strict) scope"; got == nil || got.Error() != want {
+	if got, want := run(ioutil.Discard, "", "", "", certFile.Name(), false, false, false, false, true, nil, ""), "must provide the --name flag with --raw and --scope strict"; got == nil || got.Error() != want {
 		t.Fatalf("want matching: %q, got: %q", want, got.Error())
 	}
 

--- a/cmd/kubeseal/main_test.go
+++ b/cmd/kubeseal/main_test.go
@@ -343,7 +343,7 @@ func TestRaw(t *testing.T) {
 	fmt.Fprintln(certFile, testCert)
 	certFile.Close()
 
-	if got, want := run(ioutil.Discard, "", "", "", certFile.Name(), false, false, false, false, true, nil, ""), "must provide the --name flag with --raw"; got == nil || got.Error() != want {
+	if got, want := run(ioutil.Discard, "", "", "", certFile.Name(), false, false, false, false, true, nil, ""), "must provide the --name flag with --raw and default (strict) scope"; got == nil || got.Error() != want {
 		t.Fatalf("want matching: %q, got: %q", want, got.Error())
 	}
 


### PR DESCRIPTION
Allows the use of --raw without specifying secret name and namespace for cluster-wide scope and without specifying secret name for namespace-wide scope. Warns if secret name is provided when using non-strict scope.

(Note: I've never written a lick of Golang before so please feel free to discard with impunity :) )