### PR TITLE
Add helm signature

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -22,6 +22,20 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - name: Prepare GPG key
+        run: |
+          gpg_dir=/tmp/cr-gpg
+          mkdir "$gpg_dir"
+          keyring="$gpg_dir/secring.gpg"
+          base64 -d <<< "$GPG_KEYRING_BASE64" > "$keyring"
+          passphrase_file="$gpg_dir/passphrase"
+          echo "$GPG_PASSPHRASE" > "$passphrase_file"
+          echo "CR_PASSPHRASE_FILE=$passphrase_file" >> "$GITHUB_ENV"
+          echo "CR_KEYRING=$keyring" >> "$GITHUB_ENV"
+        env:
+          GPG_KEYRING_BASE64: "${{ secrets.GPG_KEYRING_BASE64 }}"
+          GPG_PASSPHRASE: "${{ secrets.GPG_PASSPHRASE }}"
+
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:
@@ -30,6 +44,7 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.1
         with:
+          config: cr.yaml
           charts_dir: helm
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,0 +1,2 @@
+sign: true
+key: sealed-secrets


### PR DESCRIPTION
**Be careful**, this PR have requirements to follow before merge it.

In this PR I recommend to use [Keybase.io](https://Keybase.io) to share keys. You can also use other solutions but you have to explain how exporting it and explain how import it.

# Prerequisites
## Setup
First of all you need to generate a new GPG key.
Assuming you use GnuPG:
```sh
# genere key
# Be careful, initially the name must be "sealed-secrets", see below to change it
$ gpg --full-gen-key # You can also use $ gpg --gen-key but you can't configure your key

# List all keys and target the desired key with it's fingerprint
$ gpg --list-secret-keys

$ gpg --output secring.gpg --export-secret-keys <fingerprint>
$ base64 -w0 secring.gpg > secring.gpg.base64
```

Then you have to create 2 new github secrets :
- **GPG_KEYRING_BASE64** with the content of the *secring.gpg.base64* file
- **GPG_PASSPHRASE** with the passphrase of the gpg key

If you would like to change the name of your key, you have to change it in the *cr.yaml* file

## Share the key
To permit users to verify the signature, you have to share the public key.

You can use, for example, [Keybase.io](https://Keybase.io) which allows you to share a key.
Before anything you have to install keybase cli client, you can find more informations [here](https://keybase.io/docs/the_app/install_linux). 
```sh
# If you're not already, you must log in to your account
$ keybase login

# Then, you can choose the generated key
$ keybase pgp select # add the --multi flag to have more than one key
```

# Verify the signature
Before verify the signature, users have to get the key.

```sh
$ keybase follow <bitnami_or_sealed-secrets_repo>
$ keybase pull 
```

**Warning**: As written [there](https://helm.sh/docs/topics/provenance/), the GnuPG v2 store your secret keyring using a new format kbx on the default location ~/.gnupg/pubring.kbx. Please use the following command to convert your keyring to the legacy gpg format:
```sh
# Public keys
$ gpg --export >~/.gnupg/pubring.gpg

# Your private keys
$ gpg --export-secret-keys >~/.gnupg/secring.gpg
```

To verify an helm package you have two choices:
- You can download the *chart.tgz* and *chart.tgz.prov* files and use
```sh
# You have both files <file>.tgz and <file>.tgz.prov in the same folder
$ helm verify chart.tgz
```

- You can also verify with the installation
```sh
$ helm install --verify my_release chart.tgz
# or, with the bitnami repository
$ helm install --verify <repo_name>/sealed-secrets
```
---
**Benefits**
Permit users to verify the helm chart when install it.

**Possible drawbacks**
None

**Applicable issues**
The CI fail if the secrets are not correctly filled in.

**Additional information**
I don't write anything on the readme because I don't know if [Keybase.io](https://Keybase.io) is the solution you want to use.

I would have liked the gpg to be generated with the previously generated cosign key. However currently helm only manages gpg keys. There is a [helm plugin](https://github.com/sigstore/cosign/issues/1118) who permit that
During my research I found [this PR](https://github.com/sigstore/cosign/pull/1144) and [this issue](https://github.com/sigstore/cosign/issues/1118) that concerns a cosign integration form helm. Unfortunatly it does not seem to be really finished, and has not been merged yet.

I thought of converting the cosign key into a gpg key, but the process is tedious (needs to create a csr, sign it, convert it into a GPG key, etc...)

Maybe this PR could change later, when an other solution will be availble.