### PR TITLE
Remove magic init funcs and global flags

### DIFF
--- a/cmd/controller/keyregistry.go
+++ b/cmd/controller/keyregistry.go
@@ -47,8 +47,8 @@ func NewKeyRegistry(client kubernetes.Interface, namespace, keyPrefix, keyLabel 
 	}
 }
 
-func (kr *KeyRegistry) generateKey(ctx context.Context) (string, error) {
-	key, cert, err := generatePrivateKeyAndCert(kr.keysize)
+func (kr *KeyRegistry) generateKey(ctx context.Context, validFor time.Duration, cn string) (string, error) {
+	key, cert, err := generatePrivateKeyAndCert(kr.keysize, validFor, cn)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/controller/keyregistry_test.go
+++ b/cmd/controller/keyregistry_test.go
@@ -7,19 +7,21 @@ import (
 
 func TestRegisterNewKey(t *testing.T) {
 	const keySize = 2048
+	validFor := time.Hour
+	cn := "my-cn"
 	kr := NewKeyRegistry(nil, "namespace", "prefix", "label", keySize)
 
 	if kr.mostRecentKey != nil {
 		t.Fatal("this test assumes a new key registry has no keys")
 	}
 
-	key1, cert1, err := generatePrivateKeyAndCert(keySize)
+	key1, cert1, err := generatePrivateKeyAndCert(keySize, validFor, cn)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t1 := time.Now()
 
-	key2, cert2, err := generatePrivateKeyAndCert(keySize)
+	key2, cert2, err := generatePrivateKeyAndCert(keySize, validFor, cn)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/controller/keys.go
+++ b/cmd/controller/keys.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"time"
 
 	"github.com/bitnami-labs/sealed-secrets/pkg/crypto"
 	v1 "k8s.io/api/core/v1"
@@ -23,8 +24,8 @@ var (
 	ErrPrivateKeyNotRSA = errors.New("Private key is not an RSA key")
 )
 
-func generatePrivateKeyAndCert(keySize int) (*rsa.PrivateKey, *x509.Certificate, error) {
-	return crypto.GeneratePrivateKeyAndCert(keySize, *validFor, *myCN)
+func generatePrivateKeyAndCert(keySize int, validFor time.Duration, cn string) (*rsa.PrivateKey, *x509.Certificate, error) {
+	return crypto.GeneratePrivateKeyAndCert(keySize, validFor, cn)
 }
 
 func readKey(secret v1.Secret) (*rsa.PrivateKey, []*x509.Certificate, error) {

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -80,10 +80,10 @@ func bindControllerFlags(f *Flags) {
 
 	flag.BoolVar(&f.OldGCBehavior, "old-gc-behaviour", false, "Revert to old GC behavior where the controller deletes secrets instead of delegating that to k8s itself.")
 
-	flag.BoolVar(&f.UpdateStatus, "update-status", true, "beta: if true, the controller will update the status subresource whenever it processes a sealed secret")
-
 	flag.DurationVar(&f.KeyRenewPeriod, "rotate-period", defaultKeyRenewPeriod, "")
 	_ = flag.CommandLine.MarkDeprecated("rotate-period", "please use key-renew-period instead")
+
+	flag.BoolVar(&f.UpdateStatus, "update-status", true, "beta: if true, the controller will update the status subresource whenever it processes a sealed secret")
 }
 
 func bindFlags(f *Flags, printVersion *bool) {

--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -55,7 +55,9 @@ func TestInitKeyRegistry(t *testing.T) {
 	}
 
 	// Add a key to the controller for second test
-	_, err = registry.generateKey(ctx)
+	validFor := time.Hour
+	cn := "my-cn"
+	_, err = registry.generateKey(ctx, validFor, cn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +89,9 @@ func TestInitKeyRotation(t *testing.T) {
 		t.Fatalf("initKeyRegistry() returned err: %v", err)
 	}
 
-	keyGenTrigger, err := initKeyRenewal(ctx, registry, 0, time.Time{})
+	validFor := time.Hour
+	cn := "my-cn"
+	keyGenTrigger, err := initKeyRenewal(ctx, registry, 0, validFor, time.Time{}, cn)
 	if err != nil {
 		t.Fatalf("initKeyRenewal() returned err: %v", err)
 	}
@@ -126,7 +130,9 @@ func TestInitKeyRotationTick(t *testing.T) {
 		t.Fatalf("initKeyRegistry() returned err: %v", err)
 	}
 
-	_, err = initKeyRenewal(ctx, registry, 100*time.Millisecond, time.Time{})
+	validFor := time.Hour
+	cn := "my-cn"
+	_, err = initKeyRenewal(ctx, registry, 100*time.Millisecond, validFor, time.Time{}, cn)
 	if err != nil {
 		t.Fatalf("initKeyRenewal() returned err: %v", err)
 	}
@@ -179,7 +185,9 @@ func TestReuseKey(t *testing.T) {
 		t.Fatalf("initKeyRegistry() returned err: %v", err)
 	}
 
-	_, err = initKeyRenewal(ctx, registry, 0, time.Time{})
+	validFor := time.Hour
+	cn := "my-cn"
+	_, err = initKeyRenewal(ctx, registry, 0, validFor, time.Time{}, cn)
 	if err != nil {
 		t.Fatalf("initKeyRenewal() returned err: %v", err)
 	}
@@ -223,7 +231,9 @@ func TestRenewStaleKey(t *testing.T) {
 		t.Fatalf("initKeyRegistry() returned err: %v", err)
 	}
 
-	_, err = initKeyRenewal(ctx, registry, period, time.Time{})
+	validFor := time.Hour
+	cn := "my-cn"
+	_, err = initKeyRenewal(ctx, registry, period, validFor, time.Time{}, cn)
 	if err != nil {
 		t.Fatalf("initKeyRenewal() returned err: %v", err)
 	}
@@ -281,7 +291,9 @@ func TestKeyCutoff(t *testing.T) {
 	client.ClearActions()
 
 	// by setting cutoff to "now" we effectively force the creation of a new key.
-	_, err = initKeyRenewal(ctx, registry, period, time.Now())
+	validFor := time.Hour
+	cn := "my-cn"
+	_, err = initKeyRenewal(ctx, registry, period, validFor, time.Now(), cn)
 	if err != nil {
 		t.Fatalf("initKeyRenewal() returned err: %v", err)
 	}
@@ -343,7 +355,9 @@ func TestLegacySecret(t *testing.T) {
 		t.Fatalf("initKeyRegistry() returned err: %v", err)
 	}
 
-	_, err = initKeyRenewal(ctx, registry, 0, time.Time{})
+	validFor := time.Hour
+	cn := "my-cn"
+	_, err = initKeyRenewal(ctx, registry, 0, validFor, time.Time{}, cn)
 	if err != nil {
 		t.Fatalf("initKeyRenewal() returned err: %v", err)
 	}

--- a/cmd/controller/metrics.go
+++ b/cmd/controller/metrics.go
@@ -27,14 +27,7 @@ var conditionStatusToGaugeValue = map[v1.ConditionStatus]float64{
 
 // Define Prometheus metrics to expose
 var (
-	buildInfo = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace:   metricNamespace,
-			Name:        "build_info",
-			Help:        "Build information.",
-			ConstLabels: prometheus.Labels{"revision": VERSION},
-		},
-	)
+	buildInfo prometheus.Gauge
 	// TODO: rename metric, change increment logic, or accept behaviour
 	// when a SealedSecret is deleted the unseal() function is called which is
 	// not technically an 'unseal request'.
@@ -80,7 +73,15 @@ var (
 	)
 )
 
-func init() {
+func registerMetrics(version string) {
+	buildInfo = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace:   metricNamespace,
+			Name:        "build_info",
+			Help:        "Build information.",
+			ConstLabels: prometheus.Labels{"revision": version},
+		},
+	)
 	// Register metrics with Prometheus
 	prometheus.MustRegister(buildInfo)
 	prometheus.MustRegister(collectors.NewBuildInfoCollector())

--- a/cmd/controller/server_test.go
+++ b/cmd/controller/server_test.go
@@ -39,12 +39,14 @@ func shutdownServer(server *http.Server, t *testing.T) {
 }
 
 func TestHttpCert(t *testing.T) {
-	_, certBefore, err := generatePrivateKeyAndCert(2048)
+	validFor := time.Hour
+	cn := "my-cn"
+	_, certBefore, err := generatePrivateKeyAndCert(2048, validFor, cn)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, certAfter, err := generatePrivateKeyAndCert(2048)
+	_, certAfter, err := generatePrivateKeyAndCert(2048, validFor, cn)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Like with the CLI, the controller main code relies too much on global flags that get used more deeply in the code than needed. Also the use of `func init()` "magic" initializations would make moving code out of the main package problematic. So:
- All flags but the `printVersion` one are packed into a single `Flags` struct, similarly to what was done with the CLI recently. That removes most global variables in main right now.
- Both `func init()` functions are replaced by explicit calls with explicit parameters.

**Benefits**

The code is now ready to be easily moved to a package while keeping the command line concerns in main.
