### PR TITLE
Update status subresource

### DIFF
--- a/controller-norbac.jsonnet
+++ b/controller-norbac.jsonnet
@@ -9,7 +9,13 @@ local namespace = 'kube-system';
   controllerImage:: std.extVar('CONTROLLER_IMAGE'),
   imagePullPolicy:: std.extVar('IMAGE_PULL_POLICY'),
 
-  crd: kube.CustomResourceDefinition('bitnami.com', 'v1alpha1', 'SealedSecret'),
+  crd: kube.CustomResourceDefinition('bitnami.com', 'v1alpha1', 'SealedSecret') {
+    spec+: {
+      subresources: {
+        status: {},
+      }
+    },
+  },
 
   namespace:: { metadata+: { namespace: namespace } },
 

--- a/controller.jsonnet
+++ b/controller.jsonnet
@@ -13,7 +13,12 @@ controller {
       {
         apiGroups: ['bitnami.com'],
         resources: ['sealedsecrets'],
-        verbs: ['get', 'list', 'watch', 'update'],
+        verbs: ['get', 'list', 'watch'],
+      },
+      {
+        apiGroups: ['bitnami.com'],
+        resources: ['sealedsecrets/status'],
+        verbs: ['update'],
       },
       {
         apiGroups: [''],


### PR DESCRIPTION
Part of #346

TL;DR we now update the CRD status using `UpdateStatus`, updating `ObservedGeneration` correctly, but we don't yet write out any status "conditions".

---

We already had some code to update the `status` field of the CRD (`func updateSealedSecretStatus`).
It was buggy but the bug wasn't triggered because the write to the status field was always a no operation.

The `Status.ObservedGeneration` field is designed to reflect the generation number of the customer resource that the controller has last processed. We used to write the generation number of the new unsealed secret resource we're creating in memory, which is always 0.

Once we fixed bug, though, each `.Update` of the SealedSecret CRD would create a feedback loop because the update to the ObservedGeneration field will cause an increment of the `Generation` field and so on.

This PR, switches to `.UpdateStatus`, since now the `CustomResourceSubresources` feature gate is enabled
in all supported k8s versions (see table https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/).

This requires a change in our RBAC configs since the controller needs to be able to update the status subresource.

In the next PR we'll write out actual "status conditions" (success, error, message, etc)