### PR TITLE
Bump distroless/static to fix DLA-2542-1, DLA-2509-1, DLA-2424-1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static@sha256:c6d5981545ce1406d33e61434c61e9452dad93ecd8397c41e89036ef977a88f4
+FROM gcr.io/distroless/static@sha256:8ad6f3ec70dad966479b9fb48da991138c72ba969859098ec689d1450c2e6c97
 LABEL maintainer "Bitnami <containers@bitnami.com>, Marko Mikulicic <mmikulicic@gmail.com>"
 
 ARG TARGETARCH


### PR DESCRIPTION
Bump distroless/static to fix issues with tzdata package that are flagged by image vulnerability scanners.
