### PR TITLE
Tag Status field as omitempty

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -288,10 +288,12 @@ func (c *Controller) unseal(key string) (unsealErr error) {
 
 func (c *Controller) updateSealedSecretStatus(ssecret *ssv1alpha1.SealedSecret, unsealError error) error {
 	ssecret = ssecret.DeepCopy()
-	st := &ssecret.Status
+	if ssecret.Status == nil {
+		ssecret.Status = &ssv1alpha1.SealedSecretStatus{}
+	}
 
-	st.ObservedGeneration = ssecret.ObjectMeta.Generation
-	updateSealedSecretsStatusConditions(st, unsealError)
+	ssecret.Status.ObservedGeneration = ssecret.ObjectMeta.Generation
+	updateSealedSecretsStatusConditions(ssecret.Status, unsealError)
 
 	_, err := c.ssclient.SealedSecrets(ssecret.GetObjectMeta().GetNamespace()).UpdateStatus(ssecret)
 	return err

--- a/pkg/apis/sealed-secrets/v1alpha1/types.go
+++ b/pkg/apis/sealed-secrets/v1alpha1/types.go
@@ -24,7 +24,7 @@ const (
 
 	// SealedSecretManagedAnnotation is the name for the annotation for
 	// flaging the existing secrets be managed by SealedSecret controller.
- 	SealedSecretManagedAnnotation = annoNs + "managed"
+	SealedSecretManagedAnnotation = annoNs + "managed"
 )
 
 // SecretTemplateSpec describes the structure a Secret should have
@@ -101,8 +101,9 @@ type SealedSecret struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   SealedSecretSpec   `json:"spec"`
-	Status SealedSecretStatus `json:"status"`
+	Spec SealedSecretSpec `json:"spec"`
+	// +optional
+	Status *SealedSecretStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/sealed-secrets/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/sealed-secrets/v1alpha1/zz_generated.deepcopy.go
@@ -36,7 +36,11 @@ func (in *SealedSecret) DeepCopyInto(out *SealedSecret) {
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	in.Spec.DeepCopyInto(&out.Spec)
-	in.Status.DeepCopyInto(&out.Status)
+	if in.Status != nil {
+		in, out := &in.Status, &out.Status
+		*out = new(SealedSecretStatus)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 


### PR DESCRIPTION
Checked that nobody depends on the Status field since we're technically breaking source backward compat
https://pkg.go.dev/github.com/bitnami-labs/sealed-secrets@v0.11.0/pkg/apis/sealed-secrets/v1alpha1?tab=doc#SealedSecretStatus