### PR TITLE
Force name and namespace from --merge-into target

### DIFF
--- a/cmd/kubeseal/main_test.go
+++ b/cmd/kubeseal/main_test.go
@@ -12,14 +12,15 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
+	ssv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealed-secrets/v1alpha1"
+	"github.com/bitnami-labs/sealed-secrets/pkg/crypto"
+	"github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-
-	ssv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealed-secrets/v1alpha1"
-	"github.com/spf13/pflag"
 )
 
 const testCert = `
@@ -156,7 +157,7 @@ func TestSeal(t *testing.T) {
 	t.Logf("input is: %s", string(inbuf.Bytes()))
 
 	outbuf := bytes.Buffer{}
-	if err := seal(&inbuf, &outbuf, scheme.Codecs, key); err != nil {
+	if err := seal(&inbuf, &outbuf, scheme.Codecs, key, "", ""); err != nil {
 		t.Fatalf("seal() returned error: %v", err)
 	}
 
@@ -184,11 +185,37 @@ func TestSeal(t *testing.T) {
 	// NB: See sealedsecret_test.go for e2e crypto test
 }
 
-func mkTestSecret(t *testing.T, key, value string) []byte {
+type mkTestSecretOpt func(*mkTestSecretOpts)
+type mkTestSecretOpts struct {
+	secretName      string
+	secretNamespace string
+}
+
+func withSecretName(n string) mkTestSecretOpt {
+	return func(o *mkTestSecretOpts) {
+		o.secretName = n
+	}
+}
+
+func withSecretNamespace(n string) mkTestSecretOpt {
+	return func(o *mkTestSecretOpts) {
+		o.secretNamespace = n
+	}
+}
+
+func mkTestSecret(t *testing.T, key, value string, opts ...mkTestSecretOpt) []byte {
+	o := mkTestSecretOpts{
+		secretName:      "testname",
+		secretNamespace: "testns",
+	}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	secret := v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "testsecret",
-			Namespace: "testns",
+			Name:      o.secretName,
+			Namespace: o.secretNamespace,
 			Annotations: map[string]string{
 				key: value, // putting secret here just to have a simple way to test annotation merges
 			},
@@ -213,23 +240,36 @@ func mkTestSecret(t *testing.T, key, value string) []byte {
 	return inbuf.Bytes()
 }
 
-func mkTestSealedSecret(t *testing.T, pubKey *rsa.PublicKey, key, value string) []byte {
-	inbuf := bytes.NewBuffer(mkTestSecret(t, key, value))
+func mkTestSealedSecret(t *testing.T, pubKey *rsa.PublicKey, key, value string, opts ...mkTestSecretOpt) []byte {
+	inbuf := bytes.NewBuffer(mkTestSecret(t, key, value, opts...))
 	var outbuf bytes.Buffer
-	if err := seal(inbuf, &outbuf, scheme.Codecs, pubKey); err != nil {
+	if err := seal(inbuf, &outbuf, scheme.Codecs, pubKey, "", ""); err != nil {
 		t.Fatalf("seal() returned error: %v", err)
 	}
 
 	return outbuf.Bytes()
 }
 
-func TestMergeInto(t *testing.T) {
-	pubKey, err := parseKey(strings.NewReader(testCert))
+func newTestKeyPair(t *testing.T) (*rsa.PublicKey, map[string]*rsa.PrivateKey) {
+	privKey, _, err := crypto.GeneratePrivateKeyAndCert(2048, time.Hour, "testcn")
 	if err != nil {
-		t.Fatalf("Failed to parse test key: %v", err)
+		t.Fatal(err)
 	}
+	pubKey := &privKey.PublicKey
 
-	merge := func(newSecret, oldSealedSecret []byte) *ssv1alpha1.SealedSecret {
+	fp, err := crypto.PublicKeyFingerprint(pubKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privKeys := map[string]*rsa.PrivateKey{fp: privKey}
+
+	return pubKey, privKeys
+}
+
+func TestMergeInto(t *testing.T) {
+	pubKey, privKeys := newTestKeyPair(t)
+
+	merge := func(t *testing.T, newSecret, oldSealedSecret []byte) *ssv1alpha1.SealedSecret {
 		f, err := ioutil.TempFile("", "*.json")
 		if err != nil {
 			t.Fatal(err)
@@ -253,11 +293,17 @@ func TestMergeInto(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		_, err = merged.Unseal(scheme.Codecs, privKeys)
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		return merged
 	}
 
-	{
-		merged := merge(
+	t.Run("added", func(t *testing.T) {
+		merged := merge(t,
 			mkTestSecret(t, "foo", "secret1"),
 			mkTestSealedSecret(t, pubKey, "bar", "secret2"),
 		)
@@ -279,16 +325,16 @@ func TestMergeInto(t *testing.T) {
 		checkAdded(merged.Spec.EncryptedData, "foo", "bar")
 		checkAdded(merged.Spec.Template.Annotations, "foo", "bar")
 		checkAdded(merged.Spec.Template.Labels, "foo", "bar")
-	}
+	})
 
-	{
+	t.Run("updated", func(t *testing.T) {
 		origSrc := mkTestSealedSecret(t, pubKey, "foo", "secret2")
 		orig, err := decodeSealedSecret(scheme.Codecs, origSrc)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		merged := merge(
+		merged := merge(t,
 			mkTestSecret(t, "foo", "secret1"),
 			origSrc,
 		)
@@ -306,7 +352,17 @@ func TestMergeInto(t *testing.T) {
 		checkUpdated(orig.Spec.EncryptedData, merged.Spec.EncryptedData, "foo")
 		checkUpdated(orig.Spec.Template.Annotations, merged.Spec.Template.Annotations, "foo")
 		checkUpdated(orig.Spec.Template.Labels, merged.Spec.Template.Labels, "foo")
-	}
+	})
+
+	t.Run("bad name", func(t *testing.T) {
+		// should not fail even if input has a bad secret name because the name in existing existing sealed secret
+		// should win (same for namespace).
+		// TODO(mkm): test for case with scope mismatch too.
+		merge(t,
+			mkTestSecret(t, "foo", "secret1", withSecretName("badname"), withSecretNamespace("badns")),
+			mkTestSealedSecret(t, pubKey, "bar", "secret2"),
+		)
+	})
 }
 
 func TestVersion(t *testing.T) {

--- a/pkg/crypto/keys.go
+++ b/pkg/crypto/keys.go
@@ -1,0 +1,57 @@
+package crypto
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"io"
+	"math/big"
+	"time"
+)
+
+// GeneratePrivateKeyAndCert generates a keypair and signed certificate.
+func GeneratePrivateKeyAndCert(keySize int, validFor time.Duration, cn string) (*rsa.PrivateKey, *x509.Certificate, error) {
+	r := rand.Reader
+	privKey, err := rsa.GenerateKey(r, keySize)
+	if err != nil {
+		return nil, nil, err
+	}
+	cert, err := SignKey(r, privKey, validFor, cn)
+	if err != nil {
+		return nil, nil, err
+	}
+	return privKey, cert, nil
+}
+
+// SignKey returns a signed certificate.
+func SignKey(r io.Reader, key *rsa.PrivateKey, validFor time.Duration, cn string) (*x509.Certificate, error) {
+	// TODO: use certificates API to get this signed by the cluster root CA
+	// See https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/
+
+	notBefore := time.Now()
+
+	serialNo, err := rand.Int(r, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, err
+	}
+
+	cert := x509.Certificate{
+		SerialNumber: serialNo,
+		KeyUsage:     x509.KeyUsageEncipherOnly,
+		NotBefore:    notBefore.UTC(),
+		NotAfter:     notBefore.Add(validFor).UTC(),
+		Subject: pkix.Name{
+			CommonName: cn,
+		},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	data, err := x509.CreateCertificate(r, &cert, &cert, &key.PublicKey, key)
+	if err != nil {
+		return nil, err
+	}
+
+	return x509.ParseCertificate(data)
+}

--- a/pkg/crypto/keys_test.go
+++ b/pkg/crypto/keys_test.go
@@ -1,0 +1,33 @@
+package crypto
+
+import (
+	"crypto/rsa"
+	"io"
+	mathrand "math/rand"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// This is omg-not safe for real crypto use!
+func testRand() io.Reader {
+	return mathrand.New(mathrand.NewSource(42))
+}
+
+func TestSignKey(t *testing.T) {
+	rand := testRand()
+
+	key, err := rsa.GenerateKey(rand, 512)
+	if err != nil {
+		t.Fatalf("Failed to generate test key: %v", err)
+	}
+
+	cert, err := SignKey(rand, key, time.Hour, "mycn")
+	if err != nil {
+		t.Errorf("signKey() returned error: %v", err)
+	}
+
+	if !reflect.DeepEqual(cert.PublicKey, &key.PublicKey) {
+		t.Errorf("cert pubkey != original pubkey")
+	}
+}


### PR DESCRIPTION
A frequent operation is to take an existing sealed secrets and update a single entry in it.

We even have a fancy command now that helps this tedious operation: `--merge-into` (documented in the README).

The rationale for implementing that command was not only to help lazy users to merge strings into the right place
into a YAML file but also to address one of the most common and confusing user errors:

```bash
$ echo -n foo | kubectl create secret generic goodname --dry-run  --from-file=bar=/dev/stdin -o json \
  | kubeseal >sealed.yml
$ echo -n bar | kubectl create secret generic baadname --dry-run  --from-file=bar=/dev/stdin -o json \
  | kubeseal --merge-into sealed.yml
```

It's even more subtle when the namespace is concerned, since it's often taken from the current kubeconfig context.

This PR turns `--merge-into` into what it was intended: a helper that helps, leaning more on the "do what I mean"
rather than blindly "do what I told you":

It treats the state of the existing sealed secret the user is merging new values into as the home for the sensible
parameters of the sealing process.

A subsequent PR will do something similar for the "scope", since that also affects how the entries are encrypted and has subtle consequences when you get it wrong (and it's harder to deal with in one-liners, since you cannot set an annotation during `kubectl create secret...`).

Possibly relevant for #285

---

Enhances the tests for the mergeInto command so that they also decrypt the values.
This resulted in a noisy refactoring due to the fact that until now the kubeseal code only encrypted values
using a dummy public key for which we had no private key.