### PR TITLE
contrib/prometheus-mixin: Adjust alert to expose namespace and reason in labels

### DIFF
--- a/contrib/prometheus-mixin/alerts/sealed-secrets-alerts.libsonnet
+++ b/contrib/prometheus-mixin/alerts/sealed-secrets-alerts.libsonnet
@@ -14,17 +14,17 @@
         // - 'for' clause not used because we are unlikely to have a sustained rate of errors unless there is a LOT of secret churn in cluster.
         // Rob Ewaschuk - My Philosophy on Alerting: https://docs.google.com/document/d/199PqyG3UsyXlwieHaqbGiWVa8eMWi8zzAn0YfcApr8Q/edit
         {
-          alert: 'SealedSecretsUnsealErrorRateHigh',
+          alert: 'SealedSecretsUnsealErrorHigh',
           expr: |||
-            sum(rate(sealed_secrets_controller_unseal_errors_total{}[5m])) > 0
+            sum by (reason, namespace) (rate(sealed_secrets_controller_unseal_errors_total{}[5m])) > 0
           ||| % $._config,
           // 'for': '5m', // Not used, see caveats above.
           labels: {
             severity: 'warning',
           },
           annotations: {
-            summary: 'Sealed Secrets Unseal Error Rate High',
-            description: 'High rate of errors unsealing Sealed Secrets',
+            summary: 'Sealed Secrets Unseal Error High',
+            description: 'High number of errors during unsealing Sealed Secrets in {{ $labels.namespace }} namespace.',
             runbook_url: 'https://github.com/bitnami-labs/sealed-secrets',
           },
         },

--- a/contrib/prometheus-mixin/tests.yaml
+++ b/contrib/prometheus-mixin/tests.yaml
@@ -8,23 +8,21 @@ evaluation_interval: 1m
 tests:
 - interval: 1m
   input_series:
-  - series: 'sealed_secrets_controller_unseal_errors_total{status="update"}'
-    values: '0+0x20'
-  - series: 'sealed_secrets_controller_unseal_errors_total{status="update"}'
-    values: '0+0x5 1+1x20'
-  - series: 'sealed_secrets_controller_unseal_errors_total{status="unseal"}'
-    values: '0+0x20'
-  - series: 'sealed_secrets_controller_unseal_errors_total{status="unseal"}'
-    values: '0+0x5 1+1x20'
+  - series: 'sealed_secrets_controller_unseal_errors_total{reason="update",namespace="test"}'
+    values: '0+0x5 1+1x5'
+  - series: 'sealed_secrets_controller_unseal_errors_total{reason="unseal",namespace="test"}'
+    values: '0+0x10'
   alert_rule_test:
-  - eval_time: 4m
-    alertname: SealedSecretsUnsealErrorRateHigh
-  - eval_time: 6m
-    alertname: SealedSecretsUnsealErrorRateHigh
+  - eval_time: 5m
+    alertname: SealedSecretsUnsealErrorHigh
+  - eval_time: 10m
+    alertname: SealedSecretsUnsealErrorHigh
     exp_alerts:
     - exp_labels:
         severity: warning
+        namespace: test
+        reason: update
       exp_annotations:
-        summary: 'Sealed Secrets Unseal Error Rate High'
-        description: 'High rate of errors unsealing Sealed Secrets'
+        summary: 'Sealed Secrets Unseal Error High'
+        description: 'High number of errors during unsealing Sealed Secrets in test namespace.'
         runbook_url: 'https://github.com/bitnami-labs/sealed-secrets'


### PR DESCRIPTION
This changes how alert works to react on specific "reason" and in a specific namespace. It should allow easier debugging when alert fires. Additionally, I adjusted the alert name as it is not alerting on error rate (number of errors vs all requests) but a rate of change in metric value. Plus I adjusted tests as they were using unreal scenario.

Ideally, `reason` label should be included somehow in the alert description, but I didn't manage to do this in a way that would be grammatically correct :shrug: 

Signed-off-by: paulfantom <pawel@krupa.net.pl>