### PR TITLE
Publish kubeseal binary in a Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,9 @@ jobs:
 
     - name: Distroless verify
       run: |
-        cosign verify --key /dev/stdin "$(grep FROM Dockerfile | awk '{print $2}')" <<EOF
+        diff <(grep FROM docker/kubeseal.Dockerfile | awk '{print $2}') \
+             <(grep FROM docker/controller.Dockerfile | awk '{print $2}')
+        cosign verify --key /dev/stdin "$(grep FROM docker/controller.Dockerfile | awk '{print $2}')" <<EOF
         -----BEGIN PUBLIC KEY-----
         MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWZzVzkb8A+DbgDpaJId/bOmV8n7Q
         OqxYbK0Iro6GzSmOzxkn+N2AKawLyXi84WSwJQBK//psATakCgAQKkNTAA==

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gotestsum: ["1.8.1"]
+        include:
+          - dockerfile: ./docker/controller.Dockerfile
+            image: docker.io/bitnami/sealed-secrets-controller
+          - dockerfile: ./docker/controller.Dockerfile
+            image: ghcr.io/bitnami-labs/sealed-secrets-controller
+          - dockerfile: ./docker/kubeseal.Dockerfile
+            image: docker.io/bitnami/sealed-secrets-kubeseal
+          - dockerfile: ./docker/kubeseal.Dockerfile
+            image: ghcr.io/bitnami-labs/sealed-secrets-kubeseal
     env:
       dockerhub_image_name: docker.io/bitnami/sealed-secrets-controller
       ghcr_image_name: ghcr.io/bitnami-labs/sealed-secrets-controller
@@ -31,7 +39,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          go install gotest.tools/gotestsum@v${{ matrix.gotestsum }}
+          go install gotest.tools/gotestsum@v1.8.1
 
       # Run tests
       - name: Tests
@@ -87,14 +95,13 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: |
-            ${{ env.dockerhub_image_name }}
-            ${{ env.ghcr_image_name }}
+          images: ${{ matrix.image }}
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
         with:
           context: .
+          file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64,linux/arm
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,10 @@
 
 /controller.image
 /controller.image.*
+/kubeseal.image
+/kubeseal.image.*
 /pushed.controller.image.*
+/pushed.kubeseal.image.*
 /controller-manifest-*
 /push-controller-image
 /*-static
@@ -34,6 +37,7 @@
 /docker/controller
 *.iml
 .idea
+gentmp/
 
 # GoReleaser output dir
 dist/

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ CONTROLLER_GEN ?= controller-gen
 
 REGISTRY ?= docker.io
 CONTROLLER_IMAGE = $(REGISTRY)/bitnami/sealed-secrets-controller:latest
-KUBESEAL_IMAGE = $(REGISTRY)/bitnami/kubeseal:latest
+KUBESEAL_IMAGE = $(REGISTRY)/bitnami/sealed-secrets-kubeseal:latest
 INSECURE_REGISTRY = false # useful for local registry
 IMAGE_PULL_POLICY = Always
 KUBECONFIG ?= $(HOME)/.kube/config
@@ -52,7 +52,7 @@ generate: $(GO_FILES)
 	@# github.com/bitnami-labs/sealeds-secrets/...
 	@# instead of just updating ./pkg 
 	@# for that reason we generate at gentmp and then move it all to ./pkg
-	cp -r gentmp/github.com/bitnami-labs/sealed-secrets/pkg . && rm gentmp/ -rf
+	cp -r gentmp/github.com/bitnami-labs/sealed-secrets/pkg . && rm -rf gentmp/
 
 manifests:
 	$(CONTROLLER_GEN) crd paths="./pkg/apis/..."  output:crd:artifacts:config=helm/sealed-secrets/crds/
@@ -86,18 +86,23 @@ kubeseal-static: kubeseal-static-$(GOOS)-$(GOARCH)
 	cp $< $@
 
 
-define controllerimage
-controller.image.$(1)-$(2): Dockerfile controller-static-$(1)-$(2)
-	mkdir -p dist/controller_$(1)_$(2)
-	cp controller-static-$(1)-$(2) dist/controller_$(1)_$(2)/controller
-	$(DOCKER) build --build-arg TARGETARCH=$(2) -t $(CONTROLLER_IMAGE)-$(1)-$(2) .
-	@echo $(CONTROLLER_IMAGE)-$(1)-$(2) >$$@.tmp
+define image
+$(1).image.$(3)-$(4): docker/$(1).Dockerfile $(1)-static-$(3)-$(4)
+	mkdir -p dist/$(1)_$(3)_$(4)
+	cp $(1)-static-$(3)-$(4) dist/$(1)_$(3)_$(4)/$(1)
+	$(DOCKER) build --build-arg TARGETARCH=$(4) -t $(2)-$(3)-$(4) -f docker/$(1).Dockerfile .
+	@echo $(2)-$(3)-$(4) >$$@.tmp
 	@mv $$@.tmp $$@
 endef
 
-$(eval $(call controllerimage,linux,amd64))
-$(eval $(call controllerimage,linux,arm64))
-$(eval $(call controllerimage,linux,arm))
+define images
+$(call image,controller,${CONTROLLER_IMAGE},$1,$2)
+$(call image,kubeseal,${KUBESEAL_IMAGE},$1,$2)
+endef
+
+$(eval $(call images,linux,amd64))
+$(eval $(call images,linux,arm64))
+$(eval $(call images,linux,arm))
 
 %.yaml: %.jsonnet
 	$(KUBECFG) show -V CONTROLLER_IMAGE=$(CONTROLLER_IMAGE) -V IMAGE_PULL_POLICY=$(IMAGE_PULL_POLICY) -o yaml $< > $@.tmp

--- a/docker/controller.Dockerfile
+++ b/docker/controller.Dockerfile
@@ -4,7 +4,8 @@ LABEL maintainer "Bitnami <containers@bitnami.com>, Marko Mikulicic <mmikulicic@
 USER 1001
 
 ARG TARGETARCH
-COPY dist/controller_linux_$TARGETARCH*/controller /usr/local/bin/
+COPY dist/controller_linux_${TARGETARCH}*/controller /usr/local/bin/
 
 EXPOSE 8080
+
 ENTRYPOINT ["controller"]

--- a/docker/kubeseal.Dockerfile
+++ b/docker/kubeseal.Dockerfile
@@ -1,0 +1,9 @@
+FROM gcr.io/distroless/static@sha256:d6fa9db9548b5772860fecddb11d84f9ebd7e0321c0cb3c02870402680cc315f
+LABEL maintainer "Bitnami <containers@bitnami.com>, Marko Mikulicic <mmikulicic@gmail.com>"
+
+USER 1001
+
+ARG TARGETARCH
+COPY dist/kubeseal_linux_${TARGETARCH}*/kubeseal /usr/local/bin/
+
+ENTRYPOINT ["kubeseal"]


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

New official docker images containing the `kubeseal` binary

**Benefits**

Users may copy the binary directly while building their own docker images

**Possible drawbacks**

Too many images, maybe?

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #916

**Additional information**

1) <strike>Question about the name of the image, should it be `kubeseal` or `sealed-secrets-kubeseal`</strike> -> `sealed-secrets-kubeseal`

2) Another question about the dockerfiles, there does not seem to be a straightforward way to have only one Dockerfile and use arguments to specify the tool ( kubeseal vs controller ) mainly due to the entrypoint, is it okay to keep both files?

3) I have just tested the build phase via `make` but not sure about the push/release process

