### PR TITLE
Add sealed-secret chart from helm repo into sealed-secret repository

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -178,7 +179,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -186,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright The Helm Authors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/helm/sealed-secrets/.helmignore
+++ b/helm/sealed-secrets/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.3.3
+version: 1.3.4
 appVersion: 0.8.1
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.0.1
+version: 1.0.2
 appVersion: 0.7.0
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.0.2
+version: 1.1.0
 appVersion: 0.7.0
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.1.0
+version: 1.2.0
 appVersion: 0.7.0
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,7 +1,7 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.3.1
-appVersion: 0.8.0
+version: 1.3.2
+appVersion: 0.8.1
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets
 apiVersion: v1

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,7 +1,7 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.2.0
-appVersion: 0.7.0
+version: 1.3.0
+appVersion: 0.8.0
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets
 apiVersion: v1

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.3.4
+version: 1.4.0
 appVersion: 0.8.1
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.3.0
+version: 1.3.1
 appVersion: 0.8.0
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.3.2
+version: 1.3.3
 appVersion: 0.8.1
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,7 +1,7 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.4.0
-appVersion: 0.8.1
+version: 1.4.1
+appVersion: 0.8.2
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets
 apiVersion: v1

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.4.3
+version: 1.5.0
 appVersion: 0.9.1
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,7 +1,7 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.8.0
-appVersion: 0.10.0
+version: 1.9.0
+appVersion: 0.12.1
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets
 apiVersion: v1

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,7 +1,7 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.4.1
-appVersion: 0.8.2
+version: 1.4.2
+appVersion: 0.9.1
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets
 apiVersion: v1

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.4.2
+version: 1.4.3
 appVersion: 0.9.1
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,7 +1,7 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.5.0
-appVersion: 0.9.1
+version: 1.6.0
+appVersion: 0.9.5
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets
 apiVersion: v1

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,7 +1,7 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.10.2
-appVersion: 0.12.1
+version: 1.10.3
+appVersion: 0.12.4
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets
 apiVersion: v1

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.7.5
+version: 1.7.6
 appVersion: 0.9.7
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.7.1
+version: 1.7.2
 appVersion: 0.9.6
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.10.1
+version: 1.10.2
 appVersion: 0.12.1
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,7 +1,7 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.7.7
-appVersion: 0.9.7
+version: 1.8.0
+appVersion: 0.10.0
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets
 apiVersion: v1

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.7.3
+version: 1.7.4
 appVersion: 0.9.7
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.6.1
+version: 1.7.0
 appVersion: 0.9.6
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.7.0
+version: 1.7.1
 appVersion: 0.9.6
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.9.0
+version: 1.10.0
 appVersion: 0.12.1
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.7.6
+version: 1.7.7
 appVersion: 0.9.7
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.10.0
+version: 1.10.1
 appVersion: 0.12.1
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,7 +1,7 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.7.2
-appVersion: 0.9.6
+version: 1.7.3
+appVersion: 0.9.7
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets
 apiVersion: v1

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.7.4
+version: 1.7.5
 appVersion: 0.9.7
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.0.0
+version: 1.0.1
 appVersion: 0.7.0
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,0 +1,12 @@
+name: sealed-secrets
+description: A Helm chart for Sealed Secrets
+version: 1.0.0
+appVersion: 0.7.0
+kubeVersion: ">=1.9.0-0"
+home: https://github.com/bitnami-labs/sealed-secrets
+apiVersion: v1
+maintainers:
+  - name: stefanprodan
+    email: stefan.prodan@gmail.com
+  - name: olib963
+    email: olib963@gmail.com

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.10.3
+version: 1.11.0
 appVersion: 0.12.4
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,7 +1,7 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.11.0
-appVersion: 0.12.4
+version: 1.12.0
+appVersion: 0.13.1
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets
 apiVersion: v1

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,7 +1,7 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.6.0
-appVersion: 0.9.5
+version: 1.6.1
+appVersion: 0.9.6
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets
 apiVersion: v1

--- a/helm/sealed-secrets/OWNERS
+++ b/helm/sealed-secrets/OWNERS
@@ -4,3 +4,4 @@ approvers:
 reviewers:
 - olib963
 - stefanprodan
+- srueg

--- a/helm/sealed-secrets/OWNERS
+++ b/helm/sealed-secrets/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- olib963
+- stefanprodan
+reviewers:
+- olib963
+- stefanprodan

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -26,6 +26,20 @@ $ helm delete [--purge] my-release
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
+## Using kubeseal
+
+Install the kubeseal CLI by downloading the binary from [sealed-secrets/releases](https://github.com/bitnami-labs/sealed-secrets/releases).
+
+Fetch the public key by passing the release name and namespace:
+
+```bash
+kubeseal --fetch-cert \
+--controller-name=my-release \
+--controller-namespace=my-release-namespace \
+> pub-cert.pem
+```
+
+Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-labs/sealed-secrets#usage).
 
 ## Configuration
 

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -36,7 +36,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | **serviceAccount.create** | Whether to create a service account or not | `true` |
 | **serviceAccount.name** | The name of the service account to create or use | `"sealed-secrets-controller"` |
 | **secretName** | The name of the TLS secret containing the key used to encrypt secrets | `"sealed-secrets-key"` |
-| **image.tag** | The `Sealed Secrets` image tag | `v0.7.0` |
+| **image.tag** | The `Sealed Secrets` image tag | `v0.8.1` |
 | **image.pullPolicy** | The image pull policy for the deployment | `IfNotPresent` |
 | **image.repository** | The repository to get the controller image from | `quay.io/bitnami/sealed-secrets-controller` |
 | **resources** | CPU/Memory resource requests/limits | `{}` |

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -39,6 +39,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | **image.pullPolicy** | The image pull policy for the deployment | `IfNotPresent` |
 | **image.repository** | The repository to get the controller image from | `quay.io/bitnami/sealed-secrets-controller` |
 | **resources** | CPU/Memory resource requests/limits | `{}` |
+| **crd.create** | `true` if crd resources should be created | `true` |
 | **crd.keep** | `true` if the sealed secret CRD should be kept when the chart is deleted | `true` |
 
 - In the case that **serviceAccount.create** is `false` and **rbac.create** is `true` it is expected for a service account with the name **serviceAccount.name** to exist _in the same namespace as this chart_ before installation.

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -41,6 +41,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | **resources** | CPU/Memory resource requests/limits | `{}` |
 | **crd.create** | `true` if crd resources should be created | `true` |
 | **crd.keep** | `true` if the sealed secret CRD should be kept when the chart is deleted | `true` |
+|**networkPolicy** | Whether to create a network policy that allows access to the service | `false`|
 
 - In the case that **serviceAccount.create** is `false` and **rbac.create** is `true` it is expected for a service account with the name **serviceAccount.name** to exist _in the same namespace as this chart_ before installation.
 - If **serviceAccount.create** is `true` there cannot be an existing service account with the name **serviceAccount.name**.

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -32,6 +32,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Parameter | Description | Default |
 |----------:|:------------|:--------|
 | **rbac.create** | `true` if rbac resources should be created | `true` |
+| **rbac.pspEnabled** | `true` if psp resources should be created | `false` |
 | **serviceAccount.create** | Whether to create a service account or not | `true` |
 | **serviceAccount.name** | The name of the service account to create or use | `"sealed-secrets-controller"` |
 | **secretName** | The name of the TLS secret containing the key used to encrypt secrets | `"sealed-secrets-key"` |

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -57,6 +57,7 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 | **crd.create** | `true` if crd resources should be created | `true` |
 | **crd.keep** | `true` if the sealed secret CRD should be kept when the chart is deleted | `true` |
 |**networkPolicy** | Whether to create a network policy that allows access to the service | `false`|
+|**securityContext.runAsUser** | Defines under which user the operator Pod and its containers/processes run | `1001`|
 
 - In the case that **serviceAccount.create** is `false` and **rbac.create** is `true` it is expected for a service account with the name **serviceAccount.name** to exist _in the same namespace as this chart_ before installation.
 - If **serviceAccount.create** is `true` there cannot be an existing service account with the name **serviceAccount.name**.

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -1,0 +1,46 @@
+# Sealed Secrets
+
+This chart contains the resources to use [sealed-secrets](https://github.com/bitnami-labs/sealed-secrets).
+
+## Prerequisites
+
+* Kubernetes >= 1.9
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --namespace kube-system --name my-release stable/sealed-secrets
+```
+
+The command deploys a controller and [CRD](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/) for sealed secrets on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete [--purge] my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+
+## Configuration
+
+| Parameter | Description | Default |
+|----------:|:------------|:--------|
+| **rbac.create** | `true` if rbac resources should be created | `true` |
+| **serviceAccount.create** | Whether to create a service account or not | `true` |
+| **serviceAccount.name** | The name of the service account to create or use | `"sealed-secrets-controller"` |
+| **secretName** | The name of the TLS secret containing the key used to encrypt secrets | `"sealed-secrets-key"` |
+| **image.tag** | The `Sealed Secrets` image tag | `v0.7.0` |
+| **image.pullPolicy** | The image pull policy for the deployment | `IfNotPresent` |
+| **image.repository** | The repository to get the controller image from | `quay.io/bitnami/sealed-secrets-controller` |
+| **resources** | CPU/Memory resource requests/limits | `{}` |
+| **crd.keep** | `true` if the sealed secret CRD should be kept when the chart is deleted | `true` |
+
+- In the case that **serviceAccount.create** is `false` and **rbac.create** is `true` it is expected for a service account with the name **serviceAccount.name** to exist _in the same namespace as this chart_ before installation.
+- If **serviceAccount.create** is `true` there cannot be an existing service account with the name **serviceAccount.name**.
+- If a secret with name **secretName** does not exist _in the same namespace as this chart_, then on install one will be created. If a secret already exists with this name the keys inside will be used.

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -51,7 +51,7 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 | **serviceAccount.create** | Whether to create a service account or not | `true` |
 | **serviceAccount.name** | The name of the service account to create or use | `"sealed-secrets-controller"` |
 | **secretName** | The name of the TLS secret containing the key used to encrypt secrets | `"sealed-secrets-key"` |
-| **image.tag** | The `Sealed Secrets` image tag | `v0.8.1` |
+| **image.tag** | The `Sealed Secrets` image tag | `v0.9.5` |
 | **image.pullPolicy** | The image pull policy for the deployment | `IfNotPresent` |
 | **image.repository** | The repository to get the controller image from | `quay.io/bitnami/sealed-secrets-controller` |
 | **resources** | CPU/Memory resource requests/limits | `{}` |

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -45,6 +45,7 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 
 | Parameter | Description | Default |
 |----------:|:------------|:--------|
+| **controller.create** | `true` if Sealed Secrets controller resources should be created | `true` |
 | **rbac.create** | `true` if rbac resources should be created | `true` |
 | **rbac.pspEnabled** | `true` if psp resources should be created | `false` |
 | **serviceAccount.create** | Whether to create a service account or not | `true` |

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -58,6 +58,7 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 | **crd.keep** | `true` if the sealed secret CRD should be kept when the chart is deleted | `true` |
 |**networkPolicy** | Whether to create a network policy that allows access to the service | `false`|
 |**securityContext.runAsUser** | Defines under which user the operator Pod and its containers/processes run | `1001`|
+|**commandArgs** | Set optional command line arguments passed to the controller process | |
 
 - In the case that **serviceAccount.create** is `false` and **rbac.create** is `true` it is expected for a service account with the name **serviceAccount.name** to exist _in the same namespace as this chart_ before installation.
 - If **serviceAccount.create** is `true` there cannot be an existing service account with the name **serviceAccount.name**.

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -51,7 +51,7 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 | **serviceAccount.create**     | Whether to create a service account or not                                 | `true`                                      |
 | **serviceAccount.name**       | The name of the service account to create or use                           | `"sealed-secrets-controller"`               |
 | **secretName**                | The name of the TLS secret containing the key used to encrypt secrets      | `"sealed-secrets-key"`                      |
-| **image.tag**                 | The `Sealed Secrets` image tag                                             | `v0.10.0`                                   |
+| **image.tag**                 | The `Sealed Secrets` image tag                                             | `v0.12.1`                                   |
 | **image.pullPolicy**          | The image pull policy for the deployment                                   | `IfNotPresent`                              |
 | **image.repository**          | The repository to get the controller image from                            | `quay.io/bitnami/sealed-secrets-controller` |
 | **resources**                 | CPU/Memory resource requests/limits                                        | `{}`                                        |

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -43,23 +43,29 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 
 ## Configuration
 
-| Parameter | Description | Default |
-|----------:|:------------|:--------|
-| **controller.create** | `true` if Sealed Secrets controller resources should be created | `true` |
-| **rbac.create** | `true` if rbac resources should be created | `true` |
-| **rbac.pspEnabled** | `true` if psp resources should be created | `false` |
-| **serviceAccount.create** | Whether to create a service account or not | `true` |
-| **serviceAccount.name** | The name of the service account to create or use | `"sealed-secrets-controller"` |
-| **secretName** | The name of the TLS secret containing the key used to encrypt secrets | `"sealed-secrets-key"` |
-| **image.tag** | The `Sealed Secrets` image tag | `v0.9.6` |
-| **image.pullPolicy** | The image pull policy for the deployment | `IfNotPresent` |
-| **image.repository** | The repository to get the controller image from | `quay.io/bitnami/sealed-secrets-controller` |
-| **resources** | CPU/Memory resource requests/limits | `{}` |
-| **crd.create** | `true` if crd resources should be created | `true` |
-| **crd.keep** | `true` if the sealed secret CRD should be kept when the chart is deleted | `true` |
-|**networkPolicy** | Whether to create a network policy that allows access to the service | `false`|
-|**securityContext.runAsUser** | Defines under which user the operator Pod and its containers/processes run | `1001`|
-|**commandArgs** | Set optional command line arguments passed to the controller process | |
+| Parameter                     | Description                                                                | Default                                     |
+|------------------------------:|:---------------------------------------------------------------------------|:--------------------------------------------|
+| **controller.create**         | `true` if Sealed Secrets controller resources should be created            | `true`                                      |
+| **rbac.create**               | `true` if rbac resources should be created                                 | `true`                                      |
+| **rbac.pspEnabled**           | `true` if psp resources should be created                                  | `false`                                     |
+| **serviceAccount.create**     | Whether to create a service account or not                                 | `true`                                      |
+| **serviceAccount.name**       | The name of the service account to create or use                           | `"sealed-secrets-controller"`               |
+| **secretName**                | The name of the TLS secret containing the key used to encrypt secrets      | `"sealed-secrets-key"`                      |
+| **image.tag**                 | The `Sealed Secrets` image tag                                             | `v0.9.6`                                    |
+| **image.pullPolicy**          | The image pull policy for the deployment                                   | `IfNotPresent`                              |
+| **image.repository**          | The repository to get the controller image from                            | `quay.io/bitnami/sealed-secrets-controller` |
+| **resources**                 | CPU/Memory resource requests/limits                                        | `{}`                                        |
+| **crd.create**                | `true` if crd resources should be created                                  | `true`                                      |
+| **crd.keep**                  | `true` if the sealed secret CRD should be kept when the chart is deleted   | `true`                                      |
+| **networkPolicy**             | Whether to create a network policy that allows access to the service       | `false`                                     |
+| **securityContext.runAsUser** | Defines under which user the operator Pod and its containers/processes run | `1001`                                      |
+| **commandArgs**               | Set optional command line arguments passed to the controller process       | `[]`                                        |
+| **ingress.enabled**           | Enables Ingress                                                            | `false`                                     |
+| **ingress.annotations**       | Ingress annotations                                                        | `{}`                                        |
+| **ingress.path**              | Ingress path                                                               | `/v1/cert.pem`                              |
+| **ingress.hosts**             | Ingress accepted hostnames                                                 | `["chart-example.local"]`                   |
+| **ingress.tls**               | Ingress TLS configuration                                                  | `[]`                                        |
+
 
 - In the case that **serviceAccount.create** is `false` and **rbac.create** is `true` it is expected for a service account with the name **serviceAccount.name** to exist _in the same namespace as this chart_ before installation.
 - If **serviceAccount.create** is `true` there cannot be an existing service account with the name **serviceAccount.name**.

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -51,7 +51,7 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 | **serviceAccount.create**     | Whether to create a service account or not                                 | `true`                                      |
 | **serviceAccount.name**       | The name of the service account to create or use                           | `"sealed-secrets-controller"`               |
 | **secretName**                | The name of the TLS secret containing the key used to encrypt secrets      | `"sealed-secrets-key"`                      |
-| **image.tag**                 | The `Sealed Secrets` image tag                                             | `v0.9.7`                                    |
+| **image.tag**                 | The `Sealed Secrets` image tag                                             | `v0.10.0`                                   |
 | **image.pullPolicy**          | The image pull policy for the deployment                                   | `IfNotPresent`                              |
 | **image.repository**          | The repository to get the controller image from                            | `quay.io/bitnami/sealed-secrets-controller` |
 | **resources**                 | CPU/Memory resource requests/limits                                        | `{}`                                        |

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -66,6 +66,7 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 | **ingress.hosts**             | Ingress accepted hostnames                                                 | `["chart-example.local"]`                   |
 | **ingress.tls**               | Ingress TLS configuration                                                  | `[]`                                        |
 | **podAnnotations**            | Annotations to annotate pods with.                                         | `{}`                                        |
+| **podLabels**                 | Labels to be added to pods                                                 | `{}`                                        |
 | **priorityClassName**         | Optional class to specify priority for pods                                | `""`                                        |
 
 

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -59,6 +59,7 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 | **crd.keep**                  | `true` if the sealed secret CRD should be kept when the chart is deleted   | `true`                                      |
 | **networkPolicy**             | Whether to create a network policy that allows access to the service       | `false`                                     |
 | **securityContext.runAsUser** | Defines under which user the operator Pod and its containers/processes run | `1001`                                      |
+| **securityContext.fsGroup**   | Defines fsGroup for the operator Pod and its containers/processes run      | `65534`                                     |
 | **commandArgs**               | Set optional command line arguments passed to the controller process       | `[]`                                        |
 | **ingress.enabled**           | Enables Ingress                                                            | `false`                                     |
 | **ingress.annotations**       | Ingress annotations                                                        | `{}`                                        |
@@ -73,3 +74,9 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 - In the case that **serviceAccount.create** is `false` and **rbac.create** is `true` it is expected for a service account with the name **serviceAccount.name** to exist _in the same namespace as this chart_ before installation.
 - If **serviceAccount.create** is `true` there cannot be an existing service account with the name **serviceAccount.name**.
 - If a secret with name **secretName** does not exist _in the same namespace as this chart_, then on install one will be created. If a secret already exists with this name the keys inside will be used.
+- OpenShift: unset the runAsUser and fsGroup like this:
+```
+  securityContext:
+    runAsUser:
+    fsGroup:
+```

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -65,6 +65,7 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 | **ingress.path**              | Ingress path                                                               | `/v1/cert.pem`                              |
 | **ingress.hosts**             | Ingress accepted hostnames                                                 | `["chart-example.local"]`                   |
 | **ingress.tls**               | Ingress TLS configuration                                                  | `[]`                                        |
+| **podAnnotations**            | Annotations to annotate pods with.                                         | `{}`                                        |
 
 
 - In the case that **serviceAccount.create** is `false` and **rbac.create** is `true` it is expected for a service account with the name **serviceAccount.name** to exist _in the same namespace as this chart_ before installation.

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -46,6 +46,7 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 | Parameter                     | Description                                                                | Default                                     |
 |------------------------------:|:---------------------------------------------------------------------------|:--------------------------------------------|
 | **controller.create**         | `true` if Sealed Secrets controller resources should be created            | `true`                                      |
+| **namespace**                 | The name of the Namespace to deploy the controller                         | `.Release.namespace`                        |
 | **rbac.create**               | `true` if rbac resources should be created                                 | `true`                                      |
 | **rbac.pspEnabled**           | `true` if psp resources should be created                                  | `false`                                     |
 | **serviceAccount.create**     | Whether to create a service account or not                                 | `true`                                      |

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -51,7 +51,7 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 | **serviceAccount.create**     | Whether to create a service account or not                                 | `true`                                      |
 | **serviceAccount.name**       | The name of the service account to create or use                           | `"sealed-secrets-controller"`               |
 | **secretName**                | The name of the TLS secret containing the key used to encrypt secrets      | `"sealed-secrets-key"`                      |
-| **image.tag**                 | The `Sealed Secrets` image tag                                             | `v0.9.6`                                    |
+| **image.tag**                 | The `Sealed Secrets` image tag                                             | `v0.9.7`                                    |
 | **image.pullPolicy**          | The image pull policy for the deployment                                   | `IfNotPresent`                              |
 | **image.repository**          | The repository to get the controller image from                            | `quay.io/bitnami/sealed-secrets-controller` |
 | **resources**                 | CPU/Memory resource requests/limits                                        | `{}`                                        |

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -66,6 +66,7 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 | **ingress.hosts**             | Ingress accepted hostnames                                                 | `["chart-example.local"]`                   |
 | **ingress.tls**               | Ingress TLS configuration                                                  | `[]`                                        |
 | **podAnnotations**            | Annotations to annotate pods with.                                         | `{}`                                        |
+| **priorityClassName**         | Optional class to specify priority for pods                                | `""`                                        |
 
 
 - In the case that **serviceAccount.create** is `false` and **rbac.create** is `true` it is expected for a service account with the name **serviceAccount.name** to exist _in the same namespace as this chart_ before installation.

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -52,7 +52,7 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 | **serviceAccount.create**     | Whether to create a service account or not                                 | `true`                                      |
 | **serviceAccount.name**       | The name of the service account to create or use                           | `"sealed-secrets-controller"`               |
 | **secretName**                | The name of the TLS secret containing the key used to encrypt secrets      | `"sealed-secrets-key"`                      |
-| **image.tag**                 | The `Sealed Secrets` image tag                                             | `v0.12.1`                                   |
+| **image.tag**                 | The `Sealed Secrets` image tag                                             | `v0.12.4`                                   |
 | **image.pullPolicy**          | The image pull policy for the deployment                                   | `IfNotPresent`                              |
 | **image.repository**          | The repository to get the controller image from                            | `quay.io/bitnami/sealed-secrets-controller` |
 | **resources**                 | CPU/Memory resource requests/limits                                        | `{}`                                        |

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -43,34 +43,41 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 
 ## Configuration
 
-| Parameter                     | Description                                                                | Default                                     |
-|------------------------------:|:---------------------------------------------------------------------------|:--------------------------------------------|
-| **controller.create**         | `true` if Sealed Secrets controller resources should be created            | `true`                                      |
-| **namespace**                 | The name of the Namespace to deploy the controller                         | `.Release.namespace`                        |
-| **rbac.create**               | `true` if rbac resources should be created                                 | `true`                                      |
-| **rbac.pspEnabled**           | `true` if psp resources should be created                                  | `false`                                     |
-| **serviceAccount.create**     | Whether to create a service account or not                                 | `true`                                      |
-| **serviceAccount.name**       | The name of the service account to create or use                           | `"sealed-secrets-controller"`               |
-| **secretName**                | The name of the TLS secret containing the key used to encrypt secrets      | `"sealed-secrets-key"`                      |
-| **image.tag**                 | The `Sealed Secrets` image tag                                             | `v0.12.4`                                   |
-| **image.pullPolicy**          | The image pull policy for the deployment                                   | `IfNotPresent`                              |
-| **image.repository**          | The repository to get the controller image from                            | `quay.io/bitnami/sealed-secrets-controller` |
-| **resources**                 | CPU/Memory resource requests/limits                                        | `{}`                                        |
-| **crd.create**                | `true` if crd resources should be created                                  | `true`                                      |
-| **crd.keep**                  | `true` if the sealed secret CRD should be kept when the chart is deleted   | `true`                                      |
-| **networkPolicy**             | Whether to create a network policy that allows access to the service       | `false`                                     |
-| **securityContext.runAsUser** | Defines under which user the operator Pod and its containers/processes run | `1001`                                      |
-| **securityContext.fsGroup**   | Defines fsGroup for the operator Pod and its containers/processes run      | `65534`                                     |
-| **commandArgs**               | Set optional command line arguments passed to the controller process       | `[]`                                        |
-| **ingress.enabled**           | Enables Ingress                                                            | `false`                                     |
-| **ingress.annotations**       | Ingress annotations                                                        | `{}`                                        |
-| **ingress.path**              | Ingress path                                                               | `/v1/cert.pem`                              |
-| **ingress.hosts**             | Ingress accepted hostnames                                                 | `["chart-example.local"]`                   |
-| **ingress.tls**               | Ingress TLS configuration                                                  | `[]`                                        |
-| **podAnnotations**            | Annotations to annotate pods with.                                         | `{}`                                        |
-| **podLabels**                 | Labels to be added to pods                                                 | `{}`                                        |
-| **priorityClassName**         | Optional class to specify priority for pods                                | `""`                                        |
-
+| Parameter                        | Description                                                                | Default                                     |
+|---------------------------------:|:---------------------------------------------------------------------------|:--------------------------------------------|
+| **controller.create**            | `true` if Sealed Secrets controller resources should be created            | `true`                                      |
+| **namespace**                    | The name of the Namespace to deploy the controller                         | `.Release.namespace`                        |
+| **rbac.create**                  | `true` if rbac resources should be created                                 | `true`                                      |
+| **rbac.pspEnabled**              | `true` if psp resources should be created                                  | `false`                                     |
+| **serviceAccount.create**        | Whether to create a service account or not                                 | `true`                                      |
+| **serviceAccount.name**          | The name of the service account to create or use                           | `"sealed-secrets-controller"`               |
+| **secretName**                   | The name of the TLS secret containing the key used to encrypt secrets      | `"sealed-secrets-key"`                      |
+| **image.tag**                    | The `Sealed Secrets` image tag                                             | `v0.12.4`                                   |
+| **image.pullPolicy**             | The image pull policy for the deployment                                   | `IfNotPresent`                              |
+| **image.repository**             | The repository to get the controller image from                            | `quay.io/bitnami/sealed-secrets-controller` |
+| **resources**                    | CPU/Memory resource requests/limits                                        | `{}`                                        |
+| **crd.create**                   | `true` if crd resources should be created                                  | `true`                                      |
+| **crd.keep**                     | `true` if the sealed secret CRD should be kept when the chart is deleted   | `true`                                      |
+| **networkPolicy**                | Whether to create a network policy that allows access to the service       | `false`                                     |
+| **securityContext.runAsUser**    | Defines under which user the operator Pod and its containers/processes run | `1001`                                      |
+| **securityContext.fsGroup**      | Defines fsGroup for the operator Pod and its containers/processes run      | `65534`                                     |
+| **commandArgs**                  | Set optional command line arguments passed to the controller process       | `[]`                                        |
+| **ingress.enabled**              | Enables Ingress                                                            | `false`                                     |
+| **ingress.annotations**          | Ingress annotations                                                        | `{}`                                        |
+| **ingress.path**                 | Ingress path                                                               | `/v1/cert.pem`                              |
+| **ingress.hosts**                | Ingress accepted hostnames                                                 | `["chart-example.local"]`                   |
+| **ingress.tls**                  | Ingress TLS configuration                                                  | `[]`                                        |
+| **podAnnotations**               | Annotations to annotate pods with.                                         | `{}`                                        |
+| **podLabels**                    | Labels to be added to pods                                                 | `{}`                                        |
+| **priorityClassName**            | Optional class to specify priority for pods                                | `""`                                        |
+| **serviceMonitor.create**        | Create servicemonitor from prometheus operator	                            | `false`                                     |
+| **serviceMonitor.interval**      | How frequently Prometheus should scrape                                    | `""`                                        |
+| **serviceMonitor.labels**        | Labels for the servicemonitor passed to Prometheus Operator                | `{}`                                        |
+| **serviceMonitor.namespace**     | Namespace this servicemonitor is installed in                              | `""`                                        |
+| **serviceMonitor.scrapeTimeout** | Timeout after which the scrape is ended                                    | `""`                                        |
+| **dashboards.create**            | Create Grafana dashboard config map                                        | `false`                                     |
+| **dashboards.labels**            | Extra labels to apply to the dashboard configmaps                          | `{}`                                        |
+| **dashboards.namespace**         | Namespace this dashboards are installed in                                 | `""`                                        |
 
 - In the case that **serviceAccount.create** is `false` and **rbac.create** is `true` it is expected for a service account with the name **serviceAccount.name** to exist _in the same namespace as this chart_ before installation.
 - If **serviceAccount.create** is `true` there cannot be an existing service account with the name **serviceAccount.name**.

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -52,7 +52,7 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 | **serviceAccount.create**        | Whether to create a service account or not                                 | `true`                                      |
 | **serviceAccount.name**          | The name of the service account to create or use                           | `"sealed-secrets-controller"`               |
 | **secretName**                   | The name of the TLS secret containing the key used to encrypt secrets      | `"sealed-secrets-key"`                      |
-| **image.tag**                    | The `Sealed Secrets` image tag                                             | `v0.12.4`                                   |
+| **image.tag**                    | The `Sealed Secrets` image tag                                             | `v0.13.1`                                   |
 | **image.pullPolicy**             | The image pull policy for the deployment                                   | `IfNotPresent`                              |
 | **image.repository**             | The repository to get the controller image from                            | `quay.io/bitnami/sealed-secrets-controller` |
 | **resources**                    | CPU/Memory resource requests/limits                                        | `{}`                                        |

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -51,7 +51,7 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 | **serviceAccount.create** | Whether to create a service account or not | `true` |
 | **serviceAccount.name** | The name of the service account to create or use | `"sealed-secrets-controller"` |
 | **secretName** | The name of the TLS secret containing the key used to encrypt secrets | `"sealed-secrets-key"` |
-| **image.tag** | The `Sealed Secrets` image tag | `v0.9.5` |
+| **image.tag** | The `Sealed Secrets` image tag | `v0.9.6` |
 | **image.pullPolicy** | The image pull policy for the deployment | `IfNotPresent` |
 | **image.repository** | The repository to get the controller image from | `quay.io/bitnami/sealed-secrets-controller` |
 | **resources** | CPU/Memory resource requests/limits | `{}` |

--- a/helm/sealed-secrets/ci/ci-values.yaml
+++ b/helm/sealed-secrets/ci/ci-values.yaml
@@ -1,0 +1,4 @@
+# CI is running on GKE, it requires the chart to clean up after itself so we cannot keep the CRD
+
+crd:
+  keep: false

--- a/helm/sealed-secrets/dashboards/sealed-secrets-controller.json
+++ b/helm/sealed-secrets/dashboards/sealed-secrets-controller.json
@@ -1,0 +1,302 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            }
+        ]
+    },
+    "description": "Sealed Secrets Controller",
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": 3,
+    "iteration": 1585599163503,
+    "links": [
+        {
+            "icon": "external link",
+            "tags": [],
+            "title": "GitHub",
+            "tooltip": "View Project on GitHub",
+            "type": "link",
+            "url": "https://github.com/bitnami-labs/sealed-secrets"
+        }
+    ],
+    "panels": [
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "description": "Rate of requests to unseal a SealedSecret.\n\nThis can include non-obvious operations such as deleting a SealedSecret.",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 0
+            },
+            "hiddenSeries": false,
+            "id": 2,
+            "legend": {
+                "avg": true,
+                "current": false,
+                "max": true,
+                "min": true,
+                "show": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(rate(sealed_secrets_controller_unseal_requests_total{}[1m]))",
+                    "format": "time_series",
+                    "instant": false,
+                    "intervalFactor": 1,
+                    "legendFormat": "rps",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Unseal Request Rate/s",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "description": "Rate of errors when unsealing a SealedSecret. \n\nReason for error included as label value, eg:\n- unseal = cryptography issue (key/namespace) or RBAC\n- unmanaged = destination Secret wasn't created by SealedSecrets\n- update = potentially RBAC\n- status = potentially RBAC\n- fetch = potentially RBAC\n",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 0
+            },
+            "hiddenSeries": false,
+            "id": 3,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "hideEmpty": false,
+                "hideZero": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(rate(sealed_secrets_controller_unseal_errors_total{pod=~\"$pod\"}[1m])) by (reason)",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "{{ reason }}",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Unseal Error Rate/s",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        }
+    ],
+    "refresh": false,
+    "schemaVersion": 22,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [
+            {
+                "current": {
+                    "text": "prometheus",
+                    "value": "prometheus"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "datasource",
+                "options": [],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "type": "datasource"
+            },
+            {
+                "allValue": null,
+                "current": {
+                    "selected": false,
+                    "text": "All",
+                    "value": "$__all"
+                },
+                "datasource": "$datasource",
+                "definition": "label_values(kube_pod_info, pod)",
+                "hide": 0,
+                "includeAll": true,
+                "label": null,
+                "multi": false,
+                "name": "pod",
+                "options": [],
+                "query": "label_values(kube_pod_info, pod)",
+                "refresh": 1,
+                "regex": "/^sealed-secrets-controller.*$/",
+                "skipUrlSync": false,
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            }
+        ]
+    },
+    "time": {
+        "from": "now-1h",
+        "to": "now"
+    },
+    "timepicker": {
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "",
+    "title": "Sealed Secrets Controller",
+    "uid": "UuEtZCVWz",
+    "version": 2
+}

--- a/helm/sealed-secrets/templates/NOTES.txt
+++ b/helm/sealed-secrets/templates/NOTES.txt
@@ -4,23 +4,34 @@ You should now be able to create sealed secrets.
 
 GOOS=$(go env GOOS)
 GOARCH=$(go env GOARCH)
-wget https://github.com/bitnami-labs/sealed-secrets/releases/download/$release/kubeseal-$GOOS-$GOARCH
+wget https://github.com/bitnami-labs/sealed-secrets/releases/download/{{ .Values.image.tag }}/kubeseal-$GOOS-$GOARCH
 sudo install -m 755 kubeseal-$GOOS-$GOARCH /usr/local/bin/kubeseal
 
 2. Create a sealed secret file
 
 # note the use of `--dry-run` - this does not create a secret in your cluster
-kubectl create secret generic secret-name --dry-run --from-literal=foo=bar -o [json|yaml] | kubeseal --format [json|yaml] > mysealedsecret.[json|yaml]
+kubectl create secret generic secret-name --dry-run --from-literal=foo=bar -o [json|yaml] | \
+ kubeseal \
+ --controller-name={{ template "sealed-secrets.fullname" . }} \
+ --controller-namespace={{ .Release.Namespace }} \
+ --format [json|yaml] > mysealedsecret.[json|yaml]
 
 The file mysealedsecret.[json|yaml] is a commitable file.
 
 If you would rather not need access to the cluster to generate the sealed secret you can run
 
-kubeseal --fetch-cert > mycert.pem
+kubeseal \
+ --controller-name={{ template "sealed-secrets.fullname" . }} \
+ --controller-namespace={{ .Release.Namespace }} \
+ --fetch-cert > mycert.pem
 
 to retrieve the public cert used for encryption and store it locally. You can then run 'kubeseal --cert mycert.pem' instead to use the local cert e.g.
 
-kubectl create secret generic secret-name --dry-run --from-literal=foo=bar -o [json|yaml] | kubeseal --format [json|yaml] --cert mycert.pem > mysealedsecret.[json|yaml]
+kubectl create secret generic secret-name --dry-run --from-literal=foo=bar -o [json|yaml] | \
+kubeseal \
+ --controller-name={{ template "sealed-secrets.fullname" . }} \
+ --controller-namespace={{ .Release.Namespace }} \
+ --format [json|yaml] --cert mycert.pem > mysealedsecret.[json|yaml]
 
 3. Apply the sealed secret
 
@@ -30,9 +41,3 @@ Running 'kubectl get secret secret-name -o [json|yaml]' will show the decrypted 
 
 Both the SealedSecret and generated Secret must have the same name and namespace.
 
-{{ if not (eq .Release.Namespace "kube-system") }}
---------------------------------------------------------------------------------------------------
-
-Please Note: Since this chart was not installed in the kube-system namespace all kubeseal commands must pass the option `--controller-namespace {{ .Release.Namespace }}`
-
-{{ end }}

--- a/helm/sealed-secrets/templates/NOTES.txt
+++ b/helm/sealed-secrets/templates/NOTES.txt
@@ -1,0 +1,38 @@
+You should now be able to create sealed secrets.
+
+1. Install client-side tool into /usr/local/bin/
+
+GOOS=$(go env GOOS)
+GOARCH=$(go env GOARCH)
+wget https://github.com/bitnami-labs/sealed-secrets/releases/download/$release/kubeseal-$GOOS-$GOARCH
+sudo install -m 755 kubeseal-$GOOS-$GOARCH /usr/local/bin/kubeseal
+
+2. Create a sealed secret file
+
+# note the use of `--dry-run` - this does not create a secret in your cluster
+kubectl create secret generic secret-name --dry-run --from-literal=foo=bar -o [json|yaml] | kubeseal --format [json|yaml] > mysealedsecret.[json|yaml]
+
+The file mysealedsecret.[json|yaml] is a commitable file.
+
+If you would rather not need access to the cluster to generate the sealed secret you can run
+
+kubeseal --fetch-cert > mycert.pem
+
+to retrieve the public cert used for encryption and store it locally. You can then run 'kubeseal --cert mycert.pem' instead to use the local cert e.g.
+
+kubectl create secret generic secret-name --dry-run --from-literal=foo=bar -o [json|yaml] | kubeseal --format [json|yaml] --cert mycert.pem > mysealedsecret.[json|yaml]
+
+3. Apply the sealed secret
+
+kubectl create -f mysealedsecret.[json|yaml]
+
+Running 'kubectl get secret secret-name -o [json|yaml]' will show the decrypted secret that was generated from the sealed secret.
+
+Both the SealedSecret and generated Secret must have the same name and namespace.
+
+{{ if not (eq .Release.Namespace "kube-system") }}
+--------------------------------------------------------------------------------------------------
+
+Please Note: Since this chart was not installed in the kube-system namespace all kubeseal commands must pass the option `--controller-namespace {{ .Release.Namespace }}`
+
+{{ end }}

--- a/helm/sealed-secrets/templates/NOTES.txt
+++ b/helm/sealed-secrets/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{ if .Values.controller.create -}}
 You should now be able to create sealed secrets.
 
 1. Install client-side tool into /usr/local/bin/
@@ -40,4 +41,7 @@ kubectl create -f mysealedsecret.[json|yaml]
 Running 'kubectl get secret secret-name -o [json|yaml]' will show the decrypted secret that was generated from the sealed secret.
 
 Both the SealedSecret and generated Secret must have the same name and namespace.
-
+{{- else }}
+Sealed Secrets controller not installed, You need to install controller before
+sealed secrets can be created.
+{{- end }}

--- a/helm/sealed-secrets/templates/_helpers.tpl
+++ b/helm/sealed-secrets/templates/_helpers.tpl
@@ -1,0 +1,42 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "sealed-secrets.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sealed-secrets.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "sealed-secrets.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "sealed-secrets.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "sealed-secrets.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/helm/sealed-secrets/templates/_helpers.tpl
+++ b/helm/sealed-secrets/templates/_helpers.tpl
@@ -1,4 +1,11 @@
 {{/*
+Expand to the namespace sealed-secrets installs into.
+*/}}
+{{- define "sealed-secrets.namespace" -}}
+{{- default .Release.Namespace .Values.namespace -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "sealed-secrets.chart" -}}

--- a/helm/sealed-secrets/templates/cluster-role-binding.yaml
+++ b/helm/sealed-secrets/templates/cluster-role-binding.yaml
@@ -1,0 +1,21 @@
+{{ if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: secrets-unsealer
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ template "sealed-secrets.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/helm/sealed-secrets/templates/cluster-role-binding.yaml
+++ b/helm/sealed-secrets/templates/cluster-role-binding.yaml
@@ -17,5 +17,5 @@ subjects:
   - apiGroup: ""
     kind: ServiceAccount
     name: {{ template "sealed-secrets.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "sealed-secrets.namespace" . }}
 {{ end }}

--- a/helm/sealed-secrets/templates/cluster-role.yaml
+++ b/helm/sealed-secrets/templates/cluster-role.yaml
@@ -18,12 +18,21 @@ rules:
       - get
       - list
       - watch
+      - update
   - apiGroups:
       - ""
     resources:
       - secrets
     verbs:
+      - get
       - create
       - update
       - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
 {{ end }}

--- a/helm/sealed-secrets/templates/cluster-role.yaml
+++ b/helm/sealed-secrets/templates/cluster-role.yaml
@@ -1,0 +1,29 @@
+{{ if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: secrets-unsealer
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+  - apiGroups:
+      - bitnami.com
+    resources:
+      - sealedsecrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - update
+      - delete
+{{ end }}

--- a/helm/sealed-secrets/templates/cluster-role.yaml
+++ b/helm/sealed-secrets/templates/cluster-role.yaml
@@ -18,6 +18,11 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - bitnami.com
+    resources:
+      - sealedsecrets/status
+    verbs:
       - update
   - apiGroups:
       - ""

--- a/helm/sealed-secrets/templates/configmap-dashboards.yaml
+++ b/helm/sealed-secrets/templates/configmap-dashboards.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.dashboards.create }}
+{{- $namespace := .Values.dashboards.namespace | default $.Release.Namespace }}
+{{- range $path, $_ :=  .Files.Glob  "dashboards/*.json" }}
+{{- $filename := trimSuffix (ext $path) (base $path) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "sealed-secrets.fullname" $ }}-{{ $filename }}
+  namespace: {{ $namespace }}
+  labels:
+    grafana_dashboard: "1"
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" $ }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" $ }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/version: {{ $.Chart.AppVersion }}
+    {{- if $.Values.dashboards.labels }}
+    {{- toYaml $.Values.dashboards.labels | nindent 4 }}
+    {{- end }}
+data:
+  {{ base $path }}: |-
+{{ $.Files.Get $path | indent 4 }}
+---
+{{- end }}
+{{- end }}

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
-            runAsUser: 1001
+            runAsUser: {{ .Values.securityContext.runAsUser }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ template "sealed-secrets.serviceAccountName" . }}
+      containers:
+        - name: {{ template "sealed-secrets.fullname" . }}
+          command:
+            - controller
+          args:
+            - "--key-name"
+            - "{{ .Values.secretName }}"
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 8080
+              name: http
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
           ports:
             - containerPort: 8080
               name: http
+          volumeMounts:
+          - mountPath: /tmp
+            name: tmp
           livenessProbe:
             httpGet:
               path: /healthz
@@ -46,6 +49,9 @@ spec:
             runAsUser: 1001
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+      volumes:
+      - name: tmp
+        emptyDir: {}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
           command:
             - controller
           args:
-            - "--key-name"
+            - "--key-prefix"
             - "{{ .Values.secretName }}"
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
           args:
             - "--key-prefix"
             - "{{ .Values.secretName }}"
+            {{- range $value := .Values.commandArgs }}
+            - {{ $value | quote }}
+            {{- end }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "sealed-secrets.fullname" . }}
+  namespace: {{ template "sealed-secrets.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
     helm.sh/chart: {{ template "sealed-secrets.chart" . }}

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controller.create -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -67,3 +68,4 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+{{- end }}

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -57,6 +57,8 @@ spec:
             runAsUser: {{ .Values.securityContext.runAsUser }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: tmp
         emptyDir: {}

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -16,6 +16,10 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ template "sealed-secrets.serviceAccountName" . }}
       {{- if .Values.priorityClassName }}

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -25,6 +25,9 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ template "sealed-secrets.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
       containers:
         - name: {{ template "sealed-secrets.fullname" . }}
           command:

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -59,12 +59,16 @@ spec:
               port: 8080
           securityContext:
             readOnlyRootFilesystem: true
+            {{- if .Values.securityContext.runAsUser }}
             runAsNonRoot: true
             runAsUser: {{ .Values.securityContext.runAsUser }}
+            {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+      {{- if .Values.securityContext.fsGroup }}
       securityContext:
-        fsGroup: 65534
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- end }}
       volumes:
       - name: tmp
         emptyDir: {}

--- a/helm/sealed-secrets/templates/ingress.yaml
+++ b/helm/sealed-secrets/templates/ingress.yaml
@@ -9,6 +9,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ template "sealed-secrets.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
     helm.sh/chart: {{ template "sealed-secrets.chart" . }}

--- a/helm/sealed-secrets/templates/ingress.yaml
+++ b/helm/sealed-secrets/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "sealed-secrets.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: 8080
+  {{- end }}
+{{- end }}

--- a/helm/sealed-secrets/templates/networkpolicy.yaml
+++ b/helm/sealed-secrets/templates/networkpolicy.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.networkPolicy -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+  ingress:
+    - ports:
+      - port: 8080
+{{- end -}}

--- a/helm/sealed-secrets/templates/networkpolicy.yaml
+++ b/helm/sealed-secrets/templates/networkpolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ template "sealed-secrets.fullname" . }}
+  namespace: {{ template "sealed-secrets.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
     helm.sh/chart: {{ template "sealed-secrets.chart" . }}

--- a/helm/sealed-secrets/templates/psp-clusterrole.yaml
+++ b/helm/sealed-secrets/templates/psp-clusterrole.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.pspEnabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}-psp
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "sealed-secrets.fullname" . }}
+{{- end }}

--- a/helm/sealed-secrets/templates/psp-clusterrolebinding.yaml
+++ b/helm/sealed-secrets/templates/psp-clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}-psp
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "sealed-secrets.fullname" . }}-psp
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "sealed-secrets.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/sealed-secrets/templates/psp-clusterrolebinding.yaml
+++ b/helm/sealed-secrets/templates/psp-clusterrolebinding.yaml
@@ -16,5 +16,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "sealed-secrets.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "sealed-secrets.namespace" . }}
 {{- end }}

--- a/helm/sealed-secrets/templates/psp.yaml
+++ b/helm/sealed-secrets/templates/psp.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  allowedCapabilities: []
+  volumes:
+  - 'configMap'
+  - 'emptyDir'
+  - 'projected'
+  - 'secret'
+  - 'downwardAPI'
+  - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+{{- end }}

--- a/helm/sealed-secrets/templates/psp.yaml
+++ b/helm/sealed-secrets/templates/psp.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "sealed-secrets.fullname" . }}

--- a/helm/sealed-secrets/templates/role-binding.yaml
+++ b/helm/sealed-secrets/templates/role-binding.yaml
@@ -1,0 +1,21 @@
+{{ if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sealed-secrets-key-admin
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ template "sealed-secrets.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/helm/sealed-secrets/templates/role-binding.yaml
+++ b/helm/sealed-secrets/templates/role-binding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "sealed-secrets.fullname" . }}
+  name: {{ template "sealed-secrets.fullname" . }}-key-admin
   labels:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
     helm.sh/chart: {{ template "sealed-secrets.chart" . }}
@@ -12,10 +12,29 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: sealed-secrets-key-admin
+  name: {{ template "sealed-secrets.fullname" . }}-key-admin
 subjects:
   - apiGroup: ""
     kind: ServiceAccount
     name: {{ template "sealed-secrets.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}-service-proxier
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "sealed-secrets.fullname" . }}-service-proxier
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
 {{ end }}

--- a/helm/sealed-secrets/templates/role-binding.yaml
+++ b/helm/sealed-secrets/templates/role-binding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "sealed-secrets.fullname" . }}-key-admin
+  namespace: {{ template "sealed-secrets.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
     helm.sh/chart: {{ template "sealed-secrets.chart" . }}
@@ -17,12 +18,13 @@ subjects:
   - apiGroup: ""
     kind: ServiceAccount
     name: {{ template "sealed-secrets.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "sealed-secrets.namespace" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "sealed-secrets.fullname" . }}-service-proxier
+  namespace: {{ template "sealed-secrets.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
     helm.sh/chart: {{ template "sealed-secrets.chart" . }}

--- a/helm/sealed-secrets/templates/role.yaml
+++ b/helm/sealed-secrets/templates/role.yaml
@@ -1,0 +1,27 @@
+{{ if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sealed-secrets-key-admin
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+  - apiGroups:
+      - ""
+    resourceNames:
+      - {{ .Values.secretName }}
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+{{ end }}

--- a/helm/sealed-secrets/templates/role.yaml
+++ b/helm/sealed-secrets/templates/role.yaml
@@ -24,4 +24,5 @@ rules:
       - secrets
     verbs:
       - create
+      - list
 {{ end }}

--- a/helm/sealed-secrets/templates/role.yaml
+++ b/helm/sealed-secrets/templates/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: sealed-secrets-key-admin
+  name: {{ template "sealed-secrets.fullname" . }}-key-admin
   labels:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
     helm.sh/chart: {{ template "sealed-secrets.chart" . }}
@@ -25,4 +25,25 @@ rules:
     verbs:
       - create
       - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}-service-proxier
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - 'http:{{ template "sealed-secrets.fullname" . }}:'
+  - {{ template "sealed-secrets.fullname" . }}
+  resources:
+  - services/proxy
+  verbs:
+  - get
 {{ end }}

--- a/helm/sealed-secrets/templates/role.yaml
+++ b/helm/sealed-secrets/templates/role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "sealed-secrets.fullname" . }}-key-admin
+  namespace: {{ template "sealed-secrets.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
     helm.sh/chart: {{ template "sealed-secrets.chart" . }}
@@ -30,6 +31,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "sealed-secrets.fullname" . }}-service-proxier
+  namespace: {{ template "sealed-secrets.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
     helm.sh/chart: {{ template "sealed-secrets.chart" . }}

--- a/helm/sealed-secrets/templates/role.yaml
+++ b/helm/sealed-secrets/templates/role.yaml
@@ -45,5 +45,6 @@ rules:
   resources:
   - services/proxy
   verbs:
+  - create
   - get
 {{ end }}

--- a/helm/sealed-secrets/templates/sealedsecret-crd.yaml
+++ b/helm/sealed-secrets/templates/sealedsecret-crd.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.crd.create }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -21,3 +22,4 @@ spec:
     singular: sealedsecret
   scope: Namespaced
   version: v1alpha1
+{{ end }}

--- a/helm/sealed-secrets/templates/sealedsecret-crd.yaml
+++ b/helm/sealed-secrets/templates/sealedsecret-crd.yaml
@@ -21,5 +21,7 @@ spec:
     plural: sealedsecrets
     singular: sealedsecret
   scope: Namespaced
+  subresources:
+    status: {}
   version: v1alpha1
 {{ end }}

--- a/helm/sealed-secrets/templates/sealedsecret-crd.yaml
+++ b/helm/sealed-secrets/templates/sealedsecret-crd.yaml
@@ -1,0 +1,23 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: sealedsecrets.bitnami.com
+  {{ if .Values.crd.keep }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{ end }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+spec:
+  group: bitnami.com
+  names:
+    kind: SealedSecret
+    listKind: SealedSecretList
+    plural: sealedsecrets
+    singular: sealedsecret
+  scope: Namespaced
+  version: v1alpha1

--- a/helm/sealed-secrets/templates/service-account.yaml
+++ b/helm/sealed-secrets/templates/service-account.yaml
@@ -1,0 +1,12 @@
+{{ if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "sealed-secrets.serviceAccountName" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+{{ end }}

--- a/helm/sealed-secrets/templates/service-account.yaml
+++ b/helm/sealed-secrets/templates/service-account.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "sealed-secrets.serviceAccountName" . }}
+  namespace: {{ template "sealed-secrets.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
     helm.sh/chart: {{ template "sealed-secrets.chart" . }}

--- a/helm/sealed-secrets/templates/service.yaml
+++ b/helm/sealed-secrets/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controller.create -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +14,4 @@ spec:
     - port: 8080
   selector:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+{{- end }}

--- a/helm/sealed-secrets/templates/service.yaml
+++ b/helm/sealed-secrets/templates/service.yaml
@@ -12,6 +12,7 @@ metadata:
 spec:
   ports:
     - port: 8080
+      name: http
   selector:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
 {{- end }}

--- a/helm/sealed-secrets/templates/service.yaml
+++ b/helm/sealed-secrets/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "sealed-secrets.fullname" . }}
+  namespace: {{ template "sealed-secrets.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
     helm.sh/chart: {{ template "sealed-secrets.chart" . }}

--- a/helm/sealed-secrets/templates/service.yaml
+++ b/helm/sealed-secrets/templates/service.yaml
@@ -12,7 +12,8 @@ metadata:
 spec:
   ports:
     - port: 8080
-      name: http
+      targetPort: 8080
   selector:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+  type: ClusterIP
 {{- end }}

--- a/helm/sealed-secrets/templates/service.yaml
+++ b/helm/sealed-secrets/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+spec:
+  ports:
+    - port: 8080
+  selector:
+    name: {{ template "sealed-secrets.fullname" . }}

--- a/helm/sealed-secrets/templates/service.yaml
+++ b/helm/sealed-secrets/templates/service.yaml
@@ -12,4 +12,4 @@ spec:
   ports:
     - port: 8080
   selector:
-    name: {{ template "sealed-secrets.fullname" . }}
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}

--- a/helm/sealed-secrets/templates/servicemonitor.yaml
+++ b/helm/sealed-secrets/templates/servicemonitor.yaml
@@ -1,0 +1,38 @@
+{{ if .Values.serviceMonitor.create }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- if .Values.serviceMonitor.labels }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+  - honorLabels: true
+    targetPort: 8080
+    {{- with .Values.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+      helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/version: {{ .Chart.AppVersion }}
+{{- end }}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -22,5 +22,7 @@ rbac:
 secretName: "sealed-secrets-key"
 
 crd:
+  # crd.create: `true` if the crd resources should be created
+  create: true
   # crd.keep: `true` if the sealed secret CRD should be kept when the chart is deleted
   keep: true

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -29,3 +29,7 @@ crd:
   keep: true
 
 networkPolicy: false
+
+securityContext:
+  # securityContext.runAsUser defines under which user the operator Pod and its containers/processes run.
+  runAsUser: 1001

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/bitnami/sealed-secrets-controller
-  tag: v0.7.0
+  tag: v0.8.0
   pullPolicy: IfNotPresent
 
 resources: {}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -26,3 +26,5 @@ crd:
   create: true
   # crd.keep: `true` if the sealed secret CRD should be kept when the chart is deleted
   keep: true
+
+networkPolicy: false

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -17,6 +17,7 @@ serviceAccount:
 rbac:
   # rbac.create: `true` if rbac resources should be created
   create: true
+  pspEnabled: false
 
 # secretName: The name of the TLS secret containing the key used to encrypt secrets
 secretName: "sealed-secrets-key"

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/bitnami/sealed-secrets-controller
-  tag: v0.8.0
+  tag: v0.8.1
   pullPolicy: IfNotPresent
 
 resources: {}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -8,6 +8,10 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
+controller:
+  # controller.create: `true` if Sealed Secrets controller should be created
+  create: true
+
 serviceAccount:
   # serviceAccount.create: Whether to create a service account or not
   create: true

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/bitnami/sealed-secrets-controller
-  tag: v0.10.0
+  tag: v0.12.1
   pullPolicy: IfNotPresent
 
 resources: {}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/bitnami/sealed-secrets-controller
-  tag: v0.8.2
+  tag: v0.9.1
   pullPolicy: IfNotPresent
 
 resources: {}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/bitnami/sealed-secrets-controller
-  tag: v0.8.1
+  tag: v0.8.2
   pullPolicy: IfNotPresent
 
 resources: {}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -1,0 +1,26 @@
+image:
+  repository: quay.io/bitnami/sealed-secrets-controller
+  tag: v0.7.0
+  pullPolicy: IfNotPresent
+
+resources: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+serviceAccount:
+  # serviceAccount.create: Whether to create a service account or not
+  create: true
+  # serviceAccount.name: The name of the service account to create or use
+  name: ""
+
+rbac:
+  # rbac.create: `true` if rbac resources should be created
+  create: true
+
+# secretName: The name of the TLS secret containing the key used to encrypt secrets
+secretName: "sealed-secrets-key"
+
+crd:
+  # crd.keep: `true` if the sealed secret CRD should be kept when the chart is deleted
+  keep: true

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/bitnami/sealed-secrets-controller
-  tag: v0.9.1
+  tag: v0.9.5
   pullPolicy: IfNotPresent
 
 resources: {}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -50,6 +50,8 @@ networkPolicy: false
 securityContext:
   # securityContext.runAsUser defines under which user the operator Pod and its containers/processes run.
   runAsUser: 1001
+  # securityContext.fsGroup defines the filesystem group
+  fsGroup: 65534
 
 podAnnotations: {}
 

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/bitnami/sealed-secrets-controller
-  tag: v0.9.6
+  tag: v0.9.7
   pullPolicy: IfNotPresent
 
 resources: {}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/bitnami/sealed-secrets-controller
-  tag: v0.9.7
+  tag: v0.10.0
   pullPolicy: IfNotPresent
 
 resources: {}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -26,6 +26,19 @@ rbac:
 # secretName: The name of the TLS secret containing the key used to encrypt secrets
 secretName: "sealed-secrets-key"
 
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /v1/cert.pem
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
 crd:
   # crd.create: `true` if the crd resources should be created
   create: true

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/bitnami/sealed-secrets-controller
-  tag: v0.12.1
+  tag: v0.12.4
   pullPolicy: IfNotPresent
 
 resources: {}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -52,3 +52,5 @@ securityContext:
   runAsUser: 1001
 
 podAnnotations: {}
+
+priorityClassName: ""

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -50,3 +50,5 @@ networkPolicy: false
 securityContext:
   # securityContext.runAsUser defines under which user the operator Pod and its containers/processes run.
   runAsUser: 1001
+
+podAnnotations: {}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -53,4 +53,6 @@ securityContext:
 
 podAnnotations: {}
 
+podLabels: {}
+
 priorityClassName: ""

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -12,6 +12,9 @@ controller:
   # controller.create: `true` if Sealed Secrets controller should be created
   create: true
 
+# namespace: Namespace to deploy the controller.
+namespace: ""
+
 serviceAccount:
   # serviceAccount.create: Whether to create a service account or not
   create: true

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/bitnami/sealed-secrets-controller
-  tag: v0.12.4
+  tag: v0.13.1
   pullPolicy: IfNotPresent
 
 resources: {}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -61,3 +61,24 @@ podAnnotations: {}
 podLabels: {}
 
 priorityClassName: ""
+
+serviceMonitor:
+  # Enables ServiceMonitor creation for the Prometheus Operator
+  create: false
+  # How frequently Prometheus should scrape the ServiceMonitor
+  interval:
+  # Extra labels to apply to the sealed-secrets ServiceMonitor
+  labels:
+  # The namespace where the ServiceMonitor is deployed, defaults to the installation namespace
+  namespace:
+  # The timeout after which the scrape is ended
+  scrapeTimeout:
+
+dashboards:
+  # If enabled, sealed-secrets will create a configmap with a dashboard in json that's going to be picked up by grafana
+  # See https://github.com/helm/charts/tree/master/stable/grafana#configuration - `sidecar.dashboards.enabled`
+  create: false
+  # Extra labels to apply to the dashboard configmaps
+  labels:
+  # The namespace where the dashboards are deployed, defaults to the installation namespace
+  namespace:

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/bitnami/sealed-secrets-controller
-  tag: v0.9.5
+  tag: v0.9.6
   pullPolicy: IfNotPresent
 
 resources: {}


### PR DESCRIPTION
I've retrieved the history of this chart from the helm stable repository and added it to this repository.