### PR TITLE
Add 'Simple Issue Labeler' GH action

### DIFF
--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -1,0 +1,20 @@
+name: Label issues/prs
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label issues/prs
+        uses: andymckay/labeler@1.0.4
+        with:
+          add-labels: "triage"
+          ignore-if-labeled: true
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,6 +17,6 @@ jobs:
           close-pr-message: 'Due to the lack of activity in the last 7 days since it was marked as "stale", we proceed to close this Pull Request. Do not hesitate to reopen it later if necessary.'
           days-before-stale: 15
           days-before-close: 7
-          exempt-issue-labels: 'on-hold'
-          exempt-pr-labels: 'on-hold'
+          exempt-issue-labels: 'backlog,triage'
+          exempt-pr-labels: 'backlog,triage'
           operations-per-run: 500


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Add the [Simple Issue Labeler](https://github.com/marketplace/actions/simple-issue-labeler) GH action to automatically add the label `triage` to every opened issue or PR.

It also adapts the Stale GH action to avoid marking as "stale" issues/PRs that meet on of the requirements below:

1. It has the `backlog` label: issue/pr included in the project roadmap.
2. It has the `triage` label: issue/pr that needs to be reviewed.

**Benefits**

It makes maintainers' lives easier. 🙂 

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A
