### PR TITLE
Fix dashboard ConfigMap labels

### DIFF
--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -16,4 +16,4 @@ maintainers:
     email: mmikulicic@gmail.com
 name: sealed-secrets
 type: application
-version: 2.0.1
+version: 2.0.2

--- a/helm/sealed-secrets/templates/configmap-dashboards.yaml
+++ b/helm/sealed-secrets/templates/configmap-dashboards.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ $namespace }}
   labels: {{- include "sealed-secrets.labels" $ | nindent 4 }}
     {{- if $.Values.metrics.dashboards.labels }}
-    {{- include "sealed-secrets.render" ( dict "value" $.Values.serviceAccount.labels "context" $) | nindent 4 }}
+    {{- include "sealed-secrets.render" ( dict "value" $.Values.metrics.dashboards.labels "context" $) | nindent 4 }}
     {{- end }}
 data:
   {{ base $path }}: |-


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

As part of the major update to the helm chart metrics were introduced including a ConfigMap to provide a Grafana Dashboard. The labels value on the template for the ConfigMap is referencing the serviceAccount labels incorrectly, this change is to fix that.

**Benefits**

Labelling the dashboard ConfigMap works as expected.
