### PR TITLE
Removing `DeepCopy` for updating status in a dedicated function

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -301,7 +301,6 @@ func (c *Controller) updateSealedSecretStatus(ssecret *ssv1alpha1.SealedSecret, 
 		return nil
 	}
 
-	ssecret = ssecret.DeepCopy()
 	if ssecret.Status == nil {
 		ssecret.Status = &ssv1alpha1.SealedSecretStatus{}
 	}


### PR DESCRIPTION
`DeepCopy` creates a new instance of `ssecret` for updating status but the caller's reference is not modified. The `ObserveCondition` don't receive the newly Status and can't expose the metrics.

Fixes #441