### PR TITLE
Also remove empty properties for jsonnet manifest

### DIFF
--- a/schema-v1alpha1.yaml
+++ b/schema-v1alpha1.yaml
@@ -4,4 +4,3 @@ openAPIV3Schema:
     spec:
       type: object
       x-kubernetes-preserve-unknown-fields: true
-      properties: {}


### PR DESCRIPTION
Since #529 only handled the CRD in the helm chart.