### PR TITLE
Replace deprecated docker maintainer with label

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM gcr.io/distroless/static@sha256:c6d5981545ce1406d33e61434c61e9452dad93ecd8397c41e89036ef977a88f4
-MAINTAINER Marko Mikulicic <mkmik@vmware.com>
+LABEL maintainer="Marko Mikulicic <mkmik@vmware.com>"
 COPY controller /usr/local/bin/
 
 EXPOSE 8080


### PR DESCRIPTION
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated