### PR TITLE
Helm chart - add support for customizing probes

### DIFF
--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -16,4 +16,4 @@ maintainers:
     email: mmikulicic@gmail.com
 name: sealed-secrets
 type: application
-version: 2.1.3
+version: 2.1.4

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -94,6 +94,27 @@ The command removes all the Kubernetes components associated with the chart and 
 | `keyrenewperiod`                                  | Specifies key renewal period. Default 30 days                                        | `""`                                |
 | `command`                                         | Override default container command                                                   | `[]`                                |
 | `args`                                            | Override default container args                                                      | `[]`                                |
+| `livenessProbe.enabled`                           | Enable livenessProbe on Sealed Secret containers                                     | `true`                              |
+| `livenessProbe.initialDelaySeconds`               | Initial delay seconds for livenessProbe                                              | `0`                                 |
+| `livenessProbe.periodSeconds`                     | Period seconds for livenessProbe                                                     | `10`                                |
+| `livenessProbe.timeoutSeconds`                    | Timeout seconds for livenessProbe                                                    | `1`                                 |
+| `livenessProbe.failureThreshold`                  | Failure threshold for livenessProbe                                                  | `3`                                 |
+| `livenessProbe.successThreshold`                  | Success threshold for livenessProbe                                                  | `1`                                 |
+| `readinessProbe.enabled`                          | Enable readinessProbe on Sealed Secret containers                                    | `true`                              |
+| `readinessProbe.initialDelaySeconds`              | Initial delay seconds for readinessProbe                                             | `0`                                 |
+| `readinessProbe.periodSeconds`                    | Period seconds for readinessProbe                                                    | `10`                                |
+| `readinessProbe.timeoutSeconds`                   | Timeout seconds for readinessProbe                                                   | `1`                                 |
+| `readinessProbe.failureThreshold`                 | Failure threshold for readinessProbe                                                 | `3`                                 |
+| `readinessProbe.successThreshold`                 | Success threshold for readinessProbe                                                 | `1`                                 |
+| `startupProbe.enabled`                            | Enable startupProbe on Sealed Secret containers                                      | `false`                             |
+| `startupProbe.initialDelaySeconds`                | Initial delay seconds for startupProbe                                               | `0`                                 |
+| `startupProbe.periodSeconds`                      | Period seconds for startupProbe                                                      | `10`                                |
+| `startupProbe.timeoutSeconds`                     | Timeout seconds for startupProbe                                                     | `1`                                 |
+| `startupProbe.failureThreshold`                   | Failure threshold for startupProbe                                                   | `3`                                 |
+| `startupProbe.successThreshold`                   | Success threshold for startupProbe                                                   | `1`                                 |
+| `customLivenessProbe`                             | Custom livenessProbe that overrides the default one                                  | `{}`                                |
+| `customReadinessProbe`                            | Custom readinessProbe that overrides the default one                                 | `{}`                                |
+| `customStartupProbe`                              | Custom startupProbe that overrides the default one                                   | `{}`                                |
 | `resources.limits`                                | The resources limits for the Sealed Secret containers                                | `{}`                                |
 | `resources.requests`                              | The requested resources for the Sealed Secret containers                             | `{}`                                |
 | `podSecurityContext.enabled`                      | Enabled Sealed Secret pods' Security Context                                         | `true`                              |

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -67,14 +67,29 @@ spec:
           ports:
             - containerPort: 8080
               name: http
-          livenessProbe:
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe: {{- include "sealed-secrets.render" (dict "value" (omit .Values.startupProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: http
+          {{- else if .Values.customStartupProbe }}
+          startupProbe: {{- include "sealed-secrets.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe: {{- include "sealed-secrets.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /healthz
               port: http
-          readinessProbe:
+          {{- else if .Values.customLivenessProbe }}
+          livenessProbe: {{- include "sealed-secrets.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe: {{- include "sealed-secrets.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /healthz
               port: http
+          {{- else if .Values.customReadinessProbe }}
+          readinessProbe: {{- include "sealed-secrets.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -63,6 +63,59 @@ command: []
 ## @param args Override default container args
 ##
 args: []
+## Configure extra options for Sealed Secret containers' liveness, readiness and startup probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+## @param livenessProbe.enabled Enable livenessProbe on Sealed Secret containers
+## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+## @param livenessProbe.periodSeconds Period seconds for livenessProbe
+## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+## @param livenessProbe.failureThreshold Failure threshold for livenessProbe
+## @param livenessProbe.successThreshold Success threshold for livenessProbe
+##
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 3
+  successThreshold: 1
+## @param readinessProbe.enabled Enable readinessProbe on Sealed Secret containers
+## @param readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+## @param readinessProbe.periodSeconds Period seconds for readinessProbe
+## @param readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+## @param readinessProbe.failureThreshold Failure threshold for readinessProbe
+## @param readinessProbe.successThreshold Success threshold for readinessProbe
+##
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 3
+  successThreshold: 1
+## @param startupProbe.enabled Enable startupProbe on Sealed Secret containers
+## @param startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+## @param startupProbe.periodSeconds Period seconds for startupProbe
+## @param startupProbe.timeoutSeconds Timeout seconds for startupProbe
+## @param startupProbe.failureThreshold Failure threshold for startupProbe
+## @param startupProbe.successThreshold Success threshold for startupProbe
+##
+startupProbe:
+  enabled: false
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 3
+  successThreshold: 1
+## @param customLivenessProbe Custom livenessProbe that overrides the default one
+##
+customLivenessProbe: {}
+## @param customReadinessProbe Custom readinessProbe that overrides the default one
+##
+customReadinessProbe: {}
+## @param customStartupProbe Custom startupProbe that overrides the default one
+##
+customStartupProbe: {}
 ## Sealed Secret resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ## @param resources.limits [object] The resources limits for the Sealed Secret containers


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR adds support for customizing probes (readiness/liveness/startup) in the chart.

**Benefits**

Customization

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A
