### PR TITLE
fixing Dockerfile to run as non root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM gcr.io/distroless/static@sha256:c6d5981545ce1406d33e61434c61e9452dad93ecd8397c41e89036ef977a88f4
 LABEL maintainer "Bitnami <containers@bitnami.com>, Marko Mikulicic <mmikulicic@gmail.com>"
 
+USER 1001
+
 ARG TARGETARCH
 COPY dist/controller_linux_$TARGETARCH/controller /usr/local/bin/
 


### PR DESCRIPTION
**Description of the change**

The docker container runs as root which represents a security issue (vulnerability DS002 trivy -->https://avd.aquasec.com/misconfig/dockerfile/ds002/).

we added a USER statement in the Dockerfile with UID=1001.


**Benefits**

Running containers with ‘root’ user can lead to a container escape situation. It is a best practice to run containers as non-root users.

The container will now run as non-root, providing more security.


**Possible drawbacks**

No limitations detected, the container uses a static distroless image which is a minimal distribution that doesn't require root privileges to use ressources.


**Applicable issues**

The distroless image used is outdated; Even though it poses no security problem, an update to the latest version should be done


**Additional information**

All CI ckecks have passed
