### PR TITLE
feat: add default value for commandArgs helm chart value

### DIFF
--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -19,7 +19,7 @@ controller:
     # controller.service.labels: Extra labels to be added to controller service
     labels: {}
 
-# commandArgs: set extra command line arguments to the controller deployment
+# commandArgs: Set optional command line arguments passed to the controller process
 commandArgs: []
 
 # namespace: Namespace to deploy the controller.

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -19,6 +19,9 @@ controller:
     # controller.service.labels: Extra labels to be added to controller service
     labels: {}
 
+# commandArgs: set extra command line arguments to the controller deployment
+commandArgs: []
+
 # namespace: Namespace to deploy the controller.
 namespace: ""
 


### PR DESCRIPTION
Add a default value for `commandArgs` in the `values.yaml` file. 

Fixes #576