### PR TITLE
Run CI with the last two Go releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.17.8"]
+        go: ["1.17.8", "1.18.0"]
         os: [ubuntu-latest]
         golangci-lint: ["1.44.2"]
     steps:
@@ -40,7 +40,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: ["1.17.8"]
+        go: ["1.17.8", "1.18.0"]
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
 


### PR DESCRIPTION
It's a good idea to ensure that sealed-secrets builds correctly with the latest two major versions of Go