### PR TITLE
Fixing the deprecated MAINTAINER usage

### DIFF
--- a/vendor_jsonnet/kube-libsonnet/tests/Dockerfile
+++ b/vendor_jsonnet/kube-libsonnet/tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM bitnami/minideb:buster
-MAINTAINER sre@bitnami.com
+LABEL org.opencontainers.image.authors="sre@bitnami.com"
 
 ARG jsonnet_version=0.14.0
 ARG kubectl_version=v1.13.0


### PR DESCRIPTION
**Description of the change**

This pull request fixes the deprecated usage of the MAINTAINER label in `vendor_jsonnet/kube-libsonnet/tests/Dockerfile`.

**Benefits**

Removing a deprecated element from the Dockerfile it was in.

**Possible drawbacks**

None, this is just a informative label

**Applicable issues**

No issue associated with this PR.

**Additional information**
[Official documentation mention of the deprecated MAINTAINER label usage](https://docs.docker.com/engine/deprecated/#maintainer-in-dockerfile)

Running trivy after the patch doesn't raise the warning again.
`trivy . conf` output before the patch
```
+---------------------------+------------+----------------------------+----------+------------------------------------------+
|           TYPE            | MISCONF ID |           CHECK            | SEVERITY |                 MESSAGE                  |
+---------------------------+------------+----------------------------+----------+------------------------------------------+
| Dockerfile Security Check |   DS022    | Deprecated MAINTAINER used |   HIGH   | MAINTAINER should not be used:           |
|                           |            |                            |          | 'MAINTAINER sre@bitnami.com'             |
|                           |            |                            |          | -->avd.aquasec.com/appshield/ds022       |
+---------------------------+------------+----------------------------+----------+------------------------------------------+
```
