### PR TITLE
Set up temporally the release go version in 1.16.13

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.16.13
       - name: Setup kubecfg
         run: |
           mkdir -p ~/bin


### PR DESCRIPTION
**Description of the change**

Temporally fix to avoid releasing errors with 1.16.4:

```
Error: ../../../go/pkg/mod/sigs.k8s.io/json@v0.0.0-20211020170558-c049b76a60c6/internal/golang/encoding/json/encode.go:1249:12: sf.IsExported undefined (type reflect.StructField has no field or method IsExported)
Error: ../../../go/pkg/mod/sigs.k8s.io/json@v0.0.0-20211020170558-c049b76a60c6/internal/golang/encoding/json/encode.go:1255:18: sf.IsExported undefined (type reflect.StructField has no field or method IsExported)
```

**Benefits**

Have releases

**Additional information**

Future PR bumping the project to 1.17. It seems that it is a problem with the json/encoding library solved bumping the golang version.
