### PR TITLE
empty properties gets removed in k8s - so argo-cd sees a diff

### DIFF
--- a/helm/sealed-secrets/crds/sealedsecret-crd.yaml
+++ b/helm/sealed-secrets/crds/sealedsecret-crd.yaml
@@ -23,4 +23,3 @@ spec:
           spec:
             type: object
             x-kubernetes-preserve-unknown-fields: true
-            properties: {}


### PR DESCRIPTION
setting an empty properties makes argo-cd think there's a diff between whats in k8s cluster and what we want (based on helm template output). Removing this should fix it.