### PR TITLE
Add an option to disable key generation completely

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,8 @@ Labelling a *sealing key* secret with anything other than `active` effectively d
 the key from the sealed secrets controller, but it is still available in k8s for
 manual encryption/decryption if need be.
 
+If manual (or rather external to controller) key management is the case, you may want to completely disable key generation (including key rotation), so controller doesn't intefere with whatever process is already in-place (see [bring-your-own-certificates.md](docs/bring-your-own-certificates.md)).
+
 **NOTE** Sealed secrets currently does not automatically pick up manually created, deleted or relabeled sealing keys, an admin must restart the controller before the effect will apply.
 
 ### Re-encryption (advanced)

--- a/docs/bring-your-own-certificates.md
+++ b/docs/bring-your-own-certificates.md
@@ -27,6 +27,13 @@ kubectl -n "$NAMESPACE" create secret tls "$SECRETNAME" --cert="$PUBLICKEY" --ke
 kubectl -n "$NAMESPACE" label secret "$SECRETNAME" sealedsecrets.bitnami.com/sealed-secrets-key=active
 ```
 
+## (OPTIONAL) disable key generation in the controller:
+```bash
+kubectl -n "$NAMESPACE" patch deployment/sealed-secrets-controller --type=json --patch '[{"op": "add", "path": "/spec/template/spec/containers/0/args", "value": ["--disable-key-generation"]}]'
+```
+This will ensure the controller does not try to generate a new key in case it fails to find existing one for whatever reason or in case of a periodical rotation.
+
+NB: This is NOT going to retain any command-line arguments, which were previously added manually. Adjust the command accordingly.
 ## Deleting the controller Pod is needed to pick they new keys:
 ```bash
 kubectl -n  "$NAMESPACE" delete pod -l name=sealed-secrets-controller


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

The change introduces a new command line option called `--disable-key-generation`, which disables any automatic sealing key generation done by controller (including rotation). In case key generation is disabled and there's no active sealing key present, the controller will stop and report an error, making the issue explicit/visible.

**Benefits**

The change will make a more robust controller deployment possible in a setting, where sealing keys are managed externally (i.e. not generated by controller).

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
None discovered so far. The introduced behaviour is optional and is disabled by default.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes https://github.com/bitnami-labs/sealed-secrets/issues/702

