### PR TITLE
Include stale configuration

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '0 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This Issue has been automatically marked as "stale" because it has not had recent activity (for 15 days). It will be closed if no further activity occurs. Thanks for the feedback.'
+          stale-pr-message: 'This Pull Request has been automatically marked as "stale" because it has not had recent activity (for 15 days). It will be closed if no further activity occurs. Thank you for your contribution.'
+          close-issue-message: 'Due to the lack of activity in the last 5 days since it was marked as "stale", we proceed to close this Issue. Do not hesitate to reopen it later if necessary.'
+          close-pr-message: 'Due to the lack of activity in the last 5 days since it was marked as "stale", we proceed to close this Pull Request. Do not hesitate to reopen it later if necessary.'
+          days-before-stale: 15
+          days-before-close: 7
+          exempt-issue-labels: 'on-hold'
+          exempt-pr-labels: 'on-hold'
+          operations-per-run: 500

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: 'Close stale issues and PRs'
 on:
   schedule:
-    # Stalebot will be executed at 1:00 AM every days
+    # Stalebot will be executed at 1:00 AM every day
     - cron: '0 1 * * *'
 
 jobs:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: 'Close stale issues and PRs'
 on:
   schedule:
-    # Stalebot will be execute at 1:00 AM every days
+    # Stalebot will be executed at 1:00 AM every days
     - cron: '0 1 * * *'
 
 jobs:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,19 +1,20 @@
 name: 'Close stale issues and PRs'
 on:
   schedule:
+    # Stalebot will be execute at 1:00 AM every days
     - cron: '0 1 * * *'
 
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@v4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This Issue has been automatically marked as "stale" because it has not had recent activity (for 15 days). It will be closed if no further activity occurs. Thanks for the feedback.'
           stale-pr-message: 'This Pull Request has been automatically marked as "stale" because it has not had recent activity (for 15 days). It will be closed if no further activity occurs. Thank you for your contribution.'
-          close-issue-message: 'Due to the lack of activity in the last 5 days since it was marked as "stale", we proceed to close this Issue. Do not hesitate to reopen it later if necessary.'
-          close-pr-message: 'Due to the lack of activity in the last 5 days since it was marked as "stale", we proceed to close this Pull Request. Do not hesitate to reopen it later if necessary.'
+          close-issue-message: 'Due to the lack of activity in the last 7 days since it was marked as "stale", we proceed to close this Issue. Do not hesitate to reopen it later if necessary.'
+          close-pr-message: 'Due to the lack of activity in the last 7 days since it was marked as "stale", we proceed to close this Pull Request. Do not hesitate to reopen it later if necessary.'
           days-before-stale: 15
           days-before-close: 7
           exempt-issue-labels: 'on-hold'


### PR DESCRIPTION
**Description of the change**

Include stale configuration to close inactive issues/PRs. 

The new workflow defined for the inactivity issues:

- The _stale_ label will be included in all the issues after 15 days of inactivity.
- After 7 days without any activity, the issue will be closed. Otherwise, the _stale_ label must be deleted and the issue will have again another 15 days to wait any answer from the community.

**Important note**: Issues/PRs with the _on-hold_ label are exceptions for the stalebot. Those issues/PRs won't be affected by this new workflow. All of them will keep opened and close it manually.

**Benefits**

Keep issues/PRs open when there is activity.
