### PR TITLE
Added a way to run gosec using a Makefile task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ lint:
 	 $(GOLANGCILINT) run --timeout=5m
 
 lint-gosec:
-	 $(GOSEC) -r
+	 $(GOSEC) -r --severity medium
 
 clean:
 	$(RM) ./controller ./kubeseal

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 GO = go
 GOFMT = gofmt
 GOLANGCILINT=golangci-lint
+GOSEC=gosec
 
 export GO111MODULE = on
 GO_FLAGS =
@@ -113,10 +114,13 @@ fmt:
 lint:
 	 $(GOLANGCILINT) run --timeout=5m
 
+lint-gosec:
+	 $(GOSEC) -r
+
 clean:
 	$(RM) ./controller ./kubeseal
 	$(RM) *-static*
 	$(RM) controller*.yaml
 	$(RM) controller.image*
 
-.PHONY: all kubeseal controller test clean vet fmt
+.PHONY: all kubeseal controller test clean vet fmt lint-gosec


### PR DESCRIPTION
**Description of the change**

This PR adds a new task to the Makefile: `lint-gosec`. It runs the [gosec tool](https://github.com/securego/gosec), which analyzes the go code present in the repository to find security problems. Since the task isn't included in the CI or anything else, it's up to developers to run this task manually for now.

**Benefits**

We add a number of lints to the project - making it more secure. Using a simple make task makes it easy for developers to run the tool locally. Furthermore, this PR opens the way for other PRs which could add this task to the CI, or make it run in a git hook.

**Possible drawbacks**

- the default severity of the tool is `low`, but this PR sets it to `medium` ; this might still generate too much false positives
- the `golangci-lint` tool is not used, see the section below
- it does require a new dependency for developers who want to run the linter

**Applicable issues**

None

**Additional information**

The CI pipeline still works properly on my fork.

Currently, the tool reports 8 errors, but other PRs have been created with fixes.

***Why isn't `gosec` added using `golangci-lint`?***

At first, we tried to configure `golangci-lint` to run this new tool. However, we ran into a few issues:

- by default, the tool includes tests in the analyzed source code ; quite a few tests in this repo are using snippets that are flagged, for example :
  ```
  [/home/vivescere/Projects/sealed-secrets/pkg/crypto/keys_test.go:20] - G403 (CWE-310): RSA keys should be at least 2048 bits (Confidence: HIGH, Severity: MEDIUM)
      19: 
    > 20:         key, err := rsa.GenerateKey(rand, 512)
      21:         if err != nil {
  ```
  ...but this is completely fine. The only way to change this behavior is by creating a configuration file, which affects **all** of the other linters.
- the default filters are quite aggressive, a few errors that were fixed in other PRs were simply not showing up. Once again, the configuration could be edited to discard the filters, but all of the other linters would have been affected as well.

Overall, we feel like it is easier to include gosec in a separate task.

Co-authored-by: JeNeComprendPas <nicolas04150@hotmail.fr>