### PR TITLE
Remove non-inclusive references

### DIFF
--- a/site/themes/template/static/fonts/README.md
+++ b/site/themes/template/static/fonts/README.md
@@ -1,5 +1,3 @@
-![Metropolis](https://github.com/chrismsimpson/Metropolis/blob/master/Images/metropolis-1.png)
-
 # The Metropolis Typeface
 
 The Vision

--- a/vendor_jsonnet/kube-libsonnet/README.md
+++ b/vendor_jsonnet/kube-libsonnet/README.md
@@ -1,4 +1,3 @@
-[![Build Status](https://travis-ci.org/bitnami-labs/kube-libsonnet.svg?branch=master)](https://travis-ci.org/bitnami-labs/kube-libsonnet)
 # kube-libsonnet
 
 This repo has been originally populated by the `lib/` folder contents


### PR DESCRIPTION
**Description of the change**
Remove two `master` branch references. These references are not needed (in fact, one of them is not online anymore) so it's better to remove them.

Follow-up: #917
