### PR TITLE
fix: rbac permission

### DIFF
--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -16,4 +16,4 @@ maintainers:
     email: mmikulicic@gmail.com
 name: sealed-secrets
 type: application
-version: 2.1.7
+version: 2.1.8

--- a/helm/sealed-secrets/templates/role.yaml
+++ b/helm/sealed-secrets/templates/role.yaml
@@ -37,6 +37,8 @@ metadata:
 rules:
   - apiGroups:
       - ""
+    resourceNames:
+      - {{ include "sealed-secrets.fullname" . }}
     resources:
       - services
     verbs:


### PR DESCRIPTION

**Description of the change**

add rbac name selector for get service permission in the helm chart.
I think this was missing in #715

Signed-off-by: Till Adam <lxmail@web.de>

**Benefits**

RBAC could be more restrictive

**Possible drawbacks**

none

**Applicable issues**

- fixes #827 

**Additional information**

none