### PR TITLE
Fix Dockerfile to align with new GoReleaser Path format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer "Bitnami <containers@bitnami.com>, Marko Mikulicic <mmikulicic@
 USER 1001
 
 ARG TARGETARCH
-COPY dist/controller_linux_$TARGETARCH/controller /usr/local/bin/
+COPY dist/controller_linux_$TARGETARCH*/controller /usr/local/bin/
 
 EXPOSE 8080
 ENTRYPOINT ["controller"]


### PR DESCRIPTION
**Description of the change**

GoReleaser has changed the path format to generate the binaries. Modifying the Dockerfile, we are changing the copy path to generate the images.

**Benefits**

Fix the Release process.
