### PR TITLE
Set default service name properly

### DIFF
--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -4,6 +4,8 @@ image:
   pullPolicy: IfNotPresent
   pullSecret: ""
 
+fullnameOverride: "sealed-secrets-controller"
+
 resources: {}
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
When installing the helm chart, the chances are high (it depends on a few variables so you *may* also end up lucky...) that the service will be named `sealed-secrets` whereas `kubeseal`expects `sealed-secrets-controller` by default. This PR fixes ther default to ensure it works directly. 

fix #571