### PR TITLE
Remove /dev/stdin mentions in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,14 +434,14 @@ See [Scopes](#scopes)
 `strict` scope (default):
 
 ```console
-$ echo -n foo | kubeseal --raw --from-file=/dev/stdin --namespace bar --name mysecret
+$ echo -n foo | kubeseal --raw --namespace bar --name mysecret
 AgBChHUWLMx...
 ```
 
 `namespace-wide` scope:
 
 ```console
-$ echo -n foo | kubeseal --raw --from-file=/dev/stdin --namespace bar --scope namespace-wide
+$ echo -n foo | kubeseal --raw --namespace bar --scope namespace-wide
 AgAbbFNkM54...
 ```
 Include the `sealedsecrets.bitnami.com/namespace-wide` annotation in the `SealedSecret`
@@ -454,7 +454,7 @@ metadata:
 `cluster-wide` scope:
 
 ```console
-$ echo -n foo | kubeseal --raw --from-file=/dev/stdin --scope cluster-wide
+$ echo -n foo | kubeseal --raw --scope cluster-wide
 AgAjLKpIYV+...
 ```
 Include the `sealedsecrets.bitnami.com/cluster-wide` annotation in the `SealedSecret`


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

As per https://github.com/bitnami-labs/sealed-secrets/issues/934 we noticed users might run into issues when testing the README raw commands that mention `/dev/stdin` and will not work in Windows.

As that flag is not required and does not work in Windows seems better to remove it from the examples.

**Benefits**

Simpler documentation, less confusion and friction for Windows users.
