### PR TITLE
Gosec g304

### DIFF
--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -722,7 +722,7 @@ func run(ctx context.Context, w io.Writer, inputFileName, outputFileName, secret
 			}
 
 			_, filename := parseFromFile(fromFile[0])
-			data, err = ioutil.ReadFile(filename)
+			data, err = ioutil.ReadFile(filename) /* #nosec G304 -- Necessary for CLI Tool use */
 		} else {
 			if isatty.IsTerminal(os.Stdin.Fd()) {
 				fmt.Fprintf(os.Stderr, "(tty detected: expecting a secret to encrypt in stdin)\n")

--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -193,7 +193,8 @@ func openCertLocal(filenameOrURI string) (io.ReadCloser, error) {
 	if ok, err := isFilename(filenameOrURI); err != nil {
 		return nil, err
 	} else if ok {
-		return os.Open(filenameOrURI) /* #nosec G304 -- Necessary for CLI Tool use */
+		// #nosec G304 -- should open user provided file
+		return os.Open(filenameOrURI)
 	}
 	return openCertURI(filenameOrURI)
 }
@@ -428,7 +429,8 @@ func decodeSealedSecret(codecs runtimeserializer.CodecFactory, b []byte) (*ssv1a
 }
 
 func sealMergingInto(in io.Reader, filename string, codecs runtimeserializer.CodecFactory, pubKey *rsa.PublicKey, scope ssv1alpha1.SealingScope, allowEmptyData bool) error {
-	b, err := ioutil.ReadFile(filename) /* #nosec G304 -- Necessary for CLI Tool use */
+	// #nosec G304 -- should open user provided file
+	b, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return err
 	}
@@ -499,7 +501,8 @@ func parseFromFile(s string) (string, string) {
 }
 
 func readPrivKeysFromFile(filename string) ([]*rsa.PrivateKey, error) {
-	b, err := ioutil.ReadFile(filename) /* #nosec G304 -- Necessary for CLI Tool use */
+	// #nosec G304 -- should open user provided file
+	b, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -621,7 +624,8 @@ func run(ctx context.Context, w io.Writer, inputFileName, outputFileName, secret
 
 	var input io.Reader = os.Stdin
 	if inputFileName != "" {
-		f, err := os.Open(inputFileName) /* #nosec G304 -- Necessary for CLI Tool use */
+		// #nosec G304 -- should open user provided file
+		f, err := os.Open(inputFileName)
 		if err != nil {
 			return nil
 		}
@@ -722,7 +726,8 @@ func run(ctx context.Context, w io.Writer, inputFileName, outputFileName, secret
 			}
 
 			_, filename := parseFromFile(fromFile[0])
-			data, err = ioutil.ReadFile(filename) /* #nosec G304 -- Necessary for CLI Tool use */
+			// #nosec G304 -- should open user provided file
+			data, err = ioutil.ReadFile(filename)
 		} else {
 			if isatty.IsTerminal(os.Stdin.Fd()) {
 				fmt.Fprintf(os.Stderr, "(tty detected: expecting a secret to encrypt in stdin)\n")

--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -499,7 +499,7 @@ func parseFromFile(s string) (string, string) {
 }
 
 func readPrivKeysFromFile(filename string) ([]*rsa.PrivateKey, error) {
-	b, err := ioutil.ReadFile(filename)
+	b, err := ioutil.ReadFile(filename) /* #nosec G304 -- Necessary for CLI Tool use */
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -193,7 +193,7 @@ func openCertLocal(filenameOrURI string) (io.ReadCloser, error) {
 	if ok, err := isFilename(filenameOrURI); err != nil {
 		return nil, err
 	} else if ok {
-		return os.Open(filenameOrURI)
+		return os.Open(filenameOrURI) /* #nosec G304 -- Necessary for CLI Tool use */
 	}
 	return openCertURI(filenameOrURI)
 }

--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -428,7 +428,7 @@ func decodeSealedSecret(codecs runtimeserializer.CodecFactory, b []byte) (*ssv1a
 }
 
 func sealMergingInto(in io.Reader, filename string, codecs runtimeserializer.CodecFactory, pubKey *rsa.PublicKey, scope ssv1alpha1.SealingScope, allowEmptyData bool) error {
-	b, err := ioutil.ReadFile(filename)
+	b, err := ioutil.ReadFile(filename) /* #nosec G304 -- Necessary for CLI Tool use */
 	if err != nil {
 		return err
 	}

--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -621,7 +621,7 @@ func run(ctx context.Context, w io.Writer, inputFileName, outputFileName, secret
 
 	var input io.Reader = os.Stdin
 	if inputFileName != "" {
-		f, err := os.Open(inputFileName)
+		f, err := os.Open(inputFileName) /* #nosec G304 -- Necessary for CLI Tool use */
 		if err != nil {
 			return nil
 		}


### PR DESCRIPTION
**Description of the change**
Added comments to ignore gosec potential file inclusion issue. 
These potential issues can be ignored because of their use in cli.

**Benefits**
Silent gosec wrong file inclusion issue. 
This is necessary to integrate gosec to the CI.

**Possible drawbacks**


**Applicable issues**


**Additional information**
