### PR TITLE
feat: #602 Bump rbac api version

### DIFF
--- a/vendor_jsonnet/kube-libsonnet/kube.libsonnet
+++ b/vendor_jsonnet/kube-libsonnet/kube.libsonnet
@@ -599,7 +599,7 @@
   ServiceAccount(name): $._Object("v1", "ServiceAccount", name) {
   },
 
-  Role(name): $._Object("rbac.authorization.k8s.io/v1beta1", "Role", name) {
+  Role(name): $._Object("rbac.authorization.k8s.io/v1", "Role", name) {
     rules: [],
   },
 
@@ -619,7 +619,7 @@
     apiGroup: "rbac.authorization.k8s.io",
   },
 
-  RoleBinding(name): $._Object("rbac.authorization.k8s.io/v1beta1", "RoleBinding", name) {
+  RoleBinding(name): $._Object("rbac.authorization.k8s.io/v1", "RoleBinding", name) {
     local rb = self,
 
     subjects_:: [],

--- a/vendor_jsonnet/kube-libsonnet/tests/golden/test-simple-validate.json
+++ b/vendor_jsonnet/kube-libsonnet/tests/golden/test-simple-validate.json
@@ -500,7 +500,7 @@
          }
       },
       {
-         "apiVersion": "rbac.authorization.k8s.io/v1beta1",
+         "apiVersion": "rbac.authorization.k8s.io/v1",
          "kind": "Role",
          "metadata": {
             "annotations": { },
@@ -539,7 +539,7 @@
          ]
       },
       {
-         "apiVersion": "rbac.authorization.k8s.io/v1beta1",
+         "apiVersion": "rbac.authorization.k8s.io/v1",
          "kind": "RoleBinding",
          "metadata": {
             "annotations": { },


### PR DESCRIPTION
rbac.authorization.k8s.io/v1beta1 Role is deprecated in v1.17+,
unavailable in v1.22+; use rbac.authorization.k8s.io/v1

done using command:
```
find -type f -exec sed -i -e 's%rbac.authorization.k8s.io/v1beta1%rbac.authorization.k8s.io/v1%g' {} \;
```