### PR TITLE
Updated the distroless image verification to use a local key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,12 @@ jobs:
 
     - name: Distroless verify
       run: |
-        cosign verify --key "https://raw.githubusercontent.com/GoogleContainerTools/distroless/main/cosign.pub" "$(grep FROM Dockerfile | awk '{print $2}')"
+        cosign verify --key /dev/stdin "$(grep FROM Dockerfile | awk '{print $2}')" <<EOF
+        -----BEGIN PUBLIC KEY-----
+        MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWZzVzkb8A+DbgDpaJId/bOmV8n7Q
+        OqxYbK0Iro6GzSmOzxkn+N2AKawLyXi84WSwJQBK//psATakCgAQKkNTAA==
+        -----END PUBLIC KEY-----
+        EOF
 
     - name: Setup kubecfg
       run: |


### PR DESCRIPTION
**Description of the change**

This PR improves on the recent #796 changes, by using a local key to verify the image instead of fetching it remotely.

**Benefits**

This makes the CI more reliable - it won't fail if the HTTP call fails. Additionally, if the key is ever rotated, it will have to be updated, which adds a manual step to the process, allowing developers to check that everything is still fine with the image.

**Possible drawbacks**

If the key is ever rotated, it will have to be updated.

**Applicable issues**

None

**Additional information**

The CI stills run fine on my fork.
