### PR TITLE
Fix linter errors running golangci-lint

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -68,7 +68,7 @@ type Controller struct {
 func NewController(clientset kubernetes.Interface, ssclientset ssclientset.Interface, ssinformer ssinformer.SharedInformerFactory, keyRegistry *KeyRegistry) *Controller {
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 
-	ssscheme.AddToScheme(scheme.Scheme)
+	utilruntime.Must(ssscheme.AddToScheme(scheme.Scheme))
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(log.Printf)
 	eventBroadcaster.StartRecordingToSink(&v1.EventSinkImpl{Interface: clientset.CoreV1().Events("")})

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -65,7 +65,7 @@ func init() {
 	buildinfo.FallbackVersion(&VERSION, buildinfo.DefaultVersion)
 
 	flag.DurationVar(keyRenewPeriod, "rotate-period", defaultKeyRenewPeriod, "")
-	flag.CommandLine.MarkDeprecated("rotate-period", "please use key-renew-period instead")
+	_ = flag.CommandLine.MarkDeprecated("rotate-period", "please use key-renew-period instead")
 
 	flagenv.SetFlagsFromEnv(flagEnvPrefix, goflag.CommandLine)
 	pflagenv.SetFlagsFromEnv(flagEnvPrefix, flag.CommandLine)
@@ -74,7 +74,7 @@ func init() {
 	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	if f := flag.CommandLine.Lookup("logtostderr"); f != nil {
 		f.DefValue = "true"
-		f.Value.Set(f.DefValue)
+		_ = f.Value.Set(f.DefValue)
 	}
 }
 
@@ -250,7 +250,7 @@ func main2() error {
 
 func main() {
 	flag.Parse()
-	goflag.CommandLine.Parse([]string{})
+	_ = goflag.CommandLine.Parse([]string{})
 
 	ssv1alpha1.AcceptDeprecatedV1Data = *acceptV1Data
 

--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -55,7 +55,11 @@ func TestInitKeyRegistry(t *testing.T) {
 	}
 
 	// Add a key to the controller for second test
-	registry.generateKey(ctx)
+	_, err = registry.generateKey(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if !hasAction(client, "create", "secrets") {
 		t.Fatalf("Error adding initial key to registry")
 	}

--- a/cmd/controller/server.go
+++ b/cmd/controller/server.go
@@ -39,7 +39,10 @@ func httpserver(cp certProvider, sc secretChecker, sr secretRotator) *http.Serve
 
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-		io.WriteString(w, "ok\n")
+		_, err := io.WriteString(w, "ok\n")
+		if err != nil {
+			log.Fatal(err)
+		}
 	})
 
 	mux.Handle("/metrics", promhttp.Handler())
@@ -84,7 +87,7 @@ func httpserver(cp certProvider, sc secretChecker, sr secretRotator) *http.Serve
 
 		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(newSecret)
+		_, _ = w.Write(newSecret)
 	})))
 
 	mux.Handle("/v1/cert.pem", Instrument("/v1/cert.pem", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -97,7 +100,7 @@ func httpserver(cp certProvider, sc secretChecker, sr secretRotator) *http.Serve
 
 		w.Header().Set("Content-Type", "application/x-pem-file")
 		for _, cert := range certs {
-			w.Write(pem.EncodeToMemory(&pem.Block{Type: certUtil.CertificateBlockType, Bytes: cert.Raw}))
+			_, _ = w.Write(pem.EncodeToMemory(&pem.Block{Type: certUtil.CertificateBlockType, Bytes: cert.Raw}))
 		}
 	})))
 

--- a/cmd/controller/server_test.go
+++ b/cmd/controller/server_test.go
@@ -31,6 +31,13 @@ func (c *testCertStore) setCert(cert *x509.Certificate) {
 	c.cert = cert
 }
 
