### PR TITLE
Added required resourceName to Role

### DIFF
--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -16,4 +16,4 @@ maintainers:
     email: mmikulicic@gmail.com
 name: sealed-secrets
 type: application
-version: 2.1.2
+version: 2.1.3

--- a/helm/sealed-secrets/templates/role.yaml
+++ b/helm/sealed-secrets/templates/role.yaml
@@ -45,6 +45,7 @@ rules:
       - ""
     resourceNames:
       - 'http:{{ include "sealed-secrets.fullname" . }}:'
+      - 'http:{{ include "sealed-secrets.fullname" . }}:http'
       - {{ include "sealed-secrets.fullname" . }}
     resources:
       - services/proxy


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Added necessary resourceName in Role when "RBAC create" is used.
Without this Change i got this error from kubeseal (client)
```
error: cannot fetch certificate: services "http:sealed-secrets-controller:http" is forbidden: User "XXXXXXX" cannot get resource "services/proxy" in API group "" in the namespace "sealed-secrets"
```
Eventually caused by 
- fixes #648
<!-- Describe the scope of your change - i.e. what the change does. -->
