### PR TITLE
Make both pod and container security context configurable

### DIFF
--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,7 +1,7 @@
 name: sealed-secrets
 description: Helm chart for the sealed-secrets controller.
 
-version: 1.16.1
+version: 1.16.2
 appVersion: v0.16.0
 
 kubeVersion: ">=1.16.0-0"

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -12,7 +12,7 @@ To install the chart with the release name `my-release`:
 ### Helm 3
 
 ```bash
-$ helm3 install --namespace kube-system my-release sealed-secrets/sealed-secrets 
+$ helm3 install --namespace kube-system my-release sealed-secrets/sealed-secrets
 ```
 
 ### Helm 2
@@ -25,7 +25,7 @@ The command deploys a controller and [CRD](https://kubernetes.io/docs/tasks/acce
 
 ## Uninstalling the Chart
 
-To uninstall/delete all of the resources associated with the chart `my-release` 
+To uninstall/delete all of the resources associated with the chart `my-release`
 
 ### Helm 2
 
@@ -95,9 +95,8 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 - In the case that **serviceAccount.create** is `false` and **rbac.create** is `true` it is expected for a service account with the name **serviceAccount.name** to exist _in the same namespace as this chart_ before installation.
 - If **serviceAccount.create** is `true` there cannot be an existing service account with the name **serviceAccount.name**.
 - If a secret with name **secretName** does not exist _in the same namespace as this chart_, then on install one will be created. If a secret already exists with this name the keys inside will be used.
-- OpenShift: unset the runAsUser and fsGroup like this:
+- OpenShift: unset the runAsUser and fsGroup by removing the explicit pod security context like this:
 ```
   securityContext:
-    runAsUser:
-    fsGroup:
+    {}
 ```

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -65,17 +65,15 @@ spec:
             httpGet:
               path: /healthz
               port: 8080
+          {{- with .Values.containerSecurityContext }}
           securityContext:
-            readOnlyRootFilesystem: true
-            {{- if .Values.securityContext.runAsUser }}
-            runAsNonRoot: true
-            runAsUser: {{ .Values.securityContext.runAsUser }}
-            {{- end }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-      {{- if .Values.securityContext.fsGroup }}
+      {{- with .Values.securityContext }}
       securityContext:
-        fsGroup: {{ .Values.securityContext.fsGroup }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
       - name: tmp

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -67,6 +67,16 @@ securityContext:
   # securityContext.fsGroup defines the filesystem group
   fsGroup: 65534
 
+# containerSecurityContext: configure the container security context
+containerSecurityContext:
+  runAsNonRoot: true
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  privileged: false
+  capabilities:
+    drop:
+       - ALL
+
 podAnnotations: {}
 
 podLabels: {}


### PR DESCRIPTION
This allows complete control over both the pod and container security context. The default container security context is now a bit more secure by explicitely setting `allowPrivilegeEscalation: false` and dropping all capabilites. The namings and usage of the two security contexts should now also be more aligned with other Bitnami charts.

The changes may not be backwards compatible, especially when using OpenShift, since setting `securityContext.runAsUser: ""` will no longer work, instead the entire pod security context will need to be disabled, I've updated the README accordingly.