### PR TITLE
Explain helm chart install on restricted environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ resources:
 Note that:
 - No service accounts are created, instead the one allocated to you will be used.
   - `{allocated-service-account}` is the name of the `service account` you were allocated on the cluster.
-- No RBAC roles are created neither in the namespace or the cluster.
+- No RBAC roles are created neither in the namespace nor the cluster.
 - Resource limits must be especified.
   - The limits are samples that shoudl work, but you might want to review them in your particular setup.
 

--- a/README.md
+++ b/README.md
@@ -336,8 +336,8 @@ Note that:
 - No service accounts are created, instead the one allocated to you will be used.
   - `{allocated-service-account}` is the name of the `service account` you were allocated on the cluster.
 - No RBAC roles are created neither in the namespace or the cluster.
-- Resource limits must be espeficied.
-  - The limits are samples that shoudl work, but you might want to review them in your parituclar setup.
+- Resource limits must be especified.
+  - The limits are samples that shoudl work, but you might want to review them in your particular setup.
 
 Once that file is ready, if you named it `config.yaml` you now can install the sealed secrets Helm Chart like this: 
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Users within an enterprise might face very restrictive installation environments for Sealed Secrets.

This change adds documentation specific on how to install from the Helm Chart on one of the most restrictive cases out there:
- Access to a single `namespace` and `service account` only, no cluster access at all.

**Benefits**

Users facing restrictive Kubernetes environment have now easy to follow instructions to install from the chart.
