### PR TITLE
Switch back to use TOC Generator to create the Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,47 +16,10 @@ decrypted only by the controller running in the target cluster and
 nobody else (not even the original author) is able to obtain the
 original Secret from the SealedSecret.
 
-## Table of Contents
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- ["Sealed Secrets" for Kubernetes](#sealed-secrets-for-kubernetes)
-  - [Table of Contents](#table-of-contents)
-  - [Overview](#overview)
-    - [SealedSecrets as templates for secrets](#sealedsecrets-as-templates-for-secrets)
-    - [Public key / Certificate](#public-key--certificate)
-    - [Scopes](#scopes)
-  - [Installation](#installation)
-    - [Controller](#controller)
-    - [Kustomize](#kustomize)
-    - [Helm Chart](#helm-chart)
-    - [Operator Framework](#operator-framework)
-    - [Homebrew](#homebrew)
-    - [MacPorts](#macports)
-    - [Installation from source](#installation-from-source)
-  - [Upgrade](#upgrade)
-  - [Usage](#usage)
-    - [Managing existing secrets](#managing-existing-secrets)
-    - [Update existing secrets](#update-existing-secrets)
-    - [Raw mode (experimental)](#raw-mode-experimental)
-  - [Secret Rotation](#secret-rotation)
-    - [Sealing key renewal](#sealing-key-renewal)
-    - [User secret rotation](#user-secret-rotation)
-    - [Early key renewal](#early-key-renewal)
-    - [Common misconceptions about key renewal](#common-misconceptions-about-key-renewal)
-    - [Manual key management (advanced)](#manual-key-management-advanced)
-    - [Re-encryption (advanced)](#re-encryption-advanced)
-  - [Details (advanced)](#details-advanced)
-    - [Crypto](#crypto)
-  - [Developing](#developing)
-  - [FAQ](#faq)
-    - [Will you still be able to decrypt if you no longer have access to your cluster?](#will-you-still-be-able-to-decrypt-if-you-no-longer-have-access-to-your-cluster)
-    - [How can I do a backup of my SealedSecrets?](#how-can-i-do-a-backup-of-my-sealedsecrets)
-    - [Can I decrypt my secrets offline with a backup key?](#can-i-decrypt-my-secrets-offline-with-a-backup-key)
-    - [What flags are available for kubeseal?](#what-flags-are-available-for-kubeseal)
-    - [How do I update parts of JSON/YAML/TOML.. file encrypted with sealed secrets?](#how-do-i-update-parts-of-jsonyamltoml-file-encrypted-with-sealed-secrets)
-    - [Can I bring my own (pre-generated) certificates?](#can-i-bring-my-own-pre-generated-certificates)
-    - [How to use kubeseal if the controller is not running within the `kube-system` namespace?](#how-to-use-kubeseal-if-the-controller-is-not-running-within-the-kube-system-namespace)
-  - [Community](#community)
-    - [Related projects](#related-projects)
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Overview
 


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

These changes enable back to auto-generate the "Table of Contents" using the TOC Generator GH action.

**Benefits**

Automation.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

I accidentally broke the integration with the [TOC Generator](https://github.com/technote-space/toc-generator) at [this PR ](https://github.com/bitnami-labs/sealed-secrets/pull/700).
