### PR TITLE
Use klog/v2 to fix the verbose logging

### DIFF
--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/keyutil"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	ssv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealed-secrets/v1alpha1"
 

--- a/go.mod
+++ b/go.mod
@@ -23,4 +23,5 @@ require (
 	k8s.io/client-go v0.22.1
 	k8s.io/code-generator v0.16.8
 	k8s.io/klog v1.0.0
+	k8s.io/klog/v2 v2.9.0
 )


### PR DESCRIPTION
**Description of the change**

Replace klog to use klog/v2 to fix the verbose logging. This bug was generated with the client-go bumping patch.

**Benefits**

Fix this bug setting up the verbosity level.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #721