### PR TITLE
Publish sealed-secret-controller in Dockerhub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 env:
-  CONTROLLER_IMAGE: quay.io/bitnami/sealed-secrets-controller:latest
+  CONTROLLER_IMAGE: docker.io/bitnami/sealed-secrets-controller:latest
 
 jobs:
   linter:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      image_name: quay.io/bitnami/sealed-secrets-controller
+      image_name: docker.io/bitnami/sealed-secrets-controller
     steps:
       # Checkout and set env
       - name: Checkout
@@ -55,12 +55,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Build & Publish multi-arch image
-      - name: Login to Quay
+      - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ KUBECFG = kubecfg
 DOCKER = docker
 GINKGO = ginkgo -p
 
-CONTROLLER_IMAGE = quay.io/bitnami/sealed-secrets-controller:latest
+CONTROLLER_IMAGE = docker.io/bitnami/sealed-secrets-controller:latest
 INSECURE_REGISTRY = false # useful for local registry
 IMAGE_PULL_POLICY = Always
 KUBECONFIG ?= $(HOME)/.kube/config

--- a/contrib/prometheus-mixin/README.md
+++ b/contrib/prometheus-mixin/README.md
@@ -65,7 +65,7 @@ This project includes a [PodMonitor](../../controller-podmonitor.jsonnet
 Compile jsonnet to yaml:
 ```
 $ make controller-podmonitor.yaml 
-kubecfg show -V CONTROLLER_IMAGE=quay.io/bitnami/sealed-secrets-controller:latest -V IMAGE_PULL_POLICY=Always -o yaml controller-podmonitor.jsonnet > controller-podmonitor.yaml.tmp
+kubecfg show -V CONTROLLER_IMAGE=docker.io/bitnami/sealed-secrets-controller:latest -V IMAGE_PULL_POLICY=Always -o yaml controller-podmonitor.jsonnet > controller-podmonitor.yaml.tmp
 mv controller-podmonitor.yaml.tmp controller-podmonitor.yaml
 ```
 


### PR DESCRIPTION
**Description of the change**

Publish the controller image in Dockerhub instead of Quay
