### PR TITLE
Update golang target version to latest release 1.18.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.17.8", "1.18.0"]
+        go: ["1.17.11", "1.18.3"]
         os: [ubuntu-latest]
         golangci-lint: ["1.44.2"]
     steps:
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.17.8", "1.18.0"]
+        go: ["1.17.11", "1.18.3"]
         os: [ubuntu-latest]
         gosec: ["2.11.0"]
     steps:
@@ -65,7 +65,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: ["1.17.8", "1.18.0"]
+        go: ["1.17.11", "1.18.3"]
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
 
@@ -90,7 +90,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install Cosign
-      uses: sigstore/cosign-installer@v2.1.0
+      uses: sigstore/cosign-installer@v2.3.0
 
     - name: Distroless verify
       run: |
@@ -110,7 +110,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.8
+        go-version: 1.18.3
       id: go
 
     - name: Docker build
@@ -150,7 +150,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.8
+        go-version: 1.18.3
       id: go
 
     - name: Set up Ginkgo

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.8
+          go-version: 1.18.3
       - name: Setup kubecfg
         run: |
           mkdir -p ~/bin


### PR DESCRIPTION
**Description of the change**

This PR updates the `golang` versions used for both the CI actions and the Release ones. We'll be bumping the target versions to:

- `1.17.11` for CI validations
- `1.18.3 `for integration testing and releases

Unrelated, but we also will bump the `cosign` action we use to validate the `distroless` base image 

**Benefits**

We'll be using the latest golang versions while building the product. 

**Possible drawbacks**

Golang has a clear policy of backwards compatibility, so no issue is to be expected. 
 