### PR TITLE
Made gosec a step of the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         go: ["1.17.8", "1.18.0"]
         os: [ubuntu-latest]
         golangci-lint: ["1.44.2"]
+        gosec: ["2.11.0"]
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
@@ -31,6 +32,7 @@ jobs:
     - name: Install dependencies
       run: |
         go install github.com/golangci/golangci-lint/cmd/golangci-lint@v${{ matrix.golangci-lint }}
+        go install github.com/securego/gosec/v2/cmd/gosec@v${{ matrix.gosec }}
 
     - name: Run linter
       run: make lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.16", "1.17"]
+        go: ["1.17.8", "1.18.0"]
         os: [ubuntu-latest]
         gosec: ["2.11.0"]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^${{ matrix.go }}
+        go-version: ${{ matrix.go }}
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
         go: ["1.17.8", "1.18.0"]
         os: [ubuntu-latest]
         golangci-lint: ["1.44.2"]
-        gosec: ["2.11.0"]
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
@@ -32,10 +31,34 @@ jobs:
     - name: Install dependencies
       run: |
         go install github.com/golangci/golangci-lint/cmd/golangci-lint@v${{ matrix.golangci-lint }}
-        go install github.com/securego/gosec/v2/cmd/gosec@v${{ matrix.gosec }}
 
     - name: Run linter
       run: make lint
+
+  gosec:
+    name: Run gosec
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: ["1.16", "1.17"]
+        os: [ubuntu-latest]
+        gosec: ["2.11.0"]
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^${{ matrix.go }}
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: |
+        go install github.com/securego/gosec/v2/cmd/gosec@v${{ matrix.gosec }}
+
+    - name: Run gosec
+      run: make lint-gosec
 
   test:
     name: Build

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,9 @@ lint:
 lint-gosec:
 	 $(GOSEC) -r --severity medium
 
+lint-gosec:
+	 $(GOSEC) -r
+
 clean:
 	$(RM) ./controller ./kubeseal
 	$(RM) *-static*

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ lint-gosec:
 	 $(GOSEC) -r --severity medium
 
 lint-gosec:
-	 $(GOSEC) -r
+	 $(GOSEC) -r --severity medium
 
 clean:
 	$(RM) ./controller ./kubeseal

--- a/Makefile
+++ b/Makefile
@@ -117,9 +117,6 @@ lint:
 lint-gosec:
 	 $(GOSEC) -r --severity medium
 
-lint-gosec:
-	 $(GOSEC) -r --severity medium
-
 clean:
 	$(RM) ./controller ./kubeseal
 	$(RM) *-static*


### PR DESCRIPTION
**Description of the change**

This PR depends on #797. It adds the previously added Makefile task `lint-gosec` as a dependency of the `lint` task. This makes the gosec tool run whenever `make lint` is invoked. **This has the effect of adding `gosec` to the CI pipeline**, which runs this command.

**Benefits**

It prevents bad code snippets that gosec detects from reaching the repository.

**Possible drawbacks**

- the CI pipeline might take slightly longer to run
- there may be too many false positives
- the CI pipeline **will** fail at the moment I'm writing this, since gosec still reports (8) errors

**Applicable issues**

None

**Additional information**

I'm not too sure I've done "stacked PRs" or "dependent PRs" correctly.

Other PRs have been created, which will fix some of the errors gosec reports: #795, #789, #793, #812. All errors should be fixed before merging this PR.