### PR TITLE
docs: Note about the ingress rule change in v2

### DIFF
--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -195,6 +195,7 @@ A major refactoring of the chart has been performed to adopt several common prac
 - `controller.create` renamed as `createController`.
 - `securityContext.*` parameters are deprecated in favor of `podSecurityContext.*`, and `containerSecurityContext.*` ones.
 - `image.repository` changed to `image.registry`/`image.repository`.
+- `ingress.hosts[0]` changed to `ingress.hostname`.
 
 Consult the [Parameters](#parameters) section to obtain more info about the available parameters.
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Another hidden breaking change ^^'

The "ingress.hosts" parameter is deprecated in favor of specifying one host with "hostname" attribute then "extraHosts" if necessary

I think this is also important to highlight in the breaking changes section

**Benefits**

<!-- What benefits will be realized by the code change? -->
Same as https://github.com/bitnami-labs/sealed-secrets/pull/707

**Possible drawbacks**

_None_

<!-- Describe any known limitations with your change -->

**Applicable issues**

_None_

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

```
+   {{- range .Values.ingress.hosts }}
+   - host: {{ . }}
-   {{- if .Values.ingress.hostname }}
-   - host: {{ .Values.ingress.hostname }}
```

https://github.com/bitnami-labs/sealed-secrets/pull/687/files#diff-eae18315a49ec58c7f312abb5ea787fe67e7d0afb428cfadd81b56aa81958960L35
