### PR TITLE
TOC Generator to create a PR

### DIFF
--- a/.github/workflows/toc.yml
+++ b/.github/workflows/toc.yml
@@ -15,6 +15,8 @@ jobs:
         uses: technote-space/toc-generator@v4
         with:
           CHECK_ONLY_DEFAULT_BRANCH: true
+          CREATE_PR: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TITLE: "chore(docs): update README.md TOC (${PR_MERGE_REF})"
           TARGET_PATHS: README.md
-          TOC_TITLE: '## Table of Contents'
+          TOC_TITLE: "## Table of Contents"


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Configure TOC Generator GH action to create a PR instead of pushing a commit to the main branch, which is incompatible with our current branch protection rules.

**Benefits**

TOC Generator can update the TOC in a secure way.

**Possible drawbacks**

None

**Applicable issues**

Fixes current broken GH action: https://github.com/bitnami-labs/sealed-secrets/actions/runs/1723273257

**Additional information**

N/A
