### PR TITLE
Make the sealedsecrets.bitnami.com/managed annotation value more correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ only change from existing Kubernetes is that the *contents* of the
 `Secret` are now hidden while outside the cluster.
 
 ### Managing existing secrets
-If you want `SealedSecret` controller to take management of an existing `Secret` (i.e. overwrite it when unsealing a `SealedSecret` with the same name and namespace), then you have to annotate that `Secret` with the annotation `sealedsecrets.bitnami.com/managed: true` ahead applying the [Usage](#usage) steps.
+If you want `SealedSecret` controller to take management of an existing `Secret` (i.e. overwrite it when unsealing a `SealedSecret` with the same name and namespace), then you have to annotate that `Secret` with the annotation `sealedsecrets.bitnami.com/managed: "true"` ahead applying the [Usage](#usage) steps.
 
 ### Update existing secrets
 


### PR DESCRIPTION
Annotation values must be strings, and `true` in YAML is a boolean.