### PR TITLE
Remove tty warning in --fetch-cert

### DIFF
--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -461,7 +461,7 @@ func run(w io.Writer, secretName, controllerNs, controllerName, certURL string, 
 		return nil
 	}
 
-	if !raw {
+	if !raw && !dumpCert {
 		warnTTY()
 	}
 


### PR DESCRIPTION
regression in 0.9.3