### PR TITLE
Allow to specify ServiceMonitor annotations

### DIFF
--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -16,4 +16,4 @@ maintainers:
     email: mmikulicic@gmail.com
 name: sealed-secrets
 type: application
-version: 2.1.0
+version: 2.0.2

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -16,4 +16,4 @@ maintainers:
     email: mmikulicic@gmail.com
 name: sealed-secrets
 type: application
-version: 2.0.2
+version: 2.1.0

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -126,6 +126,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------------------ | -------------------------------------------------------------------------------------- | ------- |
 | `metrics.serviceMonitor.enabled`           | Specify if a ServiceMonitor will be deployed for Prometheus Operator                   | `false` |
 | `metrics.serviceMonitor.namespace`         | Namespace where Prometheus Operator is running in                                      | `""`    |
+| `metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                                    | `{}`    |
+| `metrics.serviceMonitor.annotations`       | Annotations for the ServiceMonitor                                                     | `{}`    |
 | `metrics.serviceMonitor.interval`          | How frequently to scrape metrics                                                       | `""`    |
 | `metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                                | `""`    |
 | `metrics.serviceMonitor.metricRelabelings` | Specify additional relabeling of metrics                                               | `[]`    |

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -127,7 +127,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.serviceMonitor.enabled`           | Specify if a ServiceMonitor will be deployed for Prometheus Operator                   | `false` |
 | `metrics.serviceMonitor.namespace`         | Namespace where Prometheus Operator is running in                                      | `""`    |
 | `metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                                    | `{}`    |
-| `metrics.serviceMonitor.annotations`       | Annotations for the ServiceMonitor                                                     | `{}`    |
+| `metrics.serviceMonitor.annotations`       | Extra annotations for the ServiceMonitor                                               | `{}`    |
 | `metrics.serviceMonitor.interval`          | How frequently to scrape metrics                                                       | `""`    |
 | `metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                                | `""`    |
 | `metrics.serviceMonitor.metricRelabelings` | Specify additional relabeling of metrics                                               | `[]`    |

--- a/helm/sealed-secrets/templates/servicemonitor.yaml
+++ b/helm/sealed-secrets/templates/servicemonitor.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- if .Values.metrics.serviceMonitor.labels }}
     {{- include "sealed-secrets.render" ( dict "value" .Values.metrics.serviceMonitor.labels "context" $) | nindent 4 }}
     {{- end }}
+  {{- if .Values.metrics.serviceMonitor.annotations }}
+  annotations: {{- include "sealed-secrets.render" (dict "value" .Values.metrics.serviceMonitor.annotations "context" $) | nindent 4 }}
+  {{- end }}
 spec:
   endpoints:
     - honorLabels: true

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -258,6 +258,12 @@ metrics:
     ## @param metrics.serviceMonitor.namespace Namespace where Prometheus Operator is running in
     ##
     namespace: ""
+    ## @param metrics.serviceMonitor.labels Extra labels for the ServiceMonitor
+    ##
+    labels: {}
+    ## @param metrics.serviceMonitor.annotations Annotations for the ServiceMonitor
+    ##
+    annotations: {}
     ## @param metrics.serviceMonitor.interval How frequently to scrape metrics
     ## e.g:
     ## interval: 10s

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -261,7 +261,7 @@ metrics:
     ## @param metrics.serviceMonitor.labels Extra labels for the ServiceMonitor
     ##
     labels: {}
-    ## @param metrics.serviceMonitor.annotations Annotations for the ServiceMonitor
+    ## @param metrics.serviceMonitor.annotations Extra annotations for the ServiceMonitor
     ##
     annotations: {}
     ## @param metrics.serviceMonitor.interval How frequently to scrape metrics


### PR DESCRIPTION
Usecase: When installing with ArgoCD, Prometheus operator
(and associated CRDs) may be missing.

Adding the following in the values will allow creating the other
resources:

```yaml
serviceMonitor:
  annotations:
    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
```

Ref: https://argoproj.github.io/argo-cd/user-guide/sync-options/#skip-dry-run-for-new-custom-resources-types