### PR TITLE
feat(kubernetes/chart): explicitly mount service-account-token in deployment

### DIFF
--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -84,7 +84,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Name                                              | Description                                                                          | Value                               |
 | ------------------------------------------------- | ------------------------------------------------------------------------------------ | ----------------------------------- |
-| `image.registry`                                  | Sealed Secrets image registry                                                        | `docker.io`                           |
+| `image.registry`                                  | Sealed Secrets image registry                                                        | `docker.io`                         |
 | `image.repository`                                | Sealed Secrets image repository                                                      | `bitnami/sealed-secrets-controller` |
 | `image.tag`                                       | Sealed Secrets image tag (immutable tags are recommended)                            | `v0.18.0`                           |
 | `image.pullPolicy`                                | Sealed Secrets image pull policy                                                     | `IfNotPresent`                      |
@@ -124,6 +124,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `containerSecurityContext.readOnlyRootFilesystem` | Whether the Sealed Secret container has a read-only root filesystem                  | `true`                              |
 | `containerSecurityContext.runAsNonRoot`           | Indicates that the Sealed Secret container must run as a non-root user               | `true`                              |
 | `containerSecurityContext.runAsUser`              | Set Sealed Secret containers' Security Context runAsUser                             | `1001`                              |
+| `automountServiceAccountToken`                    | Whether to automatically mount the service account API-token to a particular pod     | `""`                                |
 | `podLabels`                                       | Extra labels for Sealed Secret pods                                                  | `{}`                                |
 | `podAnnotations`                                  | Annotations for Sealed Secret pods                                                   | `{}`                                |
 | `priorityClassName`                               | Sealed Secret pods' priorityClassName                                                | `""`                                |
@@ -159,14 +160,15 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Other Parameters
 
-| Name                    | Description                                          | Value   |
-| ----------------------- | ---------------------------------------------------- | ------- |
-| `serviceAccount.create` | Specifies whether a ServiceAccount should be created | `true`  |
-| `serviceAccount.labels` | Extra labels to be added to the ServiceAccount       | `{}`    |
-| `serviceAccount.name`   | The name of the ServiceAccount to use.               | `""`    |
-| `rbac.create`           | Specifies whether RBAC resources should be created   | `true`  |
-| `rbac.labels`           | Extra labels to be added to RBAC resources           | `{}`    |
-| `rbac.pspEnabled`       | PodSecurityPolicy                                    | `false` |
+| Name                                          | Description                                               | Value   |
+| --------------------------------------------- | --------------------------------------------------------- | ------- |
+| `serviceAccount.create`                       | Specifies whether a ServiceAccount should be created      | `true`  |
+| `serviceAccount.labels`                       | Extra labels to be added to the ServiceAccount            | `{}`    |
+| `serviceAccount.name`                         | The name of the ServiceAccount to use.                    | `""`    |
+| `serviceAccount.automountServiceAccountToken` | Specifies, whether to mount the service account API-token | `""`    |
+| `rbac.create`                                 | Specifies whether RBAC resources should be created        | `true`  |
+| `rbac.labels`                                 | Extra labels to be added to RBAC resources                | `{}`    |
+| `rbac.pspEnabled`                             | PodSecurityPolicy                                         | `false` |
 
 
 ### Metrics parameters

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "sealed-secrets.serviceAccountName" . }}
+      {{- if .Values.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      {{- end }}
       containers:
         - name: controller
           command:

--- a/helm/sealed-secrets/templates/service-account.yaml
+++ b/helm/sealed-secrets/templates/service-account.yaml
@@ -1,6 +1,9 @@
 {{ if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
+{{- if .Values.serviceAccount.automountServiceAccountToken }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 metadata:
   name: {{ include "sealed-secrets.serviceAccountName" . }}
   namespace: {{ include "sealed-secrets.namespace" . }}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -148,6 +148,10 @@ containerSecurityContext:
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 1001
+
+## @param automountServiceAccountToken whether to automatically mount the service account API-token to a particular pod
+automountServiceAccountToken: ""
+
 ## @param podLabels [object] Extra labels for Sealed Secret pods
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
@@ -307,6 +311,8 @@ serviceAccount:
   ## If not set and create is true, a name is generated using the sealed-secrets.fullname template
   ##
   name: ""
+  ## @param serviceAccount.automountServiceAccountToken Specifies, whether to mount the service account API-token
+  automountServiceAccountToken: ""
 ## RBAC configuration
 ##
 rbac:


### PR DESCRIPTION
This PR has already been treated (https://github.com/bitnami-labs/sealed-secrets/pull/811/), but changes have not been merged correctly.

**Description of the change**
Our environment has some restrictions on service-accounts: We're not allowed to use automountServiceAccountToken=true as default for a service-account but have to explicit enable the service-account-mount in each deployment.
It would be nice, if you could merge that change to make Reloader usable in such environments.

**Benefits**
Implementation for https://github.com/kubernetes/kubernetes/issues/57601

**Possible drawbacks**

no known drawbacks

**Applicable issues**
no issues


- fixes #

**Additional information**
no additional information