### PR TITLE
Rebase of Refactor flag handling

### DIFF
--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -112,7 +112,7 @@ func (f *Flags) Bind(fs *flag.FlagSet) {
 	fs.Var(&f.sealingScope, "scope", "Set the scope of the sealed secret: strict, namespace-wide, cluster-wide (defaults to strict). Mandatory for --raw, otherwise the 'sealedsecrets.bitnami.com/cluster-wide' and 'sealedsecrets.bitnami.com/namespace-wide' annotations on the input secret can be used to select the scope.")
 	fs.BoolVar(&f.reEncrypt, "rotate", false, "")
 	fs.BoolVar(&f.reEncrypt, "re-encrypt", false, "Re-encrypt the given sealed secret to use the latest cluster key.")
-	flag.CommandLine.MarkDeprecated("rotate", "please use --re-encrypt instead")
+	_ = flag.CommandLine.MarkDeprecated("rotate", "please use --re-encrypt instead")
 
 	fs.BoolVar(&f.unseal, "recovery-unseal", false, "Decrypt a sealed secrets file obtained from stdin, using the private key passed with --recovery-private-key. Intended to be used in disaster recovery mode.")
 	fs.StringSliceVar(&f.privKeys, "recovery-private-key", nil, "Private key filename used by the --recovery-unseal command. Multiple files accepted either via comma separated list or by repetition of the flag. Either PEM encoded private keys or a backup of a json/yaml encoded k8s sealed-secret controller secret (and v1.List) are accepted. ")

--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -678,8 +678,8 @@ func readPrivKeys(filenames []string) (map[string]*rsa.PrivateKey, error) {
 	return res, nil
 }
 
-func unsealSealedSecret(flags *Flags, w io.Writer, in io.Reader, codecs runtimeserializer.CodecFactory, privKeyFilenames []string) error {
-	privKeys, err := readPrivKeys(privKeyFilenames)
+func unsealSealedSecret(flags *Flags, w io.Writer, in io.Reader, codecs runtimeserializer.CodecFactory) error {
+	privKeys, err := readPrivKeys(flags.privKeys)
 	if err != nil {
 		return err
 	}
@@ -755,7 +755,7 @@ func run(w io.Writer, cfg *Config) (err error) {
 	}
 
 	if flags.unseal {
-		return unsealSealedSecret(flags, w, input, scheme.Codecs, flags.privKeys)
+		return unsealSealedSecret(flags, w, input, scheme.Codecs)
 	}
 	if len(flags.privKeys) != 0 && isatty.IsTerminal(os.Stderr.Fd()) {
 		fmt.Fprintf(os.Stderr, "warning: ignoring --recovery-private-key because unseal command not chosen with --recovery-unseal\n")

--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -11,7 +11,6 @@ import (
 	goflag "flag"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -135,6 +134,11 @@ func initNamespaceFuncFromClient(clientConfig clientcmd.ClientConfig) namespaceF
 	return func() (string, bool, error) { return clientConfig.Namespace() }
 }
 
+func logFatal(err error) {
+	fmt.Fprintf(os.Stderr, "error: %v\n", err)
+	os.Exit(1)
+}
+
 func initConfigFromFlags() *Config {
 	var flags Flags
 	flags.Bind(nil)
@@ -155,7 +159,7 @@ func initConfigFromFlags() *Config {
 
 	flag.Parse()
 	if err := goflag.CommandLine.Parse([]string{}); err != nil {
-		log.Fatalf("error: %v\n", err)
+		logFatal(err)
 	}
 
 	clientConfig := initClient(flags.kubeconfig, &overrides, os.Stdin)
@@ -831,7 +835,6 @@ func run(w io.Writer, cfg *Config) (err error) {
 func main() {
 	cfg := initConfigFromFlags()
 	if err := run(os.Stdout, cfg); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		logFatal(err)
 	}
 }

--- a/cmd/kubeseal/main_test.go
+++ b/cmd/kubeseal/main_test.go
@@ -701,7 +701,7 @@ func TestVersion(t *testing.T) {
 }
 
 func TestMainError(t *testing.T) {
-	const badFileName = "/?this/file/cannot/possibly/exist/can/it?"
+	badFileName := filepath.Join("this", "file", "cannot", "possibly", "exist", "can", "it?")
 	flags := Flags{certURL: badFileName}
 
 	err := run(io.Discard, testConfig(&flags))

--- a/cmd/kubeseal/main_test.go
+++ b/cmd/kubeseal/main_test.go
@@ -95,17 +95,18 @@ func tmpfile(t *testing.T, contents []byte) string {
 
 func testConfigOverrides() *clientcmd.ConfigOverrides {
 	flagset := flag.NewFlagSet("test", flag.PanicOnError)
-	testOverrides := initUsualKubectlFlags(flagset)
+	var overrides clientcmd.ConfigOverrides
+	initUsualKubectlFlags(&overrides, flagset)
 	err := flagset.Parse([]string{"-n", "default"})
 	if err != nil {
 		fmt.Printf("flagset parse err: %v\n", err)
 		os.Exit(1)
 	}
-	return testOverrides
+	return &overrides
 }
 
 func testClientConfig() clientcmd.ClientConfig {
-	return initClient("", *testConfigOverrides(), os.Stdin)
+	return initClient("", testConfigOverrides(), os.Stdin)
 }
 
 func TestParseKey(t *testing.T) {

--- a/cmd/kubeseal/main_test.go
+++ b/cmd/kubeseal/main_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -704,7 +703,7 @@ func TestMainError(t *testing.T) {
 	const badFileName = "/?this/file/cannot/possibly/exist/can/it?"
 	flags := Flags{certURL: badFileName}
 
-	err := run(ioutil.Discard, testConfig(&flags))
+	err := run(io.Discard, testConfig(&flags))
 	if err == nil || !os.IsNotExist(err) {
 		t.Fatalf("expecting not exist error, got: %v", err)
 	}

--- a/cmd/kubeseal/main_test.go
+++ b/cmd/kubeseal/main_test.go
@@ -486,8 +486,6 @@ func newTestKeyPair(t *testing.T) (*rsa.PublicKey, map[string]*rsa.PrivateKey) {
 }
 
 func TestUnseal(t *testing.T) {
-	var flags Flags
-
 	pubKey, privKeys := newTestKeyPair(t)
 	pkFile, err := os.CreateTemp("", "")
 	if err != nil {
@@ -513,7 +511,8 @@ func TestUnseal(t *testing.T) {
 	ss := mkTestSealedSecret(t, pubKey, secretItemKey, secretItemValue)
 
 	var buf bytes.Buffer
-	if err := unsealSealedSecret(&flags, &buf, bytes.NewBuffer(ss), scheme.Codecs, []string{pkFile.Name()}); err != nil {
+	flags := Flags{privKeys: []string{pkFile.Name()}}
+	if err := unsealSealedSecret(&flags, &buf, bytes.NewBuffer(ss), scheme.Codecs); err != nil {
 		t.Fatal(err)
 	}
 
@@ -528,8 +527,6 @@ func TestUnseal(t *testing.T) {
 }
 
 func TestUnsealList(t *testing.T) {
-	var flags Flags
-
 	pubKey, privKeys := newTestKeyPair(t)
 	pkFile, err := os.CreateTemp("", "")
 	if err != nil {
@@ -572,7 +569,8 @@ func TestUnsealList(t *testing.T) {
 	ss := mkTestSealedSecret(t, pubKey, secretItemKey, secretItemValue)
 
 	var buf bytes.Buffer
-	if err := unsealSealedSecret(&flags, &buf, bytes.NewBuffer(ss), scheme.Codecs, []string{pkFile.Name()}); err != nil {
+	flags := Flags{privKeys: []string{pkFile.Name()}}
+	if err := unsealSealedSecret(&flags, &buf, bytes.NewBuffer(ss), scheme.Codecs); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This is basically a rebase of #440 with some extra `Config` struct to wrap everything and avoid all remaining globals.

The run method was too long and it was impossible to figure out what each parameter meant.
Furthermore a few flags were still accessed via global variables making it hard to reason about
and to test properly.

This is the first pass that just mechanically puts all the flag variables into a struct.

**Benefits**

No more global variables, easier to pass flags around and more readable and maintainable code.
