### PR TITLE
Warn if using --recovery-private-key without --recovery-unseal

### DIFF
--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -618,6 +618,9 @@ func run(w io.Writer, secretName, controllerNs, controllerName, certURL string, 
 	if unseal {
 		return unsealSealedSecret(w, os.Stdin, scheme.Codecs, privKeys)
 	}
+	if len(privKeys) != 0 && isatty.IsTerminal(os.Stderr.Fd()) {
+		fmt.Fprintf(os.Stderr, "warning: ignoring --recovery-private-key because unseal command not chosen with --recovery-unseal\n")
+	}
 
 	if raw {
 		ns, _, err := namespaceFromClientConfig()


### PR DESCRIPTION
Why are we not just raising an error if --recovery-private-key is set and --recovery-unseal is not,
or just implying the "unseal" mode if "--recovery-private-key" is set?

1. because doing so would break backwards compat and backwards compat is an important rule to not break lightly
2. because we use `flagenv` to default some flag values, so it's entirely possible that some users pass the `--recovery-private-key` implicitly while using kubeseal's other commands.

The current "flag based" UX sucks a bit, and I do want to address that, but not know as there are bigger fishes to fry and changing the UX would create a lot of noise.

Closes #351