### PR TITLE
Put status update feature behind a disabled feature flag

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -50,6 +50,8 @@ var (
 
 	oldGCBehavior = flag.Bool("old-gc-behaviour", false, "Revert to old GC behavior where the controller deletes secrets instead of delegating that to k8s itself.")
 
+	updateStatus = flag.Bool("update-status", false, "beta: if true, the controller will update the status subresource whenever it processes a sealed secret")
+
 	// VERSION set from Makefile
 	VERSION = buildinfo.DefaultVersion
 
@@ -231,6 +233,7 @@ func main2() error {
 	ssinformer := ssinformers.NewFilteredSharedInformerFactory(ssclientset, 0, namespace, nil)
 	controller := NewController(clientset, ssclientset, ssinformer, keyRegistry)
 	controller.oldGCBehavior = *oldGCBehavior
+	controller.updateStatus = *updateStatus
 
 	stop := make(chan struct{})
 	defer close(stop)


### PR DESCRIPTION
A few people have reported that upgrading to v0.12.0 results in a feedback loop where the controller
keeps updating the sealed secrets resources without any respite.

The v0.12.0 release also ships the prometheus feature thus some users will love to update but currently can't.