### PR TITLE
contrib/prometheus: Honor Labels added by controller

### DIFF
--- a/controller-podmonitor.jsonnet
+++ b/controller-podmonitor.jsonnet
@@ -1,9 +1,9 @@
-// Prometheus Service Monitor manifest
+// Prometheus Pod Monitor manifest
 
 local controller = import 'controller.jsonnet';
 
 controller {
-  serviceMonitor: {
+  podMonitor: {
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'PodMonitor',
     metadata: {
@@ -27,6 +27,7 @@ controller {
       },
       podMetricsEndpoints: [
         {
+          honorLabels: true,  // prefer controller metric namespace
           port: 'http',
           interval: '30s',
         },

--- a/controller-podmonitor.jsonnet
+++ b/controller-podmonitor.jsonnet
@@ -1,4 +1,5 @@
 // Prometheus Pod Monitor manifest
+// ref: https://github.com/prometheus-operator/prometheus-operator#customresourcedefinitions
 
 local controller = import 'controller.jsonnet';
 


### PR DESCRIPTION
Closes #613 

Preserve `namespace="test"` labels added by the controller so that
dashboards and alerts will correctly show corresponding SealedSecrets
namespace and not the default, eg: `namespace="sealed-secrets"`

The helm chart already has this set.