### PR TITLE
Add extra RBAC permissions

### DIFF
--- a/controller.jsonnet
+++ b/controller.jsonnet
@@ -23,7 +23,7 @@ controller {
       {
         apiGroups: [''],
         resources: ['secrets'],
-        verbs: ['get', 'create', 'update', 'delete'],
+        verbs: ['get', 'list', 'create', 'update', 'delete'],
       },
       {
         apiGroups: [''],
@@ -46,6 +46,22 @@ controller {
 
   serviceProxierRole: kube.Role('sealed-secrets-service-proxier') + $.namespace {
     rules: [
+      {
+        apiGroups: [
+          '',
+        ],
+        resources: [
+          'services',
+        ],
+        resourceNames: [
+          'sealed-secrets-controller',
+        ],
+        // kubeseal dynamically obtains the service port name so later on
+        // can access the service using a proxy
+        verbs: [
+          'get',
+        ],
+      },
       {
         apiGroups: [
           '',

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -16,4 +16,4 @@ maintainers:
     email: mmikulicic@gmail.com
 name: sealed-secrets
 type: application
-version: 2.1.0
+version: 2.1.1

--- a/helm/sealed-secrets/templates/cluster-role.yaml
+++ b/helm/sealed-secrets/templates/cluster-role.yaml
@@ -28,6 +28,7 @@ rules:
       - secrets
     verbs:
       - get
+      - list
       - create
       - update
       - delete

--- a/helm/sealed-secrets/templates/role.yaml
+++ b/helm/sealed-secrets/templates/role.yaml
@@ -35,14 +35,20 @@ metadata:
     {{- include "sealed-secrets.render" ( dict "value" .Values.rbac.labels "context" $) | nindent 4 }}
     {{- end }}
 rules:
-- apiGroups:
-  - ""
-  resourceNames:
-  - 'http:{{ include "sealed-secrets.fullname" . }}:'
-  - {{ include "sealed-secrets.fullname" . }}
-  resources:
-  - services/proxy
-  verbs:
-  - create
-  - get
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - 'http:{{ include "sealed-secrets.fullname" . }}:'
+      - {{ include "sealed-secrets.fullname" . }}
+    resources:
+      - services/proxy
+    verbs:
+      - create
+      - get
 {{ end }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR adds extra permissions to the ClusterRole so it can list services and the panic error below is addressed:

```
panic: secrets is forbidden: User "system:serviceaccount:kube-system:sealed-secrets" cannot list resource "secrets" in API group "" in the namespace "kube-system"
```

It also adds extra permissions to the "service-proxier" Role since the changes introduced at https://github.com/bitnami-labs/sealed-secrets/pull/648 require getting the service to obtain the port name information dynamically.

**Benefits**

Sealed Secrets to be compatible with K8s environments with RBAC enabled.

**Possible drawbacks**

None

**Applicable issues**

- fixes #708

**Additional information**

N/A
