### PR TITLE
Simplify controller testing

### DIFF
--- a/docs/developer/controller.md
+++ b/docs/developer/controller.md
@@ -33,7 +33,7 @@ The controller sources are located under `cmd/controller/` and use packages from
 
 ### Setup a kubernetes cluster to run the tests
 
-You need a kubernetes cluster to run the intgeration tests.
+You need a kubernetes cluster to run the integration tests.
 
 For instance:
 

--- a/docs/developer/controller.md
+++ b/docs/developer/controller.md
@@ -11,11 +11,14 @@ The controller exposes an API defined using the Swagger or OpenAPI v3 specificat
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Download the controller source code](#download-the-controller-source-code)
-  - [Building the `controller` binary](#building-the-controller-binary)
-  - [Running unit tests](#running-unit-tests)
-  - [Building the controller image](#building-the-controller-image)
-  - [Building the controller manifests](#building-the-controller-manifests)
-  - [Running integration tests](#running-integration-tests)
+  - [Setup a kubernetes cluster to run the tests](#setup-a-kubernetes-cluster-to-run-the-tests)
+  - [Run all controller tests with a single command](#run-all-controller-tests-with-a-single-command)
+  - [Run tests step by step](#run-tests-step-by-step)
+    - [Building the `controller` binary](#building-the-controller-binary)
+    - [Running unit tests](#running-unit-tests)
+    - [Push the controller image](#push-the-controller-image)
+    - [Building & applying the controller manifests](#building--applying-the-controller-manifests)
+    - [Running integration tests](#running-integration-tests)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -27,43 +30,12 @@ git clone https://github.com/bitnami-labs/sealed-secrets.git $SEALED_SECRETS_DIR
 
 The controller sources are located under `cmd/controller/` and use packages from the `pkg` directory.
 
-### Building the `controller` binary
 
-```bash
-make controller
-```
+### Setup a kubernetes cluster to run the tests
 
-This builds the `controller` binary in the working directory.
+You need a kubernetes cluster to run the intgeration tests.
 
-### Running unit tests
-
-To run the unit tests for `controller` binary:
-
-```bash
-make test
-```
-
-### Building the controller image
-
-```bash
-CONTROLLER_IMAGE="bitnami/sealed-secrets-controller:development"
-make CONTROLLER_IMAGE=$CONTROLLER_IMAGE controller.image.linux-amd64
-docker tag $CONTROLLER_IMAGE-linux-amd64 $CONTROLLER_IMAGE
-```
-
-This builds the controller container image.
-
-### Building the controller manifests
-
-```bash
-make CONTROLLER_IMAGE=$CONTROLLER_IMAGE IMAGE_PULL_POLICY=Never controller.yaml
-```
-
-This builds the controller K8s manifests in the working directory.
-
-### Running integration tests
-
-To run the integration tests:
+For instance:
 
 - Start Minikube and configure your local environment to re-use the Docker daemon inside the Minikube instance:
 
@@ -72,18 +44,64 @@ minikube start
 eval $(minikube docker-env)
 ```
 
-- [Build the controller container image](#building-the-controller-image).
-- [Build the controller manifests](#building-the-controller-manifests).
-
-- Deploy the Sealed Secrets CRD and controller to your Minikube cluster:
+### Run all controller tests with a single command
 
 ```bash
-kubectl apply -f controller.yaml
+make K8S_CONTEXT=mytestk8s-context OS=linux ARCH=amd64 controller-tests
 ```
 
-- Clean the environment and run the integration tests:
+Note that:
+- `K8S_CONTEXT` must be set to the name of your `kubectl` context pointing to the expected text cluster.
+- `OS` & `ARCH` must match the Operating System and Architecture of your test cluster.
+
+Optionally, you can customize the `REGISTRY` as well:
 
 ```bash
-make clean
+make K8S_CONTEXT=kind-mykind REGISTRY=localhost:5000 OS=linux ARCH=amd64 controller-tests
+```
+
+### Run tests step by step
+
+#### Building the `controller` binary
+
+```bash
+make controller
+```
+
+This builds the `controller` binary in the working directory.
+
+#### Running unit tests
+
+To run the unit tests for `controller` binary:
+
+```bash
+make test
+```
+
+#### Push the controller image
+
+```bash
+make OS=linux ARCH=amd64 push-controller
+```
+
+This builds the controller container image and pushes it.
+
+Remember that the `REGISTRY` env var is only needed when using a custom registry:
+
+```bash
+make REGISTRY=localhost:5000 OS=linux ARCH=amd64 push-controller
+```
+
+#### Building & applying the controller manifests
+
+```bash
+make K8S_CONTEXT=kind-mykind REGISTRY=localhost:5000 apply-controller-manifests
+```
+
+This builds the controller K8s manifests in the working directory and deploys them.
+
+#### Running integration tests
+
+```bash
 make integrationtest
 ```

--- a/scripts/check-k8s
+++ b/scripts/check-k8s
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export K8S_CONTEXT="${K8S_CONTEXT}"
+
+if kubectl config current-context > /dev/null ;then
+	k8s_current_context=$(kubectl config current-context);
+	if [ "${k8s_current_context}" != "${K8S_CONTEXT}" ]; then \
+		echo "Expected k8s context '${K8S_CONTEXT}' but got '${k8s_current_context}'";
+		exit 1;
+	fi
+else
+	echo "Set up your k8s config for '${K8S_CONTEXT}' (using minikube or kind for example)";
+	exit 1;
+fi
+
+echo "'${K8S_CONTEXT}' is configured as kubectl's current context"
+


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add a `controller-tests` Makefile rule that will automatically setup everything to run all tests required for validating the controller. 

This includes the integration tests and requires that a given Kubernetes configuration context, environment variable `K8S_CONTEXT`, is available to deploy all controller artifacts and run the integration tests.

There are also environment variables to:
- Customize the `REGISTRY` to which the controller images compiled will we pushed to and used from the tested code.
- Specify the `OS` and architecture (`ARCH`) of the target test cluster.

**Benefits**

I noticed I was failing to properly run the numerous steps to test the controller on my local `kind` cluster. For instance, I was not setting the registry properly, so it was probably testing a stale older image of the controller.

This new single step avoids an error prone sequence of steps. Not only it makes things easier, it also ensures you are running the test against the expected cluster context.
