### PR TITLE
Changing writefile permission in main.go:478 - Gosec G306

### DIFF
--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -473,7 +473,7 @@ func sealMergingInto(in io.Reader, filename string, codecs runtimeserializer.Cod
 	// The actual permissions will be filtered by the user's umask.
 	// We still drop any permissions to the other group because despite the sealed secret
 	// being encrypted, we still don't know how the end users feel about it.
-	return ioutil.WriteFile(filename, out.Bytes(), 0660)
+	return ioutil.WriteFile(filename, out.Bytes(), 0600)
 }
 
 func encryptSecretItem(w io.Writer, secretName, ns string, data []byte, scope ssv1alpha1.SealingScope, pubKey *rsa.PublicKey) error {


### PR DESCRIPTION
**Description of the change**

Changing the writefile permission in `/cmd/kubeseal/main.go` (line 478, function `sealMergingInto`) from 0660 to 0600.
```
[sealed-secrets/cmd/kubeseal/main.go:478] - G306 (CWE-276): Expect WriteFile permissions to be 0600 or less (Confidence
477: // being encrypted, we still don't know how the end users feel about it.
> 478: return ioutil.WriteFile(filename, out.Bytes(), 0660)
479: }
```

**Benefits**

This issue if flagged by gosec as a **poor file permissions used when writing to a new file** because of the 0660 writefile permission. Changing the permission to 0600 should ensure that access and modification attributes to the file is only for the user that require those actions.

https://cwe.mitre.org/data/definitions/276.html

**Possible drawbacks**

None discovered so far.

**Additional information**

All CI checks passed successfully.
