### PR TITLE
Enable goimports in golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ fmt:
 	$(GOFMT) -s -w $(GO_FILES)
 
 lint:
-	 $(GOLANGCILINT) run --timeout=5m
+	 $(GOLANGCILINT) run --enable goimports --timeout=5m
 
 lint-gosec:
 	 $(GOSEC) -r --severity medium


### PR DESCRIPTION
**Description of the change**
Enable `goimports` in `golangci-lint`.

**Benefits**
Ensure the code is properly formatted.

**Additional information**
Has to be rebased after merging #815