### PR TITLE
Prometheus - Grafana dashboard corrections

### DIFF
--- a/contrib/prometheus-mixin/dashboards/sealed-secrets-controller.json
+++ b/contrib/prometheus-mixin/dashboards/sealed-secrets-controller.json
@@ -16,14 +16,14 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": null,
-  "iteration": 1562104739964,
+  "id": 3,
+  "iteration": 1585599163503,
   "links": [
     {
-      "icon": "doc",
+      "icon": "external link",
       "tags": [],
-      "title": "Runbook",
-      "tooltip": "View Runbook on Gitlab",
+      "title": "GitHub",
+      "tooltip": "View Project on GitHub",
       "type": "link",
       "url": "https://github.com/bitnami-labs/sealed-secrets"
     }
@@ -35,28 +35,33 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "description": "Unseal request rate/min",
+      "description": "Rate of requests to unseal a SealedSecret.\n\nThis can include non-obvious operations such as deleting a SealedSecret.",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 0,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 2,
       "legend": {
-        "avg": false,
+        "avg": true,
         "current": false,
-        "max": false,
-        "min": false,
+        "max": true,
+        "min": true,
         "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -69,8 +74,9 @@
         {
           "expr": "sum(rate(sealed_secrets_controller_unseal_requests_total{}[1m]))",
           "format": "time_series",
+          "instant": false,
           "intervalFactor": 1,
-          "legendFormat": "",
+          "legendFormat": "rps",
           "refId": "A"
         }
       ],
@@ -78,7 +84,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Successful unseals/min",
+      "title": "Unseal Request Rate/s",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -121,14 +127,16 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "description": "Rate of errors when unsealing a SealedSecret. Reason for error included as label value, such as cryptography issue (key/namespace), update issue (RBAC/API I/O), etc.",
+      "description": "Rate of errors when unsealing a SealedSecret. \n\nReason for error included as label value, eg:\n- unseal = cryptography issue (key/namespace) or RBAC\n- unmanaged = destination Secret wasn't created by SealedSecrets\n- update = potentially RBAC\n- status = potentially RBAC\n- fetch = potentially RBAC\n",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 12,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 3,
       "legend": {
         "avg": false,
@@ -145,6 +153,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null as zero",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -166,7 +177,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Unseal Error Rate/min",
+      "title": "Unseal Error Rate/s",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -202,9 +213,10 @@
         "align": false,
         "alignLevel": null
       }
-    },
+    }
   ],
-  "schemaVersion": 18,
+  "refresh": false,
+  "schemaVersion": 22,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -228,7 +240,11 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "$datasource",
         "definition": "label_values(kube_pod_info, pod)",
         "hide": 0,
@@ -282,5 +298,5 @@
   "timezone": "",
   "title": "Sealed Secrets Controller",
   "uid": "UuEtZCVWz",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
- correctly state rps instead of rpm - per minute calculation was
  removed.
- change description from successes to total requests
- add legend to request rate panel
- add potential causes of errors to description
- update link to GitHub text