### PR TITLE
Cosign signature setup for release and docker image in CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      # Setup Cosign
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v2.1.0
+      - name: Write Cosign key
+        run: echo "$COSIGN_KEY" > /tmp/cosign.key
+        env:
+          COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
+
+
       # Build & Release binaries
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
@@ -53,6 +62,7 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
 
       # Build & Publish multi-arch image
       - name: Login to Quay

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,4 +79,11 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm
           push: true
           tags: ${{ env.image_name }}:latest,${{ env.image_name }}:${{ github.ref_name }}
-
+      - name: Sign image with a key
+        run: |
+          echo -n "$COSIGN_PASSWORD" | cosign sign --key /tmp/cosign.key $TAG_LATEST
+          echo -n "$COSIGN_PASSWORD" | cosign sign --key /tmp/cosign.key $TAG_CURRENT
+        env:
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          TAG_LATEST: ${{ env.image_name }}:latest
+          TAG_CURRENT: ${{ env.image_name }}:${{ github.ref_name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
 
       # Setup Cosign
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v2.1.0
+        uses: sigstore/cosign-installer@v2.3.0
       - name: Write Cosign key
         run: echo "$COSIGN_KEY" > /tmp/cosign.key
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,6 @@ jobs:
         env:
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
 
-
       # Build & Release binaries
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
@@ -81,8 +80,7 @@ jobs:
           tags: ${{ env.image_name }}:latest,${{ env.image_name }}:${{ github.ref_name }}
       - name: Sign image with a key
         run: |
-          echo -n "$COSIGN_PASSWORD" | cosign sign --key /tmp/cosign.key $TAG_LATEST
-          echo -n "$COSIGN_PASSWORD" | cosign sign --key /tmp/cosign.key $TAG_CURRENT
+          echo -n "$COSIGN_PASSWORD" | cosign sign --key /tmp/cosign.key $TAG_LATEST $TAG_CURRENT
         env:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           TAG_LATEST: ${{ env.image_name }}:latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,6 +40,16 @@ changelog:
       - '^helm:'
       - '^integration:'
       - '^vendor_jsonnet:'
+signs:
+  - cmd: cosign
+    stdin: '{{ .Env.COSIGN_PASSWORD }}'
+    output: true
+    artifacts: all
+    args:
+      - 'sign-blob'
+      - '--key=/tmp/cosign.key'
+      - '--output-signature=${signature}'
+      - '${artifact}'
 release:
   name_template: "{{ .ProjectName }}-v{{ .Version }}"
   header: |


### PR DESCRIPTION
**Be careful**, this PR have requirements to follow before merge it.

*The objective of this PR is to add a signature process for release and docker images to the sealed secret project, trough the CI.*
The signature process use [Cosign](https://github.com/sigstore/cosign) and the [Cosign installer action](https://github.com/sigstore/cosign-installer).

**Prerequisites**
You need to have cosign installed on your computer and generate a key pair.
According to cosign documentation, if you have Go 1.17+, you can setup a development environment:
```sh
$ git clone https://github.com/sigstore/cosign
$ cd cosign
$ go install ./cmd/cosign
$ (go env GOPATH)/bin/cosign
```

Then
```sh
$ cosign generate-key-pair
```

You have to put content of cosign.key in a github secret action named **COSIGN_KEY** and the password in a github secret action named **COSIGN_PASSWORD**

Once this is setup you have to put the public key in the repository, usually the path is **.github/workflows/cosign.pub**

**Description of the change**
Add signature to release, checksum and docker image (stored with metadata in the docker image on the registry).
This signature can be verified with

```sh
# For releases and checksum file
$ cosign verify-blob --key=url/to/public_key --signature <file>.sig <file>

# For docker image
$ cosign verify --key url/to/public_key <docker_image>
```

**Benefits**
Permit to users to verify provenance and integrity of files.

**Possible drawbacks**
If the private key is compromise, then it must be change and the public key also.

**Applicable issues**
- The CI fail if the secrets are not correctly filled in.
- #696 

**Additional information**
I don't write anything on the readme because I don't know where we can explain how to verify the signature of these contents. I am interested in proposals on this subject.

It might be a good idea to also consider signing the chart (you can do that directly with helm but you need a something like [keybase.io](https://keybase.io/)).

For the github Action, I've opened [this issue](https://github.com/sigstore/cosign-installer/issues/67) to ask sigstore to verify their action in the github marketstore.