### PR TITLE
Remove new line from the end of the unencoded secret

### DIFF
--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -715,7 +715,7 @@ func run(w io.Writer, inputFileName, outputFileName, secretName, controllerNs, c
 		if err != nil {
 			return err
 		}
-
+		data = bytes.TrimSuffix(data, []byte{10})
 		return encryptSecretItem(w, secretName, ns, data, sealingScope, pubKey)
 	}
 


### PR DESCRIPTION
Kubeseal adds a new line to the end of (only) some secrets which Kubernetes
does not like. So far I've been able to verify this using an AWS Secret
Access Key.

Using version `0.16.0`, to reproduce the issue:

```
kubeseal --raw --cert <public key> --from-file=aws_secret_access_key.txt --scope cluster-wide
```
or
```
kubeseal --raw --cert <public key path> --from-file=/dev/stdin --scope cluster-wide  <<<  $(echo -n <an AWS Secret Access Key>)
```
then decrypt it using:
```
kubeseal --recovery-unseal --recovery-private-key <private key path> -o yaml < sealed_secret_yaml_manifest_containing_the_secret.yaml
```
and compare the `base64` encoded that the above command returns with the output of `echo -n <an AWS Secret Access Key>  | base64` (if doing this on Ubuntu, you need to run `echo -n <an AWS Secret Access Key>  | base64 -w 0` ).


`sealed_secret_yaml_manifest_containing_the_secret.yaml`:
```
apiVersion: bitnami.com/v1alpha1
kind: SealedSecret
metadata:
  name: test
  annotations:
    sealedsecrets.bitnami.com/cluster-wide: "true"
spec:
  encryptedData:
    test: <encrypted secret>
```
