### PR TITLE
Add Issue & PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--
+ Before you open the bug report please review the following FAQ:
+
+ - [Sealed Secrets FAQ](https://github.com/bitnami-labs/sealed-secrets#faq)
+ -->
+
+**Which component**:
+The name (and version) of the affected component (controller or kubeseal)
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Run the command '....'
+3. Wait for '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Version of Kubernetes**:
+
+- Output of `kubectl version`:
+
+```
+(paste your output here)
+```
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Which component**:
+The name (and version) of the affected component (controller or kubeseal)
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+<!--
+ Before you open the request please review the following guidelines and tips to help it be more easily integrated:
+
+ - Describe the scope of your change - i.e. what the change does.
+ - Describe any known limitations with your change.
+ - Please run any tests or examples that can exercise your modified code.
+
+ Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).
+
+ Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
+ -->
+
+**Description of the change**
+
+<!-- Describe the scope of your change - i.e. what the change does. -->
+
+**Benefits**
+
+<!-- What benefits will be realized by the code change? -->
+
+**Possible drawbacks**
+
+<!-- Describe any known limitations with your change -->
+
+**Applicable issues**
+
+<!-- Enter any applicable Issues here (You can reference an issue using #) -->
+- fixes #
+
+**Additional information**
+
+<!-- If there's anything else that's important and relevant to your pull
+request, mention that information here.-->


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Add [Issue & PR templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates) as recommended by GitHub building communities guidelines.

**Benefits**

Defining the standards to propose changes according to our contributing guidelines.

**Possible drawbacks**

None

**Applicable issues**

  - fixes #669

**Additional information**

N/A