### PR TITLE
Re-enable update status feature

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -51,7 +51,7 @@ var (
 
 	oldGCBehavior = flag.Bool("old-gc-behaviour", false, "Revert to old GC behavior where the controller deletes secrets instead of delegating that to k8s itself.")
 
-	updateStatus = flag.Bool("update-status", false, "beta: if true, the controller will update the status subresource whenever it processes a sealed secret")
+	updateStatus = flag.Bool("update-status", true, "beta: if true, the controller will update the status subresource whenever it processes a sealed secret")
 
 	// VERSION set from Makefile
 	VERSION = buildinfo.DefaultVersion


### PR DESCRIPTION
According to the [release notes](https://github.com/bitnami-labs/sealed-secrets/blob/b0918f5a1f6554e7cba1e280645d9b514e20055c/RELEASE-NOTES.md#v0150) of v0.15.0, the `--update-status` flag would be enabled by default in the next release. v0.16.0 was released, but this flag [wasn't](https://github.com/bitnami-labs/sealed-secrets/blob/b0918f5a1f6554e7cba1e280645d9b514e20055c/cmd/controller/main.go#L54) enabled.

This PR re-enables `--update-status` by default.

(Ignore this PR if this wasn't enabled for a reason. But please update the release notes in that case.)