### PR TITLE
Take into account annotations and commonAnnotations in our chart

### DIFF
--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
     url: https://github.com/bitnami-labs/sealed-secrets
 name: sealed-secrets
 type: application
-version: 2.6.1
+version: 2.6.2

--- a/helm/sealed-secrets/templates/service.yaml
+++ b/helm/sealed-secrets/templates/service.yaml
@@ -4,8 +4,14 @@ kind: Service
 metadata:
   name: {{ include "sealed-secrets.fullname" . }}
   namespace: {{ include "sealed-secrets.namespace" . }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- toYaml .Values.commonAnnotations | nindent 4 }}
+  {{- if or .Values.service.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.service.annotations }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- end }}
   labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
     {{- if .Values.service.labels }}


### PR DESCRIPTION
**Description of the change**

Our chart is including only the commonAnnotations without taking into account the service.annotations. This patch includes support for including the annotations in service.annotations and commonAnnotations. 

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #942
