### PR TITLE
Allow setting of the clusterrolename for multiple instances of sealed…

### DIFF
--- a/helm/sealed-secrets/templates/cluster-role-binding.yaml
+++ b/helm/sealed-secrets/templates/cluster-role-binding.yaml
@@ -10,7 +10,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: secrets-unsealer
+  name: {{ .Values.rbac.clusterRoleName }}
 subjects:
   - apiGroup: ""
     kind: ServiceAccount

--- a/helm/sealed-secrets/templates/cluster-role.yaml
+++ b/helm/sealed-secrets/templates/cluster-role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: secrets-unsealer
+  name: {{ .Values.rbac.clusterRoleName }}
   labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
     {{- if .Values.rbac.labels }}
     {{- include "sealed-secrets.render" ( dict "value" .Values.rbac.labels "context" $) | nindent 4 }}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -259,6 +259,9 @@ rbac:
   ## @param rbac.pspEnabled PodSecurityPolicy
   ##
   pspEnabled: false
+  ## @param rbac.clusterRoleName Name of the clusterrole. To run multiple instances of sealed secrets with create RBAC true you need to set differnet rolenames.
+  ##
+  clusterRoleName: secrets-unsealer
 
 ## @section Metrics parameters
 


### PR DESCRIPTION
I use two instances in two different namespaces and RBAC creation fails for the instance in the second namespace. I use different service accounts, one for each namespace.
Overriding the RBAC cluster role name solves the issue.