### PR TITLE
Add runtimeClassName as configurable value

### DIFF
--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -16,4 +16,4 @@ maintainers:
     email: mmikulicic@gmail.com
 name: sealed-secrets
 type: application
-version: 2.1.6
+version: 2.1.7

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -126,6 +126,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `podLabels`                                       | Extra labels for Sealed Secret pods                                                  | `{}`                                |
 | `podAnnotations`                                  | Annotations for Sealed Secret pods                                                   | `{}`                                |
 | `priorityClassName`                               | Sealed Secret pods' priorityClassName                                                | `""`                                |
+| `runtimeClassName`                                | Sealed Secret pods' runtimeClassName                                                 | `""`                                |
 | `affinity`                                        | Affinity for Sealed Secret pods assignment                                           | `{}`                                |
 | `nodeSelector`                                    | Node labels for Sealed Secret pods assignment                                        | `{}`                                |
 | `tolerations`                                     | Tolerations for Sealed Secret pods assignment                                        | `[]`                                |

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: {{ .Values.runtimeClassName | quote }}
+      {{- end }}
       {{- if .Values.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -155,6 +155,9 @@ podAnnotations: {}
 ## @param priorityClassName Sealed Secret pods' priorityClassName
 ##
 priorityClassName: ""
+## @param runtimeClassName Sealed Secret pods' runtimeClassName
+##
+runtimeClassName: ""
 ## @param affinity [object] Affinity for Sealed Secret pods assignment
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Adds a configurable value to support the [Runtime Class](https://kubernetes.io/docs/concepts/containers/runtime-class/) feature on the deployment object. 

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Allows for users to specify a specific runtime class if they so desire

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

1 additional configurable value to maintain

<!-- Describe any known limitations with your change -->

**Applicable issues**

N/A

**Additional information**

I've been testing out and using [gvisor](https://gvisor.dev/) for awhile and noticed quite a few helm charts don't support this parameter as its somewhat new and uncommon to use.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
