### PR TITLE
instruction about kubeseal installation on Linux distribution like ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ nix-env -iA nixpkgs.kubeseal
 
 ### Linux
 
-The `kubeseal` client can be installed on Linux, using below commands:
+The `kubeseal` client can be installed on Linux, using the below commands:
 
 ```bash
 wget https://github.com/bitnami-labs/sealed-secrets/releases/download/<release-tag>/kubeseal-<version>-linux-amd64.tar.gz

--- a/README.md
+++ b/README.md
@@ -333,7 +333,8 @@ nix-env -iA nixpkgs.kubeseal
 The `kubeseal` client can be installed on Linux, using below commands:
 
 ```bash
-wget https://github.com/bitnami-labs/sealed-secrets/releases/download/<release-tag>/kubeseal-linux-amd64 -O kubeseal
+wget https://github.com/bitnami-labs/sealed-secrets/releases/download/<release-tag>/kubeseal-<version>-linux-amd64.tar.gz
+tar -xvzf kubeseal-<version>-linux-amd64.tar.gz kubeseal
 sudo install -m 755 kubeseal /usr/local/bin/kubeseal
 ```
 where `release-tag` is [version tag](https://github.com/bitnami-labs/sealed-secrets/tags) of the kubeseal release you want to use. For example `v0.18.0`

--- a/README.md
+++ b/README.md
@@ -337,7 +337,8 @@ wget https://github.com/bitnami-labs/sealed-secrets/releases/download/<release-t
 tar -xvzf kubeseal-<version>-linux-amd64.tar.gz kubeseal
 sudo install -m 755 kubeseal /usr/local/bin/kubeseal
 ```
-where `release-tag` is [version tag](https://github.com/bitnami-labs/sealed-secrets/tags) of the kubeseal release you want to use. For example `v0.18.0`
+
+where `release-tag` is the [version tag](https://github.com/bitnami-labs/sealed-secrets/tags) of the kubeseal release you want to use. For example: `v0.18.0`.
 
 ### Installation from source
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ original Secret from the SealedSecret.
     - [Helm Chart](#helm-chart)
   - [Homebrew](#homebrew)
   - [MacPorts](#macports)
+  - [Linux](#linux)
   - [Installation from source](#installation-from-source)
 - [Upgrade](#upgrade)
 - [Usage](#usage)
@@ -326,6 +327,16 @@ The `kubeseal` client is also available on [Nixpkgs](https://search.nixos.org/pa
 ```bash
 nix-env -iA nixpkgs.kubeseal
 ```
+
+### Linux
+
+The `kubeseal` client can be installed on Linux, using below commands:
+
+```bash
+wget https://github.com/bitnami-labs/sealed-secrets/releases/download/<release-tag>/kubeseal-linux-amd64 -O kubeseal
+sudo install -m 755 kubeseal /usr/local/bin/kubeseal
+```
+where `release-tag` is [version tag](https://github.com/bitnami-labs/sealed-secrets/tags) of the kubeseal release you want to use. For example `v0.18.0`
 
 ### Installation from source
 


### PR DESCRIPTION

**Description of the change**

have amended README.md to have small instruction set about how kubeseal client can be installed on linux distro

**Benefits**

Being a newbie(and anyone like me who is heavily dependent on README.md for installation) to Kubeseal, I was initially struggling with kubeseal client installation on the Linux machine.Took a bit of time to go through the doc and couldn't find one. So I believe this will help for newcomers with installation of client easily

**Possible drawbacks**

None

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
