### PR TITLE
Fix missing push and readme on new tests rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,7 @@ check-k8s:
 
 push-controller: clean check-k8s controller.image.$(OS)-$(ARCH)
 	docker tag $(CONTROLLER_IMAGE)-$(OS)-$(ARCH) $(CONTROLLER_IMAGE)
+	docker push $(CONTROLLER_IMAGE)
 
 apply-controller-manifests: clean check-k8s controller.yaml
 	kubectl apply -f controller.yaml

--- a/docs/developer/controller.md
+++ b/docs/developer/controller.md
@@ -81,7 +81,7 @@ make test
 #### Push the controller image
 
 ```bash
-make OS=linux ARCH=amd64 push-controller
+make K8S_CONTEXT=kind-mykind OS=linux ARCH=amd64 push-controller
 ```
 
 This builds the controller container image and pushes it.
@@ -89,7 +89,7 @@ This builds the controller container image and pushes it.
 Remember that the `REGISTRY` env var is only needed when using a custom registry:
 
 ```bash
-make REGISTRY=localhost:5000 OS=linux ARCH=amd64 push-controller
+make K8S_CONTEXT=kind-mykind REGISTRY=localhost:5000 OS=linux ARCH=amd64 push-controller
 ```
 
 #### Building & applying the controller manifests


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

The push was missing and some instructions also regarding the push rule were inaccurate, missing the `K8S_CONTEXT` env var.
