### PR TITLE
Build arm/arm64 release binaries in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@
 
 /controller
 /kubeseal
+/kubeseal-arm
+/kubeseal-arm64
+
 /controller.image
 /*-static
 /controller.yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,6 +117,10 @@ script:
   - rm -f kubeseal-static
   - GOOS=windows GOARCH=amd64 make kubeseal-static
   - cp kubeseal-static kubeseal.exe
+  - GOOS=linux GOARCH=arm GOARM=7 make kubeseal-static
+  - cp kubeseal-static kubeseal-arm
+  - GOOS=linux GOARCH=arm64 make kubeseal-static
+  - cp kubeseal-static kubeseal-arm64
 
 after_script: set +e
 
@@ -146,6 +150,8 @@ deploy:
   file:
     - $EXE_NAME
     - kubeseal.exe
+    - kubeseal-arm
+    - kubeseal-arm64
     - controller.yaml
     - controller-norbac.yaml
   on:


### PR DESCRIPTION
Build arm/arm64 release binaries in CI

Closes: #173

This patch adds a build for arm and arm64 by setting the
GOARM and GOARCH flags, and will be built on Linux.

GOARM7=armhf/Raspberry Pi, called "arm" by the K8s projects
GOARM8=aarch64 / 64-bit ARM such as AWS Graviton

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>