### PR TITLE
Replace ioutil with io or os

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -7,7 +7,6 @@ import (
 	goflag "flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
@@ -126,7 +125,7 @@ func myNamespace() string {
 	}
 
 	// Fall back to the namespace associated with the service account token, if available
-	if data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
 		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
 			return ns
 		}

--- a/cmd/controller/server.go
+++ b/cmd/controller/server.go
@@ -4,7 +4,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"time"
@@ -48,7 +47,7 @@ func httpserver(cp certProvider, sc secretChecker, sr secretRotator, burst int, 
 	mux.Handle("/metrics", promhttp.Handler())
 
 	mux.Handle("/v1/verify", Instrument("/v1/verify", httpRateLimiter.RateLimit(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		content, err := ioutil.ReadAll(r.Body)
+		content, err := io.ReadAll(r.Body)
 		if err != nil {
 			log.Printf("Error handling /v1/verify request: %v", err)
 			w.WriteHeader(http.StatusBadRequest)
@@ -71,7 +70,7 @@ func httpserver(cp certProvider, sc secretChecker, sr secretRotator, burst int, 
 
 	// TODO(mkm): rename to re-encrypt
 	mux.Handle("/v1/rotate", Instrument("/v1/rotate", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		content, err := ioutil.ReadAll(r.Body)
+		content, err := io.ReadAll(r.Body)
 		if err != nil {
 			log.Printf("Error handling /v1/rotate request: %v", err)
 			w.WriteHeader(http.StatusBadRequest)

--- a/cmd/controller/server_test.go
+++ b/cmd/controller/server_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -70,7 +70,7 @@ func TestHttpCert(t *testing.T) {
 		}
 		defer resp.Body.Close()
 
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -11,7 +11,6 @@ import (
 	goflag "flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -110,7 +109,7 @@ func init() {
 }
 
 func parseKey(r io.Reader) (*rsa.PublicKey, error) {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +137,7 @@ func parseKey(r io.Reader) (*rsa.PublicKey, error) {
 }
 
 func readSecret(codec runtime.Decoder, r io.Reader) (*v1.Secret, error) {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +326,7 @@ func validateSealedSecret(ctx context.Context, in io.Reader, namespace, name str
 		return err
 	}
 
-	content, err := ioutil.ReadAll(in)
+	content, err := io.ReadAll(in)
 	if err != nil {
 		return err
 	}
@@ -365,7 +364,7 @@ func reEncryptSealedSecret(ctx context.Context, in io.Reader, out io.Writer, cod
 		return err
 	}
 
-	content, err := ioutil.ReadAll(in)
+	content, err := io.ReadAll(in)
 	if err != nil {
 		return err
 	}
@@ -523,7 +522,7 @@ func parseFromFile(s string) (string, string) {
 
 func readPrivKeysFromFile(filename string) ([]*rsa.PrivateKey, error) {
 	// #nosec G304 -- should open user provided file
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -616,7 +615,7 @@ func unsealSealedSecret(w io.Writer, in io.Reader, codecs runtimeserializer.Code
 		return err
 	}
 
-	b, err := ioutil.ReadAll(in)
+	b, err := io.ReadAll(in)
 	if err != nil {
 		return err
 	}
@@ -749,12 +748,12 @@ func run(ctx context.Context, w io.Writer, inputFileName, outputFileName, secret
 
 			_, filename := parseFromFile(fromFile[0])
 			// #nosec G304 -- should open user provided file
-			data, err = ioutil.ReadFile(filename)
+			data, err = os.ReadFile(filename)
 		} else {
 			if isatty.IsTerminal(os.Stdin.Fd()) {
 				fmt.Fprintf(os.Stderr, "(tty detected: expecting a secret to encrypt in stdin)\n")
 			}
-			data, err = ioutil.ReadAll(os.Stdin)
+			data, err = io.ReadAll(os.Stdin)
 		}
 		if err != nil {
 			return err

--- a/cmd/kubeseal/main_test.go
+++ b/cmd/kubeseal/main_test.go
@@ -9,7 +9,7 @@ import (
 	"encoding/pem"
 	goflag "flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -89,7 +89,7 @@ func TestMain(m *testing.M) {
 }
 
 func tmpfile(t *testing.T, contents []byte) string {
-	f, err := ioutil.TempFile("", "testdata")
+	f, err := os.CreateTemp("", "testdata")
 	if err != nil {
 		t.Fatalf("Failed to create tempfile: %v", err)
 	}
@@ -140,7 +140,7 @@ func TestOpenCertFile(t *testing.T) {
 			t.Fatalf("Error reading test cert file: %v", err)
 		}
 
-		data, err := ioutil.ReadAll(f)
+		data, err := io.ReadAll(f)
 		if err != nil {
 			t.Fatalf("Error reading from test cert file: %v", err)
 		}
@@ -468,7 +468,7 @@ func newTestKeyPair(t *testing.T) (*rsa.PublicKey, map[string]*rsa.PrivateKey) {
 
 func TestUnseal(t *testing.T) {
 	pubKey, privKeys := newTestKeyPair(t)
-	pkFile, err := ioutil.TempFile("", "")
+	pkFile, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -508,7 +508,7 @@ func TestUnseal(t *testing.T) {
 
 func TestUnsealList(t *testing.T) {
 	pubKey, privKeys := newTestKeyPair(t)
-	pkFile, err := ioutil.TempFile("", "")
+	pkFile, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -567,7 +567,7 @@ func TestMergeInto(t *testing.T) {
 	pubKey, privKeys := newTestKeyPair(t)
 
 	merge := func(t *testing.T, newSecret, oldSealedSecret []byte) *ssv1alpha1.SealedSecret {
-		f, err := ioutil.TempFile("", "*.json")
+		f, err := os.CreateTemp("", "*.json")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -581,7 +581,7 @@ func TestMergeInto(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		b, err := ioutil.ReadFile(f.Name())
+		b, err := os.ReadFile(f.Name())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -678,7 +678,7 @@ func TestVersion(t *testing.T) {
 func TestMainError(t *testing.T) {
 	ctx := context.Background()
 	badFileName := filepath.Join("this", "file", "cannot", "possibly", "exist", "can", "it?")
-	err := run(ctx, ioutil.Discard, "", "", "", "", "", badFileName, false, false, false, false, false, false, nil, "", false, nil)
+	err := run(ctx, io.Discard, "", "", "", "", "", badFileName, false, false, false, false, false, false, nil, "", false, nil)
 
 	if err == nil || !os.IsNotExist(err) {
 		t.Fatalf("expecting not exist error, got: %v", err)
@@ -822,11 +822,11 @@ func sealTestItem(certFilename, secretNS, secretName, secretValue string, scope 
 	defer func(s ssv1alpha1.SealingScope) { sealingScope = s }(sealingScope)
 	sealingScope = scope
 	/*
-		if got, want := run(ioutil.Discard, "", "", "", certFilename, false, false, false, false, true, nil, "", false, nil), "must provide the --name flag with --raw and --scope strict"; got == nil || got.Error() != want {
+		if got, want := run(io.Discard, "", "", "", certFilename, false, false, false, false, true, nil, "", false, nil), "must provide the --name flag with --raw and --scope strict"; got == nil || got.Error() != want {
 			t.Fatalf("want matching: %q, got: %q", want, got.Error())
 		}
 
-		if got, want := run(ioutil.Discard, secretName, "", "", certFilename, false, false, false, false, true, nil, "", false, nil), "must provide the --from-file flag with --raw"; got == nil || got.Error() != want {
+		if got, want := run(io.Discard, secretName, "", "", certFilename, false, false, false, false, true, nil, "", false, nil), "must provide the --from-file flag with --raw"; got == nil || got.Error() != want {
 			t.Fatalf("want matching: %q, got: %q", want, got.Error())
 		}
 	*/
@@ -852,7 +852,7 @@ func TestWriteToFile(t *testing.T) {
 	certFilename, _, cleanup := testingKeypairFiles(t)
 	defer cleanup()
 
-	in, err := ioutil.TempFile("", "")
+	in, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -867,7 +867,7 @@ data:
 `)
 	in.Close()
 
-	out, err := ioutil.TempFile("", "*.yaml")
+	out, err := os.CreateTemp("", "*.yaml")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -884,7 +884,7 @@ data:
 		t.Errorf("got: %d, want: %d", got, want)
 	}
 
-	b, err := ioutil.ReadFile(out.Name())
+	b, err := os.ReadFile(out.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -897,7 +897,7 @@ func TestFailToWriteToFile(t *testing.T) {
 	certFilename, _, cleanup := testingKeypairFiles(t)
 	defer cleanup()
 
-	in, err := ioutil.TempFile("", "")
+	in, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -910,7 +910,7 @@ metadata:
 `)
 	in.Close()
 
-	out, err := ioutil.TempFile("", "")
+	out, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -932,7 +932,7 @@ metadata:
 		t.Errorf("got: %d, want: %d", got, want)
 	}
 
-	b, err := ioutil.ReadFile(out.Name())
+	b, err := os.ReadFile(out.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -943,7 +943,7 @@ metadata:
 
 // writeTempFile creates a temporary file, writes data into it and closes it.
 func writeTempFile(b []byte) (string, error) {
-	tmp, err := ioutil.TempFile("", "")
+	tmp, err := os.CreateTemp("", "")
 	if err != nil {
 		return "", err
 	}
@@ -964,7 +964,7 @@ func TestReadPrivKeyPEM(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tmp, err := ioutil.TempFile("", "")
+	tmp, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -999,7 +999,7 @@ func TestReadPrivKeySecret(t *testing.T) {
 		},
 	}
 
-	tmp, err := ioutil.TempFile("", "")
+	tmp, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/kubeseal_test.go
+++ b/integration/kubeseal_test.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"io"
-	"io/ioutil"
 	"os"
 
 	ssv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealed-secrets/v1alpha1"
@@ -55,7 +54,7 @@ var _ = Describe("kubeseal", func() {
 	})
 
 	JustBeforeEach(func() {
-		f, err := ioutil.TempFile("", "kubeconfig")
+		f, err := os.CreateTemp("", "kubeconfig")
 		Expect(err).NotTo(HaveOccurred())
 
 		buf, err := runtime.Encode(clientcmdlatest.Codec, config)
@@ -165,7 +164,7 @@ var _ = Describe("kubeseal", func() {
 
 		BeforeEach(func() {
 			var err error
-			certfile, err = ioutil.TempFile("", "kubeseal-test")
+			certfile, err = os.CreateTemp("", "kubeseal-test")
 			Expect(err).NotTo(HaveOccurred())
 
 			for _, cert := range certs {
@@ -313,7 +312,7 @@ var _ = Describe("kubeseal --cert", func() {
 	})
 
 	JustBeforeEach(func() {
-		err := runKubeseal(args, input, ioutil.Discard, runAppWithStderr(output))
+		err := runKubeseal(args, input, io.Discard, runAppWithStderr(output))
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -366,7 +365,7 @@ var _ = Describe("kubeseal --recovery-unseal", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		backupKeysFile, err = ioutil.TempFile("", "master")
+		backupKeysFile, err = os.CreateTemp("", "master")
 		Expect(err).NotTo(HaveOccurred())
 		defer backupKeysFile.Close()
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

- Replace ioutil with io or os.
  - Because ioutil is deprecated from go1.16.

**Benefits**

- Cleanup

**Possible drawbacks**

- Nothing

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- N/A

**Additional information**

 - https://go.dev/doc/go1.16#ioutil
