### PR TITLE
enable setting service name and sync to kubeseal

### DIFF
--- a/helm/sealed-secrets/templates/_helpers.tpl
+++ b/helm/sealed-secrets/templates/_helpers.tpl
@@ -47,3 +47,14 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the controller service to use
+*/}}
+{{- define "sealed-secrets.serviceName" -}}
+{{- if .Values.controller.create -}}
+    {{ default (printf "%s-controller" (include "sealed-secrets.fullname" . )) .Values.controller.service.name }}
+{{- else -}}
+    {{ default "default" .Values.controller.service.name }}
+{{- end -}}
+{{- end -}}

--- a/helm/sealed-secrets/templates/ingress.yaml
+++ b/helm/sealed-secrets/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "sealed-secrets.fullname" . -}}
+{{- $serviceName := include "sealed-secrets.serviceName" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
@@ -38,7 +39,7 @@ spec:
         paths:
           - path: {{ $ingressPath }}
             backend:
-              serviceName: {{ $fullName }}
+              serviceName: {{ $serviceName }}
               servicePort: 8080
   {{- end }}
 {{- end }}

--- a/helm/sealed-secrets/templates/service.yaml
+++ b/helm/sealed-secrets/templates/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "sealed-secrets.fullname" . }}
+  name: {{ template "sealed-secrets.serviceName" . }}
   namespace: {{ template "sealed-secrets.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -16,6 +16,8 @@ controller:
   labels: {}
   # controller.service: Configuration options for controller service
   service:
+    # controller.service.name: The name of the service to create or use
+    name: ""
     # controller.service.labels: Extra labels to be added to controller service
     labels: {}
 


### PR DESCRIPTION
To resolve bitnami-labs#571. Treating kubeseal as the source of truth. Can still use the old service name if necessary by setting `controller.service.name: sealed-secrets`