### PR TITLE
Use static distroless flavour

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,4 @@
-# Ideally we could use the "static" flavour but let's first start with the base flavour (which has glibc).
-FROM gcr.io/distroless/base@sha256:edc3643ddf96d75032a55e240900b68b335186f1e5fea0a95af3b4cc96020b77
+FROM gcr.io/distroless/static@sha256:c6d5981545ce1406d33e61434c61e9452dad93ecd8397c41e89036ef977a88f4
 MAINTAINER Marko Mikulicic <mkmik@vmware.com>
 COPY controller /usr/local/bin/
 


### PR DESCRIPTION
This is the first step towards settup up a multi-arch image (see #360).

We don't need real base images, we can use one single distroless base image
for all architectures, since the only arch specific thing is the binary we cross-build
outside of docker anyway.

The actual multi-arch build will be added in another PR.

I tested this change manually in a test cluster.