### PR TITLE
Raise error when encountering multi-document YAML

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -29,6 +29,7 @@ import (
 	ssscheme "github.com/bitnami-labs/sealed-secrets/pkg/client/clientset/versioned/scheme"
 	ssv1alpha1client "github.com/bitnami-labs/sealed-secrets/pkg/client/clientset/versioned/typed/sealed-secrets/v1alpha1"
 	ssinformer "github.com/bitnami-labs/sealed-secrets/pkg/client/informers/externalversions"
+	"github.com/bitnami-labs/sealed-secrets/pkg/multidocyaml"
 )
 
 const (
@@ -378,6 +379,10 @@ func isAnnotatedToBeManaged(secret *corev1.Secret) bool {
 
 // AttemptUnseal tries to unseal a secret.
 func (c *Controller) AttemptUnseal(content []byte) (bool, error) {
+	if err := multidocyaml.EnsureNotMultiDoc(content); err != nil {
+		return false, err
+	}
+
 	object, err := runtime.Decode(scheme.Codecs.UniversalDecoder(ssv1alpha1.SchemeGroupVersion), content)
 	if err != nil {
 		return false, err

--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/bitnami-labs/sealed-secrets/pkg/buildinfo"
 	"github.com/bitnami-labs/sealed-secrets/pkg/crypto"
+	"github.com/bitnami-labs/sealed-secrets/pkg/multidocyaml"
 	"github.com/google/renameio"
 	"github.com/mattn/go-isatty"
 	flag "github.com/spf13/pflag"
@@ -132,6 +133,10 @@ func parseKey(r io.Reader) (*rsa.PublicKey, error) {
 func readSecret(codec runtime.Decoder, r io.Reader) (*v1.Secret, error) {
 	data, err := ioutil.ReadAll(r)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := multidocyaml.EnsureNotMultiDoc(data); err != nil {
 		return nil, err
 	}
 
@@ -376,7 +381,7 @@ func resourceOutput(out io.Writer, codecs runtimeserializer.CodecFactory, gv run
 	case "json", "":
 		contentType = runtime.ContentTypeJSON
 	case "yaml":
-		contentType = "application/yaml"
+		contentType = runtime.ContentTypeYAML
 	default:
 		return fmt.Errorf("unsupported output format: %s", *outputFormat)
 	}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/throttled/throttled v2.2.2+incompatible
 	golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975
 	golang.org/x/text v0.3.3 // indirect
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.16.8
 	k8s.io/apimachinery v0.16.8
 	k8s.io/client-go v0.16.8

--- a/pkg/multidocyaml/multidocyaml.go
+++ b/pkg/multidocyaml/multidocyaml.go
@@ -1,0 +1,23 @@
+package multidocyaml
+
+import (
+	"bytes"
+	"fmt"
+
+	"gopkg.in/yaml.v2"
+)
+
+func isMultiDocumentYAML(src []byte) bool {
+	dec := yaml.NewDecoder(bytes.NewReader(src))
+	var dummy struct{}
+	_ = dec.Decode(&dummy)
+	return dec.Decode(&dummy) == nil
+}
+
+// EnsureNotMultiDoc returns an error if the yaml
+func EnsureNotMultiDoc(src []byte) error {
+	if isMultiDocumentYAML(src) {
+		return fmt.Errorf("Multistream YAML not supported yet (see https://github.com/bitnami-labs/sealed-secrets/issues/114)")
+	}
+	return nil
+}

--- a/pkg/multidocyaml/multidocyaml_test.go
+++ b/pkg/multidocyaml/multidocyaml_test.go
@@ -1,0 +1,23 @@
+package multidocyaml
+
+import "testing"
+
+func TestIsMultiDocumentYAML(t *testing.T) {
+	testCases := []struct {
+		src string
+		ok  bool
+	}{
+		{"foo", false},
+		{"foo\nbar\n", false},
+		{"---\nfoo", false},
+		{"foo\n---\n", true},
+		{"foo\n ---\n", false},
+		{"---\nfoo\n---\n", true},
+	}
+
+	for _, tc := range testCases {
+		if got, want := isMultiDocumentYAML([]byte(tc.src)), tc.ok; got != want {
+			t.Errorf("got: %v, want: %v (src: %q)", got, want, tc.src)
+		}
+	}
+}


### PR DESCRIPTION
Users reported in #114 that they expected multi-document YAML files to be sealed and validated.
The current implementation only parses the first document and silently ignores the rest.

Ideally we should handle multiple documents but until then at least we should report an error