### PR TITLE
Add recommended labels

### DIFF
--- a/controller-norbac.jsonnet
+++ b/controller-norbac.jsonnet
@@ -12,12 +12,23 @@ local namespace = 'kube-system';
   crd: kube.CustomResourceDefinition('bitnami.com', 'v1alpha1', 'SealedSecret'),
 
   namespace:: { metadata+: { namespace: namespace } },
+  managedBy:: 'jsonnet',
+  labels:: {
+    metadata+: {
+      labels+: {
+        'app.kubernetes.io/name': 'kubeseal',
+        'app.kubernetes.io/version': std.splitLimit($.controllerImage, ':', 1)[1],
+        'app.kubernetes.io/part-of': 'kubeseal',
+        'app.kubernetes.io/managed-by': $.managedBy,
+      },
+    },
+  },
 
-  service: kube.Service('sealed-secrets-controller') + $.namespace {
+  service: kube.Service('sealed-secrets-controller') + $.namespace + $.labels {
     target_pod: $.controller.spec.template,
   },
 
-  controller: kube.Deployment('sealed-secrets-controller') + $.namespace {
+  controller: kube.Deployment('sealed-secrets-controller') + $.namespace + $.labels {
     spec+: {
       template+: {
         spec+: {

--- a/controller.jsonnet
+++ b/controller.jsonnet
@@ -6,9 +6,9 @@ local controller = import 'controller-norbac.jsonnet';
 controller {
   local kube = self.kube,
 
-  account: kube.ServiceAccount('sealed-secrets-controller') + $.namespace,
+  account: kube.ServiceAccount('sealed-secrets-controller') + $.namespace + $.labels,
 
-  unsealerRole: kube.ClusterRole('secrets-unsealer') {
+  unsealerRole: kube.ClusterRole('secrets-unsealer') + $.labels {
     rules: [
       {
         apiGroups: ['bitnami.com'],
@@ -28,7 +28,7 @@ controller {
     ],
   },
 
-  unsealKeyRole: kube.Role('sealed-secrets-key-admin') + $.namespace {
+  unsealKeyRole: kube.Role('sealed-secrets-key-admin') + $.namespace + $.labels {
     rules: [
       {
         apiGroups: [''],
@@ -39,7 +39,7 @@ controller {
     ],
   },
 
-  serviceProxierRole: kube.Role('sealed-secrets-service-proxier') + $.namespace {
+  serviceProxierRole: kube.Role('sealed-secrets-service-proxier') + $.namespace + $.labels {
     rules: [
       {
         apiGroups: [
@@ -60,17 +60,17 @@ controller {
     ],
   },
 
-  unsealerBinding: kube.ClusterRoleBinding('sealed-secrets-controller') {
+  unsealerBinding: kube.ClusterRoleBinding('sealed-secrets-controller') + $.labels {
     roleRef_: $.unsealerRole,
     subjects_+: [$.account],
   },
 
-  unsealKeyBinding: kube.RoleBinding('sealed-secrets-controller') + $.namespace {
+  unsealKeyBinding: kube.RoleBinding('sealed-secrets-controller') + $.namespace + $.labels {
     roleRef_: $.unsealKeyRole,
     subjects_+: [$.account],
   },
 
-  serviceProxierBinding: kube.RoleBinding('sealed-secrets-service-proxier') + $.namespace {
+  serviceProxierBinding: kube.RoleBinding('sealed-secrets-service-proxier') + $.namespace + $.labels {
     roleRef_: $.serviceProxierRole,
     // kube.libsonnet assumes object here have a namespace, but system groups don't
     // thus are not supposed to use the magic "_" here.


### PR DESCRIPTION
Hi,

First, thank you for this great tool :) 

I am interested about out of the box labels to be able to manage my kubernetes resources. I added only ones define here: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/

I am not sure to use the best way to add them; so let me know if I should change. 

Some additional information about my change: 
* I didn't add `app.kubernetes.io/instance` label because I didn't know witch value use.
* I didn't apply labels to CRD. I didn't enough worked with this kind of object to to know if I should or not.
*  I add dedicated field for `app.kubernetes.io/managed-by` label to be able to override it easily. There many tools over jsonnet so I am not able to define a value. In my use case, it is [tanka](https://tanka.dev/).