### PR TITLE
New v0.17.4 release

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,6 +9,7 @@ Latest release:
 ### Changelog
 
 - Fix linter errors running golangci-lint ([#751](https://github.com/bitnami-labs/sealed-secrets/pull/751))([#771](https://github.com/bitnami-labs/sealed-secrets/pull/771))
+- Added kubeseal support for darwin/arm64 ([#752](https://github.com/bitnami-labs/sealed-secrets/pull/752))
 
 ## v0.17.3
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,6 +4,12 @@ Latest release:
 
 [![](https://img.shields.io/github/release/bitnami-labs/sealed-secrets.svg)](https://github.com/bitnami-labs/sealed-secrets/releases/latest)
 
+## v0.17.4
+
+### Changelog
+
+- Fix linter errors running golangci-lint ([#751](https://github.com/bitnami-labs/sealed-secrets/pull/751))([#771](https://github.com/bitnami-labs/sealed-secrets/pull/771))
+
 ## v0.17.3
 
 ### Changelog


### PR DESCRIPTION
**Description of the change**

Update the Release Notes so we can trigger a new release v0.17.4 including the linter fixes added at https://github.com/bitnami-labs/sealed-secrets/pull/751 and https://github.com/bitnami-labs/sealed-secrets/pull/771.

**Benefits**

New release