### PR TITLE
Use inclusive terminology

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,7 +59,7 @@ release:
   footer: |
     ## Release Notes
 
-    Please read the [RELEASE_NOTES](https://github.com/bitnami-labs/sealed-secrets/blob/master/RELEASE-NOTES.md) which contain among other things important information for who is upgrading from previous releases.
+    Please read the [RELEASE_NOTES](https://github.com/bitnami-labs/sealed-secrets/blob/main/RELEASE-NOTES.md) which contain among other things important information for who is upgrading from previous releases.
 
     ## Thanks!
   extra_files:

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ ensure you are using the correct one.
 (requires secure access to the Kubernetes API server), which is
 convenient for interactive use, but it's known to be brittle when users
 have clusters with special configurations such as [private GKE clusters](docs/GKE.md#private-gke-clusters) that have
-firewalls between master and nodes.
+firewalls between control plane and nodes.
 
 An alternative workflow
 is to store the certificate somewhere (e.g. local disk) with
@@ -214,7 +214,7 @@ seal a secret for a namespace, it cannot be moved in another namespace and decry
 We don't technically use an independent private key for each namespace, but instead we *include* the namespace name
 during the encryption process, effectively achieving the same result.
 
-Furthermore, namespaces are not the only level at which RBAC configurations can decide who can see which secret. In fact, it's possible that users can access a secret called `foo` in a given namespace but not any other secret in the same namespace. We cannot thus by default let users freely rename SealedSecret resources otherwise a malicious user would be able to decrypt any SealedSecret for that namespace by just renaming it to overwrite the one secret she does have access to. We use the same mechanism used to include the namespace in the encryption key to also include the secret name.
+Furthermore, namespaces are not the only level at which RBAC configurations can decide who can see which secret. In fact, it's possible that users can access a secret called `foo` in a given namespace but not any other secret in the same namespace. We cannot thus by default let users freely rename SealedSecret resources otherwise a malicious user would be able to decrypt any SealedSecret for that namespace by just renaming it to overwrite the one secret they do have access to. We use the same mechanism used to include the namespace in the encryption key to also include the secret name.
 
 That said, there are many scenarios where you might not care about this level of protection. For example, the only people who have access to your clusters are either admins or they cannot read any secret resource at all. You might have a use case for moving a sealed secret to other namespaces (e.g. you might not know the namespace name upfront), or you might not know the name of the secret (e.g. it could contain a unique suffix based on the hash of the contents etc).
 
@@ -473,7 +473,7 @@ The renewal time of 30d is a reasonable default, but it can be tweaked as needed
 with the `--key-renew-period=<value>` flag for the command in the pod template of the sealed secret controller. The `value` field can be given as golang
 duration flag (eg: `720h30m`).
 
-A value of `0` will disable automatic key renewal. Of course, it's possible you have a valid use case for disabling automatic sealing key renewal; but experience has shown that new users often tend to jump to conclusions that they want control over key renewal, before fully understanding how sealed secrets work. Read more about this in the [common misconceptions](#common-misconceptions-about-key-renewal) section below.
+A value of `0` will deactivate automatic key renewal. Of course, it's possible you have a valid use case for deactivating automatic sealing key renewal; but experience has shown that new users often tend to jump to conclusions that they want control over key renewal, before fully understanding how sealed secrets work. Read more about this in the [common misconceptions](#common-misconceptions-about-key-renewal) section below.
 
 > Unfortunately you cannot use e.g. "d" as a unit for days because that's not supported by the Go stdlib. Instead of hitting your face with a palm, take this as an opportunity to meditate on the [falsehoods programmers believe about time](https://infiniteundo.com/post/25326999628/falsehoods-programmers-believe-about-time).
 
@@ -594,8 +594,8 @@ No, the private keys are only stored in the Secret managed by the controller (un
 If you do want to make a backup of the encryption private keys, it's easy to do from an account with suitable access and:
 
 ```bash
-kubectl get secret -n kube-system -l sealedsecrets.bitnami.com/sealed-secrets-key -o yaml >master.key
-kubectl get secret -n kube-system sealed-secrets-key -o yaml >>master.key
+kubectl get secret -n kube-system -l sealedsecrets.bitnami.com/sealed-secrets-key -o yaml >main.key
+kubectl get secret -n kube-system sealed-secrets-key -o yaml >>main.key
 ```
 
 NOTE: you need the second statement only if you ever installed sealed-secrets older than version 0.9.x on your cluster.
@@ -605,7 +605,7 @@ NOTE: This file will contain the controller's public + private keys and should b
 To restore from a backup after some disaster, just put that secrets back before starting the controller - or if the controller was already started, replace the newly-created secrets and restart the controller:
 
 ```bash
-kubectl apply -f master.key
+kubectl apply -f main.key
 kubectl delete pod -n kube-system -l name=sealed-secrets-controller
 ```
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -61,7 +61,7 @@ Latest release:
 
 ### Announcements
 
-This release finally turns on the `update-status` feature flag that was introduced back in v0.12.0. The feature is considered stable (if it doesn't work for you, you can disable it by setting `SEALED_SECRETS_UPDATE_STATUS=0` in the controller manifest).
+This release finally turns on the `update-status` feature flag that was introduced back in v0.12.0. The feature is considered stable (if it doesn't work for you, you can deactivate it by setting `SEALED_SECRETS_UPDATE_STATUS=0` in the controller manifest).
 
 ### Changelog
 
@@ -202,7 +202,7 @@ In order to turn it back on you need to manually pass the `--update-status` flag
 ### Changelog
 
 - Make it easier to use --raw from stdin ([#386](https://github.com/bitnami-labs/sealed-secrets/issues/386))
-- Disable status updates unless a feature flag is explicitly passed ([#388](https://github.com/bitnami-labs/sealed-secrets/issues/388))
+- Deactivate status updates unless a feature flag is explicitly passed ([#388](https://github.com/bitnami-labs/sealed-secrets/issues/388))
 
 The full Changelog is maintained in https://github.com/bitnami-labs/sealed-secrets/milestone/18?closed=1
 
@@ -439,7 +439,7 @@ $ kubectl create secret generic mysecret --dry-run -o json --from-file=bar=/tmp/
 - Rename "key rotation" to "key renewal" since the terminology was confusing.
 - Key renewal is enabled by default every 30 days ([#236](https://github.com/bitnami-labs/sealed-secrets/issues/236))
 - You can now use env vars such as SEALED_SECRETS_FOO_BAR to customize the controller ([#234](https://github.com/bitnami-labs/sealed-secrets/issues/234))
-- Disabling by default deprecated "v1" encrypted data format (used by pre-v0.7.0 clients) ([#235](https://github.com/bitnami-labs/sealed-secrets/issues/235))
+- Deactivating by default deprecated "v1" encrypted data format (used by pre-v0.7.0 clients) ([#235](https://github.com/bitnami-labs/sealed-secrets/issues/235))
 - Fix RBAC rules for /v1/rotate and /v1/validate fixing #166 for good ([#249](https://github.com/bitnami-labs/sealed-secrets/issues/249))
 - Implement the --merge-into command ([#253](https://github.com/bitnami-labs/sealed-secrets/issues/253))
 - Add the `-o` alias for `--format` ([#261](https://github.com/bitnami-labs/sealed-secrets/issues/261))

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -43,7 +43,7 @@ var (
 	validFor             = flag.Duration("key-ttl", 10*365*24*time.Hour, "Duration that certificate is valid for.")
 	myCN                 = flag.String("my-cn", "", "Common name to be used as issuer/subject DN in generated certificate.")
 	printVersion         = flag.Bool("version", false, "Print version information and exit")
-	keyRenewPeriod       = flag.Duration("key-renew-period", defaultKeyRenewPeriod, "New key generation period (automatic rotation disabled if 0)")
+	keyRenewPeriod       = flag.Duration("key-renew-period", defaultKeyRenewPeriod, "New key generation period (automatic rotation deactivated if 0)")
 	acceptV1Data         = flag.Bool("accept-deprecated-v1-data", true, "Accept deprecated V1 data field.")
 	keyCutoffTime        = flag.String("key-cutoff-time", "", "Create a new key if latest one is older than this cutoff time. RFC1123 format with numeric timezone expected.")
 	namespaceAll         = flag.Bool("all-namespaces", true, "Scan all namespaces or only the current namespace (default=true).")
@@ -135,7 +135,7 @@ func myNamespace() string {
 }
 
 // Initialises the first key and starts the rotation job. returns an early trigger function.
-// A period of 0 disables automatic rotation, but manual rotation (e.g. triggered by SIGUSR1)
+// A period of 0 deactivates automatic rotation, but manual rotation (e.g. triggered by SIGUSR1)
 // is still honoured.
 func initKeyRenewal(ctx context.Context, registry *KeyRegistry, period time.Duration, cutoffTime time.Time) (func(), error) {
 	// Create a new key if it's the first key,

--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -184,7 +184,7 @@ func TestReuseKey(t *testing.T) {
 		t.Fatalf("initKeyRenewal() returned err: %v", err)
 	}
 	if hasAction(client, "create", "secrets") {
-		t.Errorf("initKeyRenewal() should not create a new secret when one already exist and rotation is disabled")
+		t.Errorf("initKeyRenewal() should not create a new secret when one already exist and rotation is deactivated")
 	}
 }
 
@@ -348,6 +348,6 @@ func TestLegacySecret(t *testing.T) {
 		t.Fatalf("initKeyRenewal() returned err: %v", err)
 	}
 	if hasAction(client, "create", "secrets") {
-		t.Errorf("initKeyRenewal() should not create a new secret when one already exist and rotation is disabled")
+		t.Errorf("initKeyRenewal() should not create a new secret when one already exist and rotation is deactivated")
 	}
 }

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -49,7 +49,7 @@ Please refer to the [Kubeseal Developer Guide](kubeseal.md) for the developer se
 
 ## git-hooks
 
-To avoid easily detectable issues and prevent them from reaching master, some validations have been implemented via [git hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks). To have those hooks committed in the repository you need to install a third party tool `git-hooks` (check [prerequisites](#prerequisites)), because the hooks provided by Git are stored in the `.git` directory that is not included as part of the repositories.
+To avoid easily detectable issues and prevent them from reaching main, some validations have been implemented via [git hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks). To have those hooks committed in the repository you need to install a third party tool `git-hooks` (check [prerequisites](#prerequisites)), because the hooks provided by Git are stored in the `.git` directory that is not included as part of the repositories.
 
 Currently, there's a single hook at pre-commit level. This hook ensures the Table of Contents (TOC) is updated using `doctoc` (check [prerequisites](#prerequisites)) in every `.md` and `.txt` file that uses this tool.
 

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -255,7 +255,7 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ### To 2.0.0
 
-A major refactoring of the chart has been performed to adopt several common practices for Helm charts. Upgrades from previous chart versions should work, however, the values structure suffered several changes and you'll have to adapt your custom values/parameters so they're aligned with the new structure. For instance, these are a couple of examples:
+A major refactoring of the chart has been performed to adopt several common practices for Helm charts. Upgrades from previous chart versions should work, however, the values structure experienced several changes and you'll have to adapt your custom values/parameters so they're aligned with the new structure. For instance, these are a couple of examples:
 
 - `controller.create` renamed as `createController`.
 - `securityContext.*` parameters are deprecated in favor of `podSecurityContext.*`, and `containerSecurityContext.*` ones.

--- a/integration/kubeseal_test.go
+++ b/integration/kubeseal_test.go
@@ -360,16 +360,16 @@ var _ = Describe("kubeseal --recovery-unseal", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 	BeforeEach(func() {
-		master, err := c.Secrets("kube-system").List(ctx, metav1.ListOptions{
+		key, err := c.Secrets("kube-system").List(ctx, metav1.ListOptions{
 			LabelSelector: keySelector,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		backupKeysFile, err = os.CreateTemp("", "master")
+		backupKeysFile, err = os.CreateTemp("", "key")
 		Expect(err).NotTo(HaveOccurred())
 		defer backupKeysFile.Close()
 
-		json, err := json.Marshal(master)
+		json, err := json.Marshal(key)
 		Expect(err).NotTo(HaveOccurred())
 
 		backupKeysFile.Write(json)

--- a/site/themes/template/layouts/partials/docs-right-bar.html
+++ b/site/themes/template/layouts/partials/docs-right-bar.html
@@ -7,7 +7,7 @@
                 {{ $issueQuery := (querify "body" $issueBody) }}
                 <li><a href="{{ $.Site.Params.github_base_url }}/issues/new?{{ $issueQuery | safeURL }}" target="_blank">Report Issues</a></li>
                 {{ $editQuery := (querify "description" "Signed-off-by: NAME <EMAIL_ADDRESS>\n\n") }}
-                <li><a href="{{ $.Site.Params.github_base_url }}/edit/master/content/{{ with .File }}{{ .Path }}{{ end }}?{{ $editQuery | safeURL }}" target="_blank"><img src="/img/github-blue.svg" /> Edit</a></li>
+                <li><a href="{{ $.Site.Params.github_base_url }}/edit/main/content/{{ with .File }}{{ .Path }}{{ end }}?{{ $editQuery | safeURL }}" target="_blank"><img src="/img/github-blue.svg" /> Edit</a></li>
             {{ end }}
         </ul>
         {{ if ne .TableOfContents "<nav id=\"TableOfContents\"></nav>" }}


### PR DESCRIPTION
**Description of the change**
Use inclusive terminology.

- When referring to the repository branch, *master* has been replaced with *main* as it is the repository's default branch
- When referring to the Kubernetes node, *master* has been replaced with *control plane*
- *she* has been replaced with *they*
- *disable* has been replaced with *deactivate*
- *suffered* has been replaced with *experienced*