### PR TITLE
Adapted `myCN` flag to set CN for both `Subject` and `Issuer` DN

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -41,7 +41,7 @@ var (
 	keyPrefix      = flag.String("key-prefix", "sealed-secrets-key", "Prefix used to name keys.")
 	keySize        = flag.Int("key-size", 4096, "Size of encryption key.")
 	validFor       = flag.Duration("key-ttl", 10*365*24*time.Hour, "Duration that certificate is valid for.")
-	myCN           = flag.String("my-cn", "", "CN to use in generated certificate.")
+	myCN           = flag.String("my-cn", "", "Common name to be used as issuer/subject DN in generated certificate.")
 	printVersion   = flag.Bool("version", false, "Print version information and exit")
 	keyRenewPeriod = flag.Duration("key-renew-period", defaultKeyRenewPeriod, "New key generation period (automatic rotation disabled if 0)")
 	acceptV1Data   = flag.Bool("accept-deprecated-v1-data", true, "Accept deprecated V1 data field.")

--- a/pkg/crypto/keys.go
+++ b/pkg/crypto/keys.go
@@ -41,6 +41,9 @@ func SignKey(r io.Reader, key *rsa.PrivateKey, validFor time.Duration, cn string
 		KeyUsage:     x509.KeyUsageEncipherOnly,
 		NotBefore:    notBefore.UTC(),
 		NotAfter:     notBefore.Add(validFor).UTC(),
+		Issuer: pkix.Name{
+			CommonName: cn,
+		},
 		Subject: pkix.Name{
 			CommonName: cn,
 		},


### PR DESCRIPTION
This pull request fixes #355 & #398 by allowing to set the Issuer Distinguished Name as required by [RFC 5280](https://tools.ietf.org/html/rfc5280#section-4.1.2.4).

The existing `myCN` flag is used for both `Subject` and `Issuer` DN.