### PR TITLE
Add index.html to Helm repository

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,6 @@
+<html>
+<head>
+    <meta http-equiv="refresh" content="0; url=https://bitnami-labs.github.io/sealed-secrets/index.yaml">
+</head>
+<p><a href="https://bitnami-labs.github.io/sealed-secrets/index.yaml">Redirect to repo index.yaml</a></p>
+</html>


### PR DESCRIPTION
Some tools, e.g. Artifactory Helm Repositories, struggle if the root of the repository returns a HTTP 404 error code, eventhough the helm repository itself is perfectly valid. To mitigate this issue, this commit adds a minimal index.html file, that will redirect any visitors to the index.yaml.