### PR TITLE
Update release GH action to include K8s manifests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,9 +19,16 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.15
+
+      # Run tests
       - name: Tests
         run: make test
-  
+
+      # Generate K8s manifests
+      - name: K8s manifests
+        run: |
+          make CONTROLLER_IMAGE=${{ env.image_name }}:${{ github.ref_name }} controller.yaml controller-norbac.yaml
+
       # Setup env for multi-arch builds
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,10 +23,7 @@ builds:
 archives:
   - builds:
       - kubeseal
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
+    name_template: "kubeseal-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
 checksum:
   algorithm: sha256
 changelog:
@@ -38,6 +35,7 @@ changelog:
       - '^integration:'
       - '^vendor_jsonnet:'
 release:
+  name_template: "{{ .ProjectName }}-v{{ .Version }}"
   header: |
     ## v{{ .Version }} ({{ .Date }})
 
@@ -48,4 +46,6 @@ release:
     Please read the [RELEASE_NOTES](https://github.com/bitnami-labs/sealed-secrets/blob/master/RELEASE-NOTES.md) which contain among other things important information for who is upgrading from previous releases.
 
     ## Thanks!
-  name_template: "{{ .ProjectName }}-v{{ .Version }}"
+  extra_files:
+    - glob: ./controller.yaml
+    - glob: ./controller-norbac.yaml


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

We stopped publishing the K8s manifests (`controller.yaml` and `controller-norbac.yaml`) in GH releases after the changes introduced at https://github.com/bitnami-labs/sealed-secrets/pull/668 to use GH actions to manage the binaries & container image releases. You can see the differences in the published assets between versions `0.16.0` and `0.17.0`:

- https://github.com/bitnami-labs/sealed-secrets/releases/tag/v0.16.0
- https://github.com/bitnami-labs/sealed-secrets/releases/tag/v0.17.0

This PR attempts to amend this so we publish again these manifests.

**Benefits**

GH releases to included updated K8s manifests.

**Possible drawbacks**

None

**Applicable issues**

- fixes #678

**Additional information**

N/A
