### PR TITLE
New v0.17.1 release

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,6 +9,7 @@ Latest release:
 ## Changelog
 
 * Binaries to emit the proper version ([#683](https://github.com/bitnami-labs/sealed-secrets/pull/683)
+* Re-enable publishing K8s manifests in GH releases ([#678](https://github.com/bitnami-labs/sealed-secrets/issues/678)
 
 # v0.17.0
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,6 +4,12 @@ Latest release:
 
 [![](https://img.shields.io/github/release/bitnami-labs/sealed-secrets.svg)](https://github.com/bitnami-labs/sealed-secrets/releases/latest)
 
+# v0.17.1
+
+## Changelog
+
+* Binaries to emit the proper version ([#683](https://github.com/bitnami-labs/sealed-secrets/pull/683)
+
 # v0.17.0
 
 ## Announcements


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Update the Release Notes so we can trigger a new release `v0.17.1` including the fix for the version.

**Benefits**

New release.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A
