### PR TITLE
Give an option to search only the current namespace

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -46,7 +46,7 @@ var (
 	keyRenewPeriod = flag.Duration("key-renew-period", defaultKeyRenewPeriod, "New key generation period (automatic rotation disabled if 0)")
 	acceptV1Data   = flag.Bool("accept-deprecated-v1-data", false, "Accept deprecated V1 data field.")
 	keyCutoffTime  = flag.String("key-cutoff-time", "", "Create a new key if latest one is older than this cutoff time. RFC1123 format with numeric timezone expected.")
-	namespaceAll   = flag.Bool("namespaceAll", true, "Scan all namespaces or only the current namespace (default=true).")
+	namespaceAll   = flag.Bool("all-namespaces", true, "Scan all namespaces or only the current namespace (default=true).")
 
 	oldGCBehavior = flag.Bool("old-gc-behaviour", false, "Revert to old GC behavior where the controller deletes secrets instead of delegating that to k8s itself.")
 


### PR DESCRIPTION
Giving an option to search only the current namespace is very helpful if somebody wants to deploy the controller in multiple namespaces in the same cluster and use the controller only per its own namespace. 