### PR TITLE
make helm chart reference image with tag v0.16.0

### DIFF
--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -11,7 +11,7 @@ description: Helm chart for the sealed-secrets controller.
 # during support requests.
 # We may want to reconsider this rule in the future.
 
-version: 1.16.0
+version: 1.16.0-r1
 appVersion: v0.16.0
 
 icon: https://avatars0.githubusercontent.com/u/34656521?s=200&v=4

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/bitnami/sealed-secrets-controller
-  tag: v0.15.0
+  tag: v0.16.0
   pullPolicy: IfNotPresent
   pullSecret: ""
 

--- a/version.yaml
+++ b/version.yaml
@@ -1,4 +1,5 @@
 version: v0.16.0
+helmRevision: r1
 
 helmReplace:
 # The helm chart started as a community effort and started off using v1.x.y


### PR DESCRIPTION
In https://github.com/bitnami-labs/sealed-secrets/blob/helm-v1.16.0/helm/sealed-secrets/values.yaml#L3 the tag is still set to v0.15.0 I think it should be v0.16.0 instead. Could you check @mkmik

It might be appropriate to add something for this to `linter.go` but I currently don't have the tooling or the time available to do it.