### PR TITLE
Fix gosec warnings

### DIFF
--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -435,10 +435,12 @@ func decodeSealedSecret(codecs runtimeserializer.CodecFactory, b []byte) (*ssv1a
 }
 
 func sealMergingInto(in io.Reader, filename string, codecs runtimeserializer.CodecFactory, pubKey *rsa.PublicKey, scope ssv1alpha1.SealingScope, allowEmptyData bool) error {
+	// #nosec G304 -- should open user provided file
 	f, err := os.OpenFile(filename, os.O_RDWR, 0)
 	if err != nil {
 		return err
 	}
+	// #nosec G307 -- we are explicitly managing a potential error from f.Close() at the end of the function
 	defer f.Close()
 
 	b, err := io.ReadAll(f)
@@ -488,6 +490,10 @@ func sealMergingInto(in io.Reader, filename string, codecs runtimeserializer.Cod
 		return err
 	}
 	if _, err := io.Copy(f, &out); err != nil {
+		return err
+	}
+	// we explicitly call f.Close() to return a pontential error when closing the file that wouldn't be returned in the deferred f.Close()
+	if err := f.Close(); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
**Description of the change**
Address the following warnings by gosec:

```
[./cmd/kubeseal/main.go:438] - G304 (CWE-22): Potential file inclusion via variable (Confidence: HIGH, Severity: MEDIUM)
    437: func sealMergingInto(in io.Reader, filename string, codecs runtimeserializer.CodecFactory, pubKey *rsa.PublicKey, scope ssv1alpha1.SealingScope, allowEmptyData bool) error {
  > 438: 	f, err := os.OpenFile(filename, os.O_RDWR, 0)
    439: 	if err != nil {



[./cmd/kubeseal/main.go:442] - G307 (CWE-703): Deferring unsafe method "Close" on type "*os.File" (Confidence: HIGH, Severity: MEDIUM)
    441: 	}
  > 442: 	defer f.Close()
    443:
```

- G304 is ignored in this case as we need to open an user provided file
- G307 is addressed by explicitly managing the error returned by `f.Close()`. Despite this, gosec still reports it but we can safely ignore it.

