### PR TITLE
Use gotestsum for better test reporting.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
       matrix:
         go: ["1.17.11", "1.18.3"]
         os: [macos-latest, windows-latest, ubuntu-latest]
+        gotestsum: ["1.8.1"]
     steps:
 
     - name: Set up Go 1.x
@@ -77,6 +78,10 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: |
+        go install gotest.tools/gotestsum@v${{ matrix.gotestsum }}
 
     - name: Test
       run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 GO = go
+GOTESTSUM = gotestsum
 GOFMT = gofmt
 GOLANGCILINT=golangci-lint
 GOSEC=gosec
@@ -97,7 +98,7 @@ controller-norbac.yaml: controller-norbac.jsonnet schema-v1alpha1.yaml kube-fixe
 controller-podmonitor.yaml: controller.jsonnet controller-norbac.jsonnet schema-v1alpha1.yaml kube-fixes.libsonnet
 
 test:
-	$(GO) test $(GO_FLAGS) $(GO_PACKAGES)
+	$(GOTESTSUM) $(GO_FLAGS) $(GO_PACKAGES)
 
 integrationtest: kubeseal controller
 	# Assumes a k8s cluster exists, with controller already installed


### PR DESCRIPTION
**Description of the change**

Experimenting with moving from plain `go test` to use [gotestsum](https://github.com/gotestyourself/gotestsum) which provides formatted test output but also a test summary. 

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Better developer experience on testing.

**Possible drawbacks**

Not sure if we might face any limitations with `gotestsum`. Their issues section has a few items but none look relevant.

Signed-off-by: Martin Perez <martinpe@vmware.com>
