### PR TITLE
Fixed typo in the CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # @alvneiayu @agarcia-oss @alemorcuq will be requested for
 # review when someone opens a pull request.
-@alvneiayu @agarcia-oss @alemorcuq
+* @alvneiayu @agarcia-oss @alemorcuq


### PR DESCRIPTION
**Description of the change**

`CODEOWNERS` latest change was not using the proper syntax (pattern to be applied)

**Benefits**
This was preventing the project maintainers to be included automatically as PR reviewers.
