### PR TITLE
add deploymentAnnotations field in helm chart

### DIFF
--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -16,4 +16,4 @@ maintainers:
     email: mmikulicic@gmail.com
 name: sealed-secrets
 type: application
-version: 2.2.0
+version: 2.3.0

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -77,6 +77,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `fullnameOverride` | String to fully override sealed-secrets.fullname        | `""`  |
 | `namespace`        | Namespace where to deploy the Sealed Secrets controller | `""`  |
 | `extraDeploy`      | Array of extra objects to deploy with the release       | `[]`  |
+| `commonAnnotations`| Annotations to add to all deployed resources            | `[]`  |
 
 
 ### Sealed Secrets Parameters

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "sealed-secrets.fullname" . }}
   namespace: {{ include "sealed-secrets.namespace" . }}
   labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- toYaml .Values.commonAnnotations | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels: {{- include "sealed-secrets.matchLabels" . | nindent 6 }}

--- a/helm/sealed-secrets/templates/service-account.yaml
+++ b/helm/sealed-secrets/templates/service-account.yaml
@@ -4,6 +4,9 @@ kind: ServiceAccount
 metadata:
   name: {{ include "sealed-secrets.serviceAccountName" . }}
   namespace: {{ include "sealed-secrets.namespace" . }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- toYaml .Values.commonAnnotations | nindent 4 }}
+  {{- end }}
   labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
     {{- if .Values.serviceAccount.labels }}
     {{- include "sealed-secrets.render" ( dict "value" .Values.serviceAccount.labels "context" $) | nindent 4 }}

--- a/helm/sealed-secrets/templates/service.yaml
+++ b/helm/sealed-secrets/templates/service.yaml
@@ -4,6 +4,9 @@ kind: Service
 metadata:
   name: {{ include "sealed-secrets.fullname" . }}
   namespace: {{ include "sealed-secrets.namespace" . }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- toYaml .Values.commonAnnotations | nindent 4 }}
+  {{- end }}
   labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
     {{- if .Values.service.labels }}
     {{- include "sealed-secrets.render" ( dict "value" .Values.service.labels "context" $) | nindent 4 }}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -15,6 +15,10 @@ namespace: ""
 ## @param extraDeploy [array] Array of extra objects to deploy with the release
 ##
 extraDeploy: []
+## @param commonAnnotations [object] Annotations to add to all deployed resources
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+commonAnnotations: {}
 
 ## @section Sealed Secrets Parameters
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This will  add `commonAnnotation` field in Helm chart
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

This will allow users to set annotation on sealed -secrets controller deployment
<!-- What benefits will be realized by the code change? -->


Ref: https://github.com/bitnami-labs/sealed-secrets/issues/863