### PR TITLE
Allow skipping ClusterRole creation

### DIFF
--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
     url: https://github.com/bitnami-labs/sealed-secrets
 name: sealed-secrets
 type: application
-version: 2.5.2
+version: 2.6.0

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -163,15 +163,16 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Other Parameters
 
-| Name                                          | Description                                               | Value   |
-| --------------------------------------------- | --------------------------------------------------------- | ------- |
-| `serviceAccount.create`                       | Specifies whether a ServiceAccount should be created      | `true`  |
-| `serviceAccount.labels`                       | Extra labels to be added to the ServiceAccount            | `{}`    |
-| `serviceAccount.name`                         | The name of the ServiceAccount to use.                    | `""`    |
-| `serviceAccount.automountServiceAccountToken` | Specifies, whether to mount the service account API-token | `""`    |
-| `rbac.create`                                 | Specifies whether RBAC resources should be created        | `true`  |
-| `rbac.labels`                                 | Extra labels to be added to RBAC resources                | `{}`    |
-| `rbac.pspEnabled`                             | PodSecurityPolicy                                         | `false` |
+| Name                                          | Description                                                   | Value   |
+| --------------------------------------------- | ------------------------------------------------------------- | ------- |
+| `serviceAccount.create`                       | Specifies whether a ServiceAccount should be created          | `true`  |
+| `serviceAccount.labels`                       | Extra labels to be added to the ServiceAccount                | `{}`    |
+| `serviceAccount.name`                         | The name of the ServiceAccount to use.                        | `""`    |
+| `serviceAccount.automountServiceAccountToken` | Specifies, whether to mount the service account API-token     | `""`    |
+| `rbac.create`                                 | Specifies whether RBAC resources should be created            | `true`  |
+| `rbac.clusterRole`                            | Specifies whether the Cluster Role resource should be created | `true`  |
+| `rbac.labels`                                 | Extra labels to be added to RBAC resources                    | `{}`    |
+| `rbac.pspEnabled`                             | PodSecurityPolicy                                             | `false` |
 
 
 ### Metrics parameters

--- a/helm/sealed-secrets/templates/cluster-role.yaml
+++ b/helm/sealed-secrets/templates/cluster-role.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.rbac.create }}
+{{ if and .Values.rbac.create .Values.rbac.clusterRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -328,6 +328,9 @@ rbac:
   ## @param rbac.create Specifies whether RBAC resources should be created
   ##
   create: true
+  ## @param rbac.clusterRole Specifies whether the Cluster Role resource should be created
+  ##
+  clusterRole: true
   ## @param rbac.labels Extra labels to be added to RBAC resources
   ##
   labels: {}


### PR DESCRIPTION
**Description of the change**
Follow-up for #749 

Adds a parameter to skip the ClusterRole creation so that it doesn't fail to install on a cluster that already has the ClusterRole.

**Benefits**
Users can install the chart easily in several namespaces of the same cluster.