### PR TITLE
Fix nil status

### DIFF
--- a/cmd/controller/metrics.go
+++ b/cmd/controller/metrics.go
@@ -69,11 +69,13 @@ func init() {
 	for _, val := range []string{"fetch", "status", "unmanaged", "unseal", "update"} {
 		unsealErrorsTotal.WithLabelValues(val)
 	}
-
 }
 
 // ObserveCondition sets a `condition_info` Gauge according to a SealedSecret status.
 func ObserveCondition(ssecret *v1alpha1.SealedSecret) {
+	if ssecret.Status == nil {
+		return
+	}
 	for _, condition := range ssecret.Status.Conditions {
 		conditionInfo.With(prometheus.Labels{
 			labelNamespace: ssecret.Namespace,
@@ -85,6 +87,9 @@ func ObserveCondition(ssecret *v1alpha1.SealedSecret) {
 
 // UnregisterCondition unregisters Gauges associated to a SealedSecret conditions.
 func UnregisterCondition(ssecret *v1alpha1.SealedSecret) {
+	if ssecret.Status == nil {
+		return
+	}
 	for _, condition := range ssecret.Status.Conditions {
 		prometheus.Unregister(conditionInfo.With(prometheus.Labels{
 			labelNamespace: ssecret.Namespace,


### PR DESCRIPTION
Controller was crashing when object had no status. The crash was visible in the integration tests, but integration tests
didn't prevent the incriminated PR to get landed since all PR integration tests fail due to quay permission issue (since in order to build multi-arch images with standard docker toolchain the image must be first pushed to a registry in order to compute the digest, we depend on the repo secret which is unavailable for jobs spawned by PRs made by external contributors). I'll need to fix the CI, but in the meantime let's land this so we can cut a release.