### PR TITLE
Fix release GH action - missing kubecfg

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,11 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.15
+      - name: Setup kubecfg
+        run: |
+          mkdir -p ~/bin
+          curl -sLf https://github.com/bitnami/kubecfg/releases/download/v0.16.0/kubecfg-linux-amd64 >~/bin/kubecfg
+          chmod +x ~/bin/kubecfg
 
       # Run tests
       - name: Tests
@@ -27,6 +32,7 @@ jobs:
       # Generate K8s manifests
       - name: K8s manifests
         run: |
+          export PATH=~/bin:$PATH
           make CONTROLLER_IMAGE=${{ env.image_name }}:${{ github.ref_name }} controller.yaml controller-norbac.yaml
 
       # Setup env for multi-arch builds


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Fixes an issue in the GH release action, see: 

- https://github.com/bitnami-labs/sealed-secrets/runs/4546087283?check_suite_focus=true

**Benefits**

GH release action to properly work.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A
