### PR TITLE
Remove operator links

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,3 +641,4 @@ Click [here](http://slack.k8s.io) to sign up to the Kubernetes Slack org.
 - Visual Studio Code extension: https://marketplace.visualstudio.com/items?itemName=codecontemplator.kubeseal
 - WebSeal: generates secrets in the browser : https://socialgouv.github.io/webseal
 - HybridEncrypt TypeScript implementation : https://github.com/SocialGouv/aes-gcm-rsa-oaep
+- [DEPRACATED] Sealed Secrets Operator: https://github.com/disposab1e/sealed-secrets-operator-helm

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ original Secret from the SealedSecret.
   - [Controller](#controller)
     - [Kustomize](#kustomize)
     - [Helm Chart](#helm-chart)
-    - [Operator Framework](#operator-framework)
   - [Homebrew](#homebrew)
   - [MacPorts](#macports)
   - [Installation from source](#installation-from-source)
@@ -296,12 +295,6 @@ kubeseal --controller-name sealed-secrets <args>
 ```
 
 Alternatively, you can override `fullnameOverride` on the helm chart install.
-
-#### Operator Framework
-
-Install Sealed Secrets as Kubernetes Operator via the Operator Lifecycle Manager of your cluster. The `Sealed Secrets Operator (Helm)` is published at [OperatorHub.io](https://operatorhub.io/operator/sealed-secrets-operator-helm) for Kubernetes, as community operator in OpenShift's integrated OperatorHub or at the [GitHub repository](https://github.com/disposab1e/sealed-secrets-operator-helm) of the project.
-
-NOTE: the sealed secrets operator is an independently maintained project, so please contact the maintainers directly for support, help or [documentation](https://sealed-secrets-operator-helm.readthedocs.io/en/latest/).
 
 ### Homebrew
 


### PR DESCRIPTION
**Description of the change**
Remove information about the Operator in the README as it was deprecated upstream (link: https://github.com/disposab1e/sealed-secrets-operator-helm)

- fixes #843