### PR TITLE
fix(kubeseal): remove kubeconfig deps from recovery-unseal

### DIFF
--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -587,6 +587,13 @@ func run(w io.Writer, secretName, controllerNs, controllerName, certURL string, 
 		}
 	}
 
+	if unseal {
+		return unsealSealedSecret(w, os.Stdin, scheme.Codecs, privKeys)
+	}
+	if len(privKeys) != 0 && isatty.IsTerminal(os.Stderr.Fd()) {
+		fmt.Fprintf(os.Stderr, "warning: ignoring --recovery-private-key because unseal command not chosen with --recovery-unseal\n")
+	}
+
 	if validateSecret {
 		return validateSealedSecret(os.Stdin, controllerNs, controllerName)
 	}
@@ -613,13 +620,6 @@ func run(w io.Writer, secretName, controllerNs, controllerName, certURL string, 
 
 	if mergeInto != "" {
 		return sealMergingInto(os.Stdin, mergeInto, scheme.Codecs, pubKey, sealingScope, allowEmptyData)
-	}
-
-	if unseal {
-		return unsealSealedSecret(w, os.Stdin, scheme.Codecs, privKeys)
-	}
-	if len(privKeys) != 0 && isatty.IsTerminal(os.Stderr.Fd()) {
-		fmt.Fprintf(os.Stderr, "warning: ignoring --recovery-private-key because unseal command not chosen with --recovery-unseal\n")
 	}
 
 	if raw {


### PR DESCRIPTION
`openCert()` in `kubeseal` triggers a kubeconfig check as it needs to fetch certificate information
from the running kubernetes cluster. Some people have used the `--cert` option as a way of
circumvent that check as it allows the kubeconfig check on `openCert()` to be bypassed by using a
previously backed up certificate. This commit applies a very basic "fix" by moving the `unseal`
command before the `openCert()` execution as it is a fairly self-sufficient command. 

fix #341 