### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,7 +573,9 @@ No, the private keys are only stored in the Secret managed by the controller (un
 If you do want to make a backup of the encryption private keys, it's easy to do from an account with suitable access and:
 
 ```bash
-kubectl get secret -n kube-system -l sealedsecrets.bitnami.com/sealed-secrets-key -o yaml >master.key
+echo '---' >master.key
+kubectl get secret -n kube-system -l sealedsecrets.bitnami.com/sealed-secrets-key -o yaml >>master.key
+echo '---' >>master.key
 kubectl get secret -n kube-system sealed-secrets-key -o yaml >>master.key
 ```
 


### PR DESCRIPTION
The current backup method on your documentation isn't working. 
I've got this error at the restore time.

```
kubectl apply --validate=true --dry-run=client -f master.key  
error: error validating "master.key": error validating data: ValidationError(Secret): unknown field "items" in io.k8s.api.core.v1.Secret; if you choose to ignore these
errors, turn validation off with --validate=false
```


so with that seem to be better.:
```
echo '---' >master.key
kubectl get secret -n kube-system -l sealedsecrets.bitnami.com/sealed-secrets-key -o yaml >>master.key
echo '---' >>master.key
kubectl get secret -n kube-system sealed-secrets-key -o yaml >>master.key

yamllint master.key |grep -v line-length master.key
  4:1       error    wrong indentation: expected 2 but found 0  (indentation)

kubectl apply --validate=true --dry-run=client -f master.key 
secret/sealed-secrets-key configured (dry run)
secret/sealed-secrets-key27grn configured (dry run)
secret/sealed-secrets-key2lxng configured (dry run)
secret/sealed-secrets-key49hwt configured (dry run)
secret/sealed-secrets-key49jtp configured (dry run)
secret/sealed-secrets-key4fqdx configured (dry run)
secret/sealed-secrets-key54z7h configured (dry run)
secret/sealed-secrets-key6dhmp configured (dry run)
secret/sealed-secrets-key7ph65 configured (dry run)
secret/sealed-secrets-key8lr8g configured (dry run)
secret/sealed-secrets-key9kb98 configured (dry run)
secret/sealed-secrets-key9wb7q configured (dry run)
secret/sealed-secrets-keyb2xjf configured (dry run)
secret/sealed-secrets-keydmk8w configured (dry run)
secret/sealed-secrets-keygkg52 configured (dry run)
secret/sealed-secrets-keygtpdq configured (dry run)
secret/sealed-secrets-keygv9pn configured (dry run)
secret/sealed-secrets-keyk2xtv configured (dry run)
secret/sealed-secrets-keyk9hwr configured (dry run)
secret/sealed-secrets-keykk6b9 configured (dry run)
secret/sealed-secrets-keylnm8h configured (dry run)
secret/sealed-secrets-keym57m2 configured (dry run)
secret/sealed-secrets-keyp9xr7 configured (dry run)
secret/sealed-secrets-keypxnpq configured (dry run)
secret/sealed-secrets-keyqs4qf configured (dry run)
secret/sealed-secrets-keyqw7jf configured (dry run)
secret/sealed-secrets-keys7p5f configured (dry run)
secret/sealed-secrets-keysxf2c configured (dry run)
secret/sealed-secrets-keytrtn7 configured (dry run)
secret/sealed-secrets-keyw2hwv configured (dry run)
secret/sealed-secrets-keyzjx6g configured (dry run)
secret/sealed-secrets-key configured (dry run)

```

