### PR TITLE
gosec G307: Deferring unsafe method "Close" on type "*os.File"

### DIFF
--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -625,6 +625,7 @@ func run(ctx context.Context, w io.Writer, inputFileName, outputFileName, secret
 		if err != nil {
 			return nil
 		}
+		// #nosec: G307 -- this deferred close is fine because it is not on a writable file
 		defer f.Close()
 
 		input = f


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

A single comment ([nosec](https://github.com/securego/gosec#annotating-code)) is added to suppress the following result from `gosec`:

```
[/home/vivescere/Projects/sealed-secrets/cmd/kubeseal/main.go:628] - G307 (CWE-703): Deferring unsafe method "Close" on type "*os.File" (Confidence: HIGH, Severity: MEDIUM)
    627:                }
  > 628:                defer f.Close()
    629: 
```

This deferred call to `f.Close()` is fine since it isn't on a writable file - we don't need to ensure any change is persisted.

**Benefits**

<!-- What benefits will be realized by the code change? -->

Along with #786 and #788 (or #789, probably), this change will allow `gosec` to be integrated into the CI/CD pipeline.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

None that I know of.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

None

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

I did run the CI pipeline on my fork, and it completed without any problem.
