### PR TITLE
Update CI to support Go 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         go: ["1.19", "1.18.5"]
         os: [ubuntu-latest]
-        golangci-lint: ["1.44.2"]
+        golangci-lint: ["1.47.3"]
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
@@ -42,7 +42,7 @@ jobs:
       matrix:
         go: ["1.19", "1.18.5"]
         os: [ubuntu-latest]
-        gosec: ["2.11.0"]
+        gosec: ["2.12.0"]
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
@@ -95,7 +95,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install Cosign
-      uses: sigstore/cosign-installer@v2.3.0
+      uses: sigstore/cosign-installer@v2.5.0
 
     - name: Distroless verify
       run: |
@@ -109,7 +109,7 @@ jobs:
     - name: Setup kubecfg
       run: |
         mkdir -p ~/bin
-        curl -sLf https://github.com/kubecfg/kubecfg/releases/download/v0.25.0/kubecfg_Linux_X64 >~/bin/kubecfg
+        curl -sLf https://github.com/kubecfg/kubecfg/releases/download/v0.26.0/kubecfg_Linux_X64 >~/bin/kubecfg
         chmod +x ~/bin/kubecfg
 
     - name: Set up Go 1.x
@@ -160,7 +160,7 @@ jobs:
 
     - name: Set up Ginkgo
       run: |
-        (cd /tmp; GO111MODULE=on go install github.com/onsi/ginkgo/ginkgo@v1.14.2)
+        go install github.com/onsi/ginkgo/ginkgo@v1.16.4
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -169,7 +169,7 @@ jobs:
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       with:
-        minikube-version: 1.24.0
+        minikube-version: 1.26.1
         k8s-version: ${{ matrix.k8s }}
 
     # need to delete old state of the cluster, see:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.17.11", "1.18.3"]
+        go: ["1.19", "1.18.5"]
         os: [ubuntu-latest]
         golangci-lint: ["1.44.2"]
     steps:
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.17.11", "1.18.3"]
+        go: ["1.19", "1.18.5"]
         os: [ubuntu-latest]
         gosec: ["2.11.0"]
     steps:
@@ -65,7 +65,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: ["1.17.11", "1.18.3"]
+        go: ["1.19", "1.18.5"]
         os: [macos-latest, windows-latest, ubuntu-latest]
         gotestsum: ["1.8.1"]
     steps:
@@ -115,7 +115,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.3
+        go-version: 1.18.5
       id: go
 
     - name: Docker build
@@ -155,7 +155,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.3
+        go-version: 1.18.5
       id: go
 
     - name: Set up Ginkgo

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.3
+          go-version: 1.18.5
       - name: Setup kubecfg
         run: |
           mkdir -p ~/bin

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup kubecfg
         run: |
           mkdir -p ~/bin
-          curl -sLf https://github.com/kubecfg/kubecfg/releases/download/v0.25.0/kubecfg_Linux_X64 >~/bin/kubecfg
+          curl -sLf https://github.com/kubecfg/kubecfg/releases/download/v0.26.0/kubecfg_Linux_X64 >~/bin/kubecfg
           chmod +x ~/bin/kubecfg
 
       # Run tests
@@ -47,7 +47,7 @@ jobs:
 
       # Setup Cosign
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v2.3.0
+        uses: sigstore/cosign-installer@v2.5.0
       - name: Write Cosign key
         run: echo "$COSIGN_KEY" > /tmp/cosign.key
         env:
@@ -58,7 +58,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         if: success() && startsWith(github.ref, 'refs/tags/')
         with:
-          version: v1.7.0
+          version: v1.10.3
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cmd/controller/server.go
+++ b/cmd/controller/server.go
@@ -104,10 +104,11 @@ func httpserver(cp certProvider, sc secretChecker, sr secretRotator, burst int, 
 	})))
 
 	server := http.Server{
-		Addr:         *listenAddr,
-		Handler:      mux,
-		ReadTimeout:  *readTimeout,
-		WriteTimeout: *writeTimeout,
+		Addr:              *listenAddr,
+		Handler:           mux,
+		ReadTimeout:       *readTimeout,
+		ReadHeaderTimeout: *readTimeout,
+		WriteTimeout:      *writeTimeout,
 	}
 
 	log.Printf("HTTP server serving on %s", server.Addr)

--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -31,7 +31,8 @@ func PublicKeyFingerprint(rp *rsa.PublicKey) (string, error) {
 
 // HybridEncrypt performs a regular AES-GCM + RSA-OAEP encryption.
 // The output bytestring is:
-//   RSA ciphertext length || RSA ciphertext || AES ciphertext
+//
+//	RSA ciphertext length || RSA ciphertext || AES ciphertext
 func HybridEncrypt(rnd io.Reader, pubKey *rsa.PublicKey, plaintext, label []byte) ([]byte, error) {
 	// Generate a random symmetric key
 	sessionKey := make([]byte, sessionKeyBytes)

--- a/pkg/flagenv/flagenv.go
+++ b/pkg/flagenv/flagenv.go
@@ -8,16 +8,16 @@
 // This example will make it possible to set the default of --my_flag also via the MY_PROG_MY_FLAG
 // env var:
 //
-//    var myflag = flag.String("my_flag", "", "some flag")
+//	var myflag = flag.String("my_flag", "", "some flag")
 //
-//    func init() {
-//        flagenv.SetFlagsFromEnv("MY_PROG", flag.CommandLine)
-//    }
+//	func init() {
+//	    flagenv.SetFlagsFromEnv("MY_PROG", flag.CommandLine)
+//	}
 //
-//    func main() {
-//        flags.Parse()
-//        ...
-//    }
+//	func main() {
+//	    flags.Parse()
+//	    ...
+//	}
 package flagenv
 
 import (

--- a/pkg/pflagenv/flagenv.go
+++ b/pkg/pflagenv/flagenv.go
@@ -8,16 +8,16 @@
 // This example will make it possible to set the default of --my_flag also via the MY_PROG_MY_FLAG
 // env var:
 //
-//    var myflag = pflag.String("my_flag", "", "some flag")
+//	var myflag = pflag.String("my_flag", "", "some flag")
 //
-//    func init() {
-//        pflagenv.SetFlagsFromEnv("MY_PROG", pflag.CommandLine)
-//    }
+//	func init() {
+//	    pflagenv.SetFlagsFromEnv("MY_PROG", pflag.CommandLine)
+//	}
 //
-//    func main() {
-//        pflag.Parse()
-//        ...
-//    }
+//	func main() {
+//	    pflag.Parse()
+//	    ...
+//	}
 package pflagenv
 
 import (


### PR DESCRIPTION
**Description of the change**
- Run the CI using the latest versions from Go (1.18.5 and 1.19).
- Remove Go 1.17 from the CI as it is not maintained.
- Use Go 1.18.5 as the release version.
- Update several CI/CD tools.

**Benefits**
- Up to date CI/CD 
- More secure releases