### PR TITLE
dry-run is deprecated, replace it with dry-run=client

### DIFF
--- a/docs/examples/config-template/README.md
+++ b/docs/examples/config-template/README.md
@@ -18,7 +18,7 @@ This example shows how to use built in support for templating encrypted secret v
 To update the encrypted data in the included sealedsecret with your own value
 for `server1` you can run:
 
-```
-echo -n baz | kubectl create secret generic example --dry-run --from-file=server1=/dev/stdin -o json \
+```sh
+echo -n baz | kubectl create secret generic example --dry-run=client --from-file=server1=/dev/stdin -o json \
   | kubeseal -o yaml --merge-into sealedsecret.yaml
 ```


### PR DESCRIPTION
When running this, I got a kubectl notice: `--dry-run is deprecated and can be replaced with --dry-run=client`, so this should circumvent it.