### PR TITLE
docs: Add a note about potential breaking change of image.repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Contributions are welcome via GitHub Pull Requests. This document outlines the process to help get your contribution accepted.
 
-Any type of contribution is welcome; from new features, bug fixes, or documentation improvements. However, VMware/Bitnami will review the proposals and perform a triage over them. By doing so, we will ensure that the most valuable contributions for the comunity will be implemented in due time.
+Any type of contribution is welcome; from new features, bug fixes, or documentation improvements. However, VMware/Bitnami will review the proposals and perform a triage over them. By doing so, we will ensure that the most valuable contributions for the community will be implemented in due time.
 
 ## How to Contribute
 

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -191,6 +191,7 @@ A major refactoring of the chart has been performed to adopt several common prac
 
 - `controller.create` renamed as `createController`.
 - `securityContext.*` parameters are deprecated in favor of `podSecurityContext.*`, and `containerSecurityContext.*` ones.
+- `image.repository` changed to `image.registry`/`image.repository`.
 
 Consult the [Parameters](#parameters) section to obtain more info about the available parameters.
 


### PR DESCRIPTION
**Description of the change**

Adding a note about a potential breaking change of `image.repository` when using internal registries

In some cases, the `repository` image parameter is overridden to point to a full path of a different image or different registry. 

After the 2.0.1 upgrade, that would override just the image name and the registry would remain unchanged ( quay )

**Benefits**

Make the users aware of the image attributes change so that they can adapt their helm-values

Users adopting the new version can decide to override the `registry`, `repository` or both parameters

**Possible drawbacks**

_None_

**Applicable issues**

_None_

**Additional information**

```
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: {{ printf "%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.tag }}
```
https://github.com/bitnami-labs/sealed-secrets/pull/687/files#diff-aac94a436c20224e24f87b8c85f3a453aad85bc68e40d93068e04f578449a847R51


```
image:
-   repository: quay.io/bitnami/sealed-secrets-controller
+   registry: quay.io
+   repository: bitnami/sealed-secrets-controller
```
https://github.com/bitnami-labs/sealed-secrets/pull/687/files#diff-c293662387deb9efc2693cf116c5b930beaf110e9d6e5074c985ba6c8311e313L2