### PR TITLE
Add cosign verification for distroless image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install Cosign
-      uses: sigstore/cosign-installer@main
+      uses: sigstore/cosign-installer@v2.1.0
 
     - name: Distroless verify
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,13 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@main
+
+    - name: Distroless verify
+      run: |
+        cosign verify --key "https://raw.githubusercontent.com/GoogleContainerTools/distroless/main/cosign.pub" "$(grep FROM Dockerfile | awk '{print $2}')"
+
     - name: Setup kubecfg
       run: |
         mkdir -p ~/bin


### PR DESCRIPTION
Co-authored-by: Nicolas Bourras <pro@nicolasb.fr>

**Description of the change**

When looking at the `Dockerfile`, we noticed that the source image was used without any verification. The distroless documentation offers a way [to verify the images](https://github.com/GoogleContainerTools/distroless#how-do-i-verify-distroless-images) that are produced.

This commit adds a new task to the **CI** that uses `cosign` in order to verify the signature of the image. To install this tool, the [cosign-installer](https://github.com/marketplace/actions/cosign-installer) action is used.

**Benefits**

- We make sure that the source distroless image is genuine.

- the signature is downloaded from the [distroless repo](https://github.com/GoogleContainerTools/distroless/blob/main/cosign.pub), so if this file is changed, the CI might fail.

**Possible drawbacks**

- the CI might take a bit longer to run.

**Applicable issues**

None

**Additional information**

For the github Action, I've opened [this issue](https://github.com/sigstore/cosign-installer/issues/67) to ask sigstore to verify their action in the github marketstore.