### PR TITLE
Fix image pull secrets in chart

### DIFF
--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -18,9 +18,11 @@ spec:
         {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.image.pullSecret }}
+      {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
-        - name: {{ .Values.image.pullSecret }}
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
       {{- end }}
       {{- if .Values.affinity }}
       affinity: {{- toYaml .Values.affinity | nindent 8 }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

The `image.pullSecrets` parameter is an array but we're wrongly treating it as a string. This PR address this.

**Benefits**

Users can set a custom a list of image pull secrets.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A
