### PR TITLE
Add `condition_info` metric to expose SealedSecrets status

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -239,6 +239,8 @@ func (c *Controller) unseal(key string) (unsealErr error) {
 			// Non-fatal.  Log and continue.
 			log.Printf("Error updating SealedSecret %s status: %v", key, err)
 			unsealErrorsTotal.WithLabelValues("status").Inc()
+		} else {
+			ObserveCondition(ssecret)
 		}
 	}()
 


### PR DESCRIPTION
Hello there 👋 

In order to notify when a specific SealedSecret cannot be synced, I added new Gauges that expose SealedSecrets status. One may create an alert rule such as:
```yaml
alert: SealedSecretSyncFailed
expr: sealed_secrets_controller_condition_info{condition="Synced"} == -1
annotations:
  summary: The Sealed Secrets controller failed to sync {{ $labels.namespace }}:{{ $labels.name }}
```

I have not put any effort in extending the Prometheus mixin with this new metric yet. Happy to get into it if that's a must have.