### PR TITLE
Document use of --controller-name for kubeseal

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,14 @@ affecting the static YAML manifests or the controller image itself.
 NOTE: the helm chart readme still contains a deprecation notice, but it's no longer reflects reality
 and will be removed upon next release.
 
+NOTE: the helm chart by default installs the controller with the name `sealed-secrets`, while the `kubeseal` command line interface (CLI) tries to access the controller with the name `sealed-secrets-controller`. You can explicitly pass `--controller-name` to the CLI:
+
+```bash
+kubeseal --controller-name sealed-secrets <args>
+```
+
+Alternatively, you can override `fullnameOverride` on the helm chart install.
+
 ### Operator Framework
 
 Install Sealed Secrets as Kubernetes Operator via the Operator Lifecycle Manager of your cluster. The `Sealed Secrets Operator (Helm)` is published at [OperatorHub.io](https://operatorhub.io/operator/sealed-secrets-operator-helm) for Kubernetes, as community operator in OpenShift's integrated OperatorHub or at the [GitHub repository](https://github.com/disposab1e/sealed-secrets-operator-helm) of the project.

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -215,6 +215,14 @@ kubeseal --fetch-cert \
 
 Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-labs/sealed-secrets#usage).
 
+NOTE: the helm chart by default installs the controller with the name `sealed-secrets`, while the `kubeseal` command line interface (CLI) tries to access the controller with the name `sealed-secrets-controller`. You can explicitly pass `--controller-name` to the CLI:
+
+```bash
+kubeseal --controller-name sealed-secrets <args>
+```
+
+Alternatively, you can override `fullnameOverride` on the helm chart install.
+
 ## Configuration and installation details
 
 - In the case that **serviceAccount.create** is `false` and **rbac.create** is `true` it is expected for a ServiceAccount with the name **serviceAccount.name** to exist _in the same namespace as this chart_ before the installation.


### PR DESCRIPTION
...particularly in regards to mismatch in the default
name installed by the helm chart versus that implicitly used
by kubeseal by default.

Closes #767

Signed-off-by: Brad Solomon <81818815+brsolomon-deloitte@users.noreply.github.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
