### PR TITLE
Fix namespace in PodMonitor declaration

### DIFF
--- a/controller-podmonitor.jsonnet
+++ b/controller-podmonitor.jsonnet
@@ -8,7 +8,7 @@ controller {
     kind: 'PodMonitor',
     metadata: {
       name: 'sealed-secrets-controller',
-      namespace: $.namespace,
+      namespace: $.namespace.metadata.namespace,
       labels: {
         name: 'sealed-secrets-controller',
       },
@@ -22,7 +22,7 @@ controller {
       },
       namespaceSelector: {
         matchNames: [
-          $.namespace,
+          $.namespace.metadata.namespace,
         ],
       },
       podMetricsEndpoints: [


### PR DESCRIPTION
`$.namespace` is not correctly used in the PodMonitor declaration, as it (ambiguously) contains a metadata object and not just a string as one would expect.

This PR fixes it by using the namespace value nested in that object. It's not very pretty, so I'll take better suggestions.

Diff of rendered PodMonitor:
```diff
--- master.json 2020-07-01 12:06:55.394457044 +0200
+++ fix-podmonitor.json  2020-07-01 12:06:47.546447733 +0200
@@ -6,21 +6,13 @@
       "name": "sealed-secrets-controller"
     },
     "name": "sealed-secrets-controller",
-    "namespace": {
-      "metadata": {
         "namespace": "kube-system"
-      }
-    }
   },
   "spec": {
     "jobLabel": "name",
     "namespaceSelector": {
       "matchNames": [
-        {
-          "metadata": {
-            "namespace": "kube-system"
-          }
-        }
+        "kube-system"
       ]
     },
```

Also, the manifest defines a `Service` object but I can't see what it is used for, as the controller should not serving request ?

Thanks for the great tool :v: 