### PR TITLE
Revert "Add recommended labels"

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ original Secret from the SealedSecret.
   - [What flags are available for kubeseal?](#what-flags-are-available-for-kubeseal)
   - [How do I update parts of JSON/YAML/TOML.. file encrypted with sealed secrets?](#how-do-i-update-parts-of-jsonyamltoml-file-encrypted-with-sealed-secrets)
 - [Community](#community)
+  - [Related projects](#related-projects)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/controller-norbac.jsonnet
+++ b/controller-norbac.jsonnet
@@ -18,23 +18,12 @@ local namespace = 'kube-system';
   },
 
   namespace:: { metadata+: { namespace: namespace } },
-  managedBy:: 'jsonnet',
-  labels:: {
-    metadata+: {
-      labels+: {
-        'app.kubernetes.io/name': 'kubeseal',
-        'app.kubernetes.io/version': std.splitLimit($.controllerImage, ':', 1)[1],
-        'app.kubernetes.io/part-of': 'kubeseal',
-        'app.kubernetes.io/managed-by': $.managedBy,
-      },
-    },
-  },
 
-  service: kube.Service('sealed-secrets-controller') + $.namespace + $.labels {
+  service: kube.Service('sealed-secrets-controller') + $.namespace {
     target_pod: $.controller.spec.template,
   },
 
-  controller: kube.Deployment('sealed-secrets-controller') + $.namespace + $.labels {
+  controller: kube.Deployment('sealed-secrets-controller') + $.namespace {
     spec+: {
       template+: {
         spec+: {

--- a/controller.jsonnet
+++ b/controller.jsonnet
@@ -6,9 +6,9 @@ local controller = import 'controller-norbac.jsonnet';
 controller {
   local kube = self.kube,
 
-  account: kube.ServiceAccount('sealed-secrets-controller') + $.namespace + $.labels,
+  account: kube.ServiceAccount('sealed-secrets-controller') + $.namespace,
 
-  unsealerRole: kube.ClusterRole('secrets-unsealer') + $.labels {
+  unsealerRole: kube.ClusterRole('secrets-unsealer') {
     rules: [
       {
         apiGroups: ['bitnami.com'],
@@ -33,7 +33,7 @@ controller {
     ],
   },
 
-  unsealKeyRole: kube.Role('sealed-secrets-key-admin') + $.namespace + $.labels {
+  unsealKeyRole: kube.Role('sealed-secrets-key-admin') + $.namespace {
     rules: [
       {
         apiGroups: [''],
@@ -44,7 +44,7 @@ controller {
     ],
   },
 
-  serviceProxierRole: kube.Role('sealed-secrets-service-proxier') + $.namespace + $.labels {
+  serviceProxierRole: kube.Role('sealed-secrets-service-proxier') + $.namespace {
     rules: [
       {
         apiGroups: [
@@ -65,17 +65,17 @@ controller {
     ],
   },
 
-  unsealerBinding: kube.ClusterRoleBinding('sealed-secrets-controller') + $.labels {
+  unsealerBinding: kube.ClusterRoleBinding('sealed-secrets-controller') {
     roleRef_: $.unsealerRole,
     subjects_+: [$.account],
   },
 
-  unsealKeyBinding: kube.RoleBinding('sealed-secrets-controller') + $.namespace + $.labels {
+  unsealKeyBinding: kube.RoleBinding('sealed-secrets-controller') + $.namespace {
     roleRef_: $.unsealKeyRole,
     subjects_+: [$.account],
   },
 
-  serviceProxierBinding: kube.RoleBinding('sealed-secrets-service-proxier') + $.namespace + $.labels {
+  serviceProxierBinding: kube.RoleBinding('sealed-secrets-service-proxier') + $.namespace {
     roleRef_: $.serviceProxierRole,
     // kube.libsonnet assumes object here have a namespace, but system groups don't
     // thus are not supposed to use the magic "_" here.


### PR DESCRIPTION
This reverts commit PR #379 which broke upgradeability
by causing the label selectors to change (which are immutable).

We'll need to give these "recommended labels" another try, this time more carefully