### PR TITLE
Do not add 'stale' label to issues marked as 'help wanted'

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,6 +17,6 @@ jobs:
           close-pr-message: 'Due to the lack of activity in the last 7 days since it was marked as "stale", we proceed to close this Pull Request. Do not hesitate to reopen it later if necessary.'
           days-before-stale: 15
           days-before-close: 7
-          exempt-issue-labels: 'backlog,triage'
-          exempt-pr-labels: 'backlog,triage'
+          exempt-issue-labels: 'backlog,help wanted,triage'
+          exempt-pr-labels: 'backlog,help wanted,triage'
           operations-per-run: 500


### PR DESCRIPTION
**Description of the change**

This PR adapts the Stale GH action to avoid marking as "stale" issues/PRs that are labeled with `help wanted`.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A
