### PR TITLE
Allow viewers to read SealedSecrets

### DIFF
--- a/helm/sealed-secrets/templates/cluster-role.yaml
+++ b/helm/sealed-secrets/templates/cluster-role.yaml
@@ -40,4 +40,28 @@ rules:
     verbs:
       - create
       - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}-view
+  namespace: {{ template "sealed-secrets.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups:
+      - bitnami.com
+    resources:
+      - sealedsecrets
+    verbs:
+      - get
+      - list
+      - watch
 {{ end }}


### PR DESCRIPTION
Since SealedSecrets only contains encrypted data, we allow reading this kind of resource for
users with view permissions. There's an existing "view" role (besides "edit" and "admin") in every cluster
which gets updated with ClusterRoles containing special aggregate instructions via annotations:
~~~
rbac.authorization.k8s.io/aggregate-to-view: "true"
rbac.authorization.k8s.io/aggregate-to-edit: "true"
rbac.authorization.k8s.io/aggregate-to-admin: "true"
~~~
The view role in my use case is also used by event exporters (ie. the one provided by Opsgenie). All occurring
events are received, enriched with the metadata of the relevant object and forwarded to an arbitrary
monitoring/log system of choice. Without this role the event exporter cannot read the SealedSecrets object.