### PR TITLE
Fix travis Go version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - '1.14'
-  - '1.13'
+  - '1.14.x'
+  - '1.13.x'
 
 services:
   - docker


### PR DESCRIPTION
Turns out all our released binaries are compiled with Go 1.14.0 because .travis.yaml
contains the `1.14` version spec which doesn't imply "latest version of 1.14 branch"

(I checked that on our released binaries following the instructions on https://dave.cheney.net/2017/06/20/how-to-find-out-which-go-version-built-your-binary)

A user reported an issue (#411) that is likely caused by a toolchain bug (https://github.com/golang/go/issues/37436)
which is fixed in 1.14.1 (2020/03/19).

Several sealed-secret releases happened after that and we didn't inherit the fix.

Given the strong backwards compat guarantees the Go team commits to,
I think it's a good idea to just build with the latest version of the toolchain.

Closes #411