### PR TITLE
Update VIB GitHub action repository

### DIFF
--- a/.github/workflows/helm-vib.yaml
+++ b/.github/workflows/helm-vib.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
-      - uses: vmware-samples/vmware-image-builder-examples/vib-action@main
+      - uses: vmware-labs/vmware-image-builder-action@main
 
   # verify chart in multiple target platforms
   vib-k8s-verify:
@@ -45,7 +45,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - uses: vmware-samples/vmware-image-builder-examples/vib-action@main
+      - uses: vmware-labs/vmware-image-builder-action@main
         with:
           pipeline: vib-platform-verify.json
         env:


### PR DESCRIPTION
**Description of the change**

Update VIB GitHub action to point to the latest repository. The previous repository will be archived and "vmware-labs/vmware-image-builder-action" is the main one.
