### PR TITLE
Binaries to emit the proper version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,8 @@ builds:
   - binary: controller
     id: controller
     main: ./cmd/controller
+    ldflags:
+      - -X main.VERSION={{ .Version }}
     targets:
       - darwin_amd64
       - linux_amd64
@@ -14,6 +16,8 @@ builds:
   - binary: kubeseal
     id: kubeseal
     main: ./cmd/kubeseal
+    ldflags:
+      - -X main.VERSION={{ .Version }}
     targets:
       - darwin_amd64
       - linux_amd64


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Binaries are reported `UNKNOWN` when asked after delegating the compilation to Goreleaser.

**Benefits**

Binaries report the proper version.

**Possible drawbacks**

None

**Applicable issues**

- fixes #680

**Additional information**

N/A
