### PR TITLE
gosec G111: Potential directory traversal

### DIFF
--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -204,6 +204,7 @@ func openCertURI(uri string) (io.ReadCloser, error) {
 	// and escape the filename properly.
 
 	t := &http.Transport{}
+	// #nosec: G111 -- we want to allow all files to be opened
 	t.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
 	c := &http.Client{Transport: t}
 


### PR DESCRIPTION
**Description of the change**

This PR adds a comment that removes a false positive from gosec output.

The `openCertURI` method in `cmd/kubeseal/main.go` handles the `file://` scheme. The function uses an http client:

```go
func openCertURI(uri string) (io.ReadCloser, error) {
        // [...]

        t := &http.Transport{}
	// #nosec: G111 -- we want to allow all files to be opened
	t.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
	c := &http.Client{Transport: t}

        // [...]
}
```

gosec flags the `http.Dir("/")` part, but here it is fine, since we want to (if I understood correctly) allow any file to be read.

**Benefits**

This will (along with other PRs) allow #798 to be merged.

**Possible drawbacks**

None.

**Applicable issues**

None

**Additional information**

None
