### PR TITLE
Extend controller-tests support and docs to minikube

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,10 +137,15 @@ check-k8s:
 
 push-controller: clean check-k8s controller.image.$(OS)-$(ARCH)
 	docker tag $(CONTROLLER_IMAGE)-$(OS)-$(ARCH) $(CONTROLLER_IMAGE)
+ifeq ($(REGISTRY),docker.io)
+  echo "Skip push: docker.io registy means minikube"
+else
 	docker push $(CONTROLLER_IMAGE)
+endif
 
 apply-controller-manifests: clean check-k8s controller.yaml
 	kubectl apply -f controller.yaml
+	kubectl rollout status deployment sealed-secrets-controller -n kube-system
 
 controller-tests: test push-controller apply-controller-manifests clean integrationtest
 

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ check-k8s:
 push-controller: clean check-k8s controller.image.$(OS)-$(ARCH)
 	docker tag $(CONTROLLER_IMAGE)-$(OS)-$(ARCH) $(CONTROLLER_IMAGE)
 ifeq ($(REGISTRY),docker.io)
-  echo "Skip push: docker.io registy means minikube"
+  echo "Skip push: docker.io registry means minikube"
 else
 	docker push $(CONTROLLER_IMAGE)
 endif


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

When making tests with `minikube` locally in the OSS project I noticed the new `make controller-tests` was not working as expected: In the case of `minikube` we need to skip the docker push that is required for kind.

I also noticed a race condition with the apply manifests rule as they did not wait for the deployment to be stable, so tests could be run too soon.

The documentation of this can be improved by adding more details on the `kind` vs `minikube` setups and the parameters they need to use.

**Benefits**

More reliable `make controller-test` supporting `minikube` and better documentation on both recommended setups: `kind` & `minikube`.