+func shutdownServer(server *http.Server, t *testing.T) (){
+    err := server.Shutdown(context.Background())
+    if err != nil {
+        t.Fatal(err)
+    }
+}
+
 func TestHttpCert(t *testing.T) {
 	_, certBefore, err := generatePrivateKeyAndCert(2048)
 	if err != nil {
@@ -44,7 +51,7 @@ func TestHttpCert(t *testing.T) {
 
 	cs := &testCertStore{}
 	server := httpserver(cs.getCert, nil, nil)
-	defer server.Shutdown(context.Background())
+	defer shutdownServer(server, t)
 	hp := *listenAddr
 	if strings.HasPrefix(hp, ":") {
 		hp = fmt.Sprintf("localhost%s", hp)

--- a/cmd/controller/signal_notwin.go
+++ b/cmd/controller/signal_notwin.go
@@ -9,7 +9,7 @@ import (
 )
 
 func initKeyGenSignalListener(trigger func()) {
-	sigChannel := make(chan os.Signal)
+	sigChannel := make(chan os.Signal, 1)
 	signal.Notify(sigChannel, syscall.SIGUSR1)
 	go func() {
 		for {

--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -87,7 +87,7 @@ func init() {
 	flag.Var(&sealingScope, "scope", "Set the scope of the sealed secret: strict, namespace-wide, cluster-wide (defaults to strict). Mandatory for --raw, otherwise the 'sealedsecrets.bitnami.com/cluster-wide' and 'sealedsecrets.bitnami.com/namespace-wide' annotations on the input secret can be used to select the scope.")
 	flag.BoolVar(&reEncrypt, "rotate", false, "")
 	flag.BoolVar(&reEncrypt, "re-encrypt", false, "Re-encrypt the given sealed secret to use the latest cluster key.")
-	flag.CommandLine.MarkDeprecated("rotate", "please use --re-encrypt instead")
+	_ = flag.CommandLine.MarkDeprecated("rotate", "please use --re-encrypt instead")
 
 	flagenv.SetFlagsFromEnv(flagEnvPrefix, goflag.CommandLine)
 
@@ -410,7 +410,7 @@ func resourceOutput(out io.Writer, codecs runtimeserializer.CodecFactory, gv run
 	if err != nil {
 		return err
 	}
-	out.Write(buf)
+	_, _ = out.Write(buf)
 	fmt.Fprint(out, "\n")
 	return nil
 }
@@ -653,7 +653,7 @@ func run(ctx context.Context, w io.Writer, inputFileName, outputFileName, secret
 		// only write the output file if the run function exits without errors.
 		defer func() {
 			if err == nil {
-				f.CloseAtomicallyReplace()
+				_ = f.CloseAtomicallyReplace()
 			}
 		}()
 
@@ -741,7 +741,7 @@ func run(ctx context.Context, w io.Writer, inputFileName, outputFileName, secret
 
 func main() {
 	flag.Parse()
-	goflag.CommandLine.Parse([]string{})
+	_ = goflag.CommandLine.Parse([]string{})
 
 	if err := run(context.Background(), os.Stdout, *inputFileName, *outputFileName, *secretName, *controllerNs, *controllerName, *certURL, *printVersion, *validateSecret, reEncrypt, *dumpCert, *raw, *allowEmptyData, *fromFile, *mergeInto, *unseal, *privKeys); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/cmd/kubeseal/main_test.go
+++ b/cmd/kubeseal/main_test.go
@@ -84,7 +84,7 @@ func TestMain(m *testing.M) {
 	goflag.Parse()
 
 	// otherwise we'd require a working KUBECONFIG file when calling `run`.
-	flag.CommandLine.Parse([]string{"-n", "default"})
+	_ = flag.CommandLine.Parse([]string{"-n", "default"})
 	os.Exit(m.Run())
 }
 
@@ -478,7 +478,10 @@ func TestUnseal(t *testing.T) {
 		t.Fatal("assuming only one test key-pair")
 	}
 	for _, key := range privKeys {
-		pem.Encode(pkFile, &pem.Block{Type: keyutil.RSAPrivateKeyBlockType, Bytes: x509.MarshalPKCS1PrivateKey(key)})
+		err := pem.Encode(pkFile, &pem.Block{Type: keyutil.RSAPrivateKeyBlockType, Bytes: x509.MarshalPKCS1PrivateKey(key)})
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 	pkFile.Close()
 

--- a/pkg/apis/sealed-secrets/v1alpha1/register.go
+++ b/pkg/apis/sealed-secrets/v1alpha1/register.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 // GroupName is the group name used in this package
@@ -21,7 +22,7 @@ var (
 )
 
 func init() {
-	SchemeBuilder.AddToScheme(scheme.Scheme)
+	utilruntime.Must(SchemeBuilder.AddToScheme(scheme.Scheme))
 }
 
 // Resource takes an unqualified resource and returns a Group qualified GroupResource


### PR DESCRIPTION
**Description of the change**

Fix all the errors listed executing golangci-lint

- Remove unused functions disabledTestRoundTrip and ssecretFuzzerFuncs
- AddToScheme return is not checked
- use buf.String() instead of string(buf.Bytes())
- Error return values is not checked

**Benefits**

Prepare the code to have no linter errors 
