### PR TITLE
Fix continuous status update on SealedSecret resources

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -305,6 +305,12 @@ func (c *Controller) updateSealedSecretStatus(ssecret *ssv1alpha1.SealedSecret, 
 		ssecret.Status = &ssv1alpha1.SealedSecretStatus{}
 	}
 
+	// No need to update the status if we already have observed it from the
+	// current generation of the resource.
+	if ssecret.Status.ObservedGeneration == ssecret.ObjectMeta.Generation {
+		return nil
+	}
+
 	ssecret.Status.ObservedGeneration = ssecret.ObjectMeta.Generation
 	updateSealedSecretsStatusConditions(ssecret.Status, unsealError)
 


### PR DESCRIPTION
Fixes #223 

Changes status behavior update to only update when the current resource generation was not observed yet. This prevents a steady update of the status field, which leads to high CPU utilization.