### PR TITLE
#791 Check if kubeseal encrypts using an expired certificate

### DIFF
--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/google/renameio"
 	"github.com/mattn/go-isatty"
@@ -127,6 +128,10 @@ func parseKey(r io.Reader) (*rsa.PublicKey, error) {
 	cert, ok := certs[0].PublicKey.(*rsa.PublicKey)
 	if !ok {
 		return nil, fmt.Errorf("Expected RSA public key but found %v", certs[0].PublicKey)
+	}
+
+	if time.Now().After(certs[0].NotAfter) {
+		return nil, fmt.Errorf("failed to encrypt using an expired certificate on %v", certs[0].NotBefore.Format("January 2, 2006"))
 	}
 
 	return cert, nil


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
There is a new check, which will give an error, if the user uses an expired cert. However, the existing sealed-secrets can still be decrypted.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
Expired certificates can no longer encrypt any secrets

**Possible drawbacks**
Users may have to renew any expired certificates

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #791

**Additional information**
mysecret.json
```
{
    "kind": "Secret",
    "apiVersion": "v1",
    "metadata": {
        "name": "mysecret",
        "creationTimestamp": null
    },
    "data": {
        "foo": "YmFy"
    }
}
```
```
# How to test it
## build the new binary
make kubeseal
## download an expired cert
openssl s_client -connect expired.badssl.com:443 -showcerts  </dev/null 2>/dev/null| openssl x509 -outform PEM > expired_cert.pem
## try encrypting a secret with an expired certificate
./kubeseal --scope cluster-wide -f mysecret.json --cert expired_cert.pem 
> error: failed to encrypt using an expired certificate on April 9, 2015
```
