### PR TITLE
add namespace to unseal error metric

### DIFF
--- a/cmd/controller/metrics.go
+++ b/cmd/controller/metrics.go
@@ -47,7 +47,7 @@ var (
 			Name:      "unseal_errors_total",
 			Help:      "Total number of sealed secret unseal errors by reason",
 		},
-		[]string{"reason"},
+		[]string{"reason", "namespace"},
 	)
 
 	conditionInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -64,11 +64,6 @@ func init() {
 	prometheus.MustRegister(unsealRequestsTotal)
 	prometheus.MustRegister(unsealErrorsTotal)
 	prometheus.MustRegister(conditionInfo)
-
-	// Initialise known label values
-	for _, val := range []string{"fetch", "status", "unmanaged", "unseal", "update"} {
-		unsealErrorsTotal.WithLabelValues(val)
-	}
 }
 
 // ObserveCondition sets a `condition_info` Gauge according to a SealedSecret status.


### PR DESCRIPTION
I've been running sealed secrets and I love it thanks!

One caveat is that it's impossible to direct `SealedSecretsUnsealErrorRateHigh` alert to specific teams. So it ends up that one team, gets all of the failures.

I think to solve it we can add the namespace to the metric so that alerts can be directed to teams that own approperiate namespaces.

One typical example is when a secret already exists and then you add a new sealed secret and it doesn't override the existing secret. In this case I would like to alert the appropriate namespace owner ;)