### PR TITLE
Allow additional volumes deployment

### DIFF
--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
     url: https://github.com/bitnami-labs/sealed-secrets
 name: sealed-secrets
 type: application
-version: 2.6.1
+version: 2.6.2

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -96,6 +96,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `rateLimit`                                       | Number of allowed sustained request per second for verify endpoint                   | `""`                                |
 | `rateLimitBurst`                                  | Number of requests allowed to exceed the rate limit per second for verify endpoint   | `""`                                |
 | `additionalNamespaces`                            | List of namespaces used to manage the Sealed Secrets                                 | `[]`                                |
+| `additionalVolumes`                               | Extra volumes to be added to the controller deployment                               | `[]`                                |
+| `additionalVolumeMounts`                          | Extra volumeMounts to be added to the controller deployment's container              | `[]`                                |
 | `command`                                         | Override default container command                                                   | `[]`                                |
 | `args`                                            | Override default container args                                                      | `[]`                                |
 | `livenessProbe.enabled`                           | Enable livenessProbe on Sealed Secret containers                                     | `true`                              |
@@ -165,6 +167,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Name                                          | Description                                                   | Value   |
 | --------------------------------------------- | ------------------------------------------------------------- | ------- |
+| `serviceAccount.annotations`                  | Extra labels to be added to the ServiceAccount                | `{}`    |
 | `serviceAccount.create`                       | Specifies whether a ServiceAccount should be created          | `true`  |
 | `serviceAccount.labels`                       | Extra labels to be added to the ServiceAccount                | `{}`    |
 | `serviceAccount.name`                         | The name of the ServiceAccount to use.                        | `""`    |

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -118,9 +118,15 @@ spec:
           securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           volumeMounts:
+            {{- if .Values.additionalVolumeMounts }}
+              {{- toYaml .Values.additionalVolumeMounts | nindent 12 }} 
+            {{- end }}
             - mountPath: /tmp
               name: tmp
-      volumes:
+      volumes: 
+      {{- if .Values.additionalVolumes }}
+        {{- toYaml .Values.additionalVolumes | nindent 8 }} 
+      {{- end }}
         - name: tmp
           emptyDir: {}
 {{- end }}

--- a/helm/sealed-secrets/templates/service-account.yaml
+++ b/helm/sealed-secrets/templates/service-account.yaml
@@ -7,8 +7,14 @@ automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountT
 metadata:
   name: {{ include "sealed-secrets.serviceAccountName" . }}
   namespace: {{ include "sealed-secrets.namespace" . }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- toYaml .Values.commonAnnotations | nindent 4 }}
+  {{- if or (.Values.commonAnnotations) (.Values.serviceAccount.annotations) }}
+  annotations: 
+    {{- if .Values.commonAnnotations }}
+    {{- toYaml .Values.commonAnnotations | nindent 4 }}
+    {{- end}}
+    {{- if .Values.serviceAccount.annotations }}
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+    {{- end}}
   {{- end }}
   labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
     {{- if .Values.serviceAccount.labels }}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -187,6 +187,14 @@ nodeSelector: {}
 ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations: []
+## @param additionalVolumes [object] Extra Volumes for the Sealed Secrets Controller Deployment
+## ref: https://kubernetes.io/docs/concepts/storage/volumes/
+##
+additionalVolumes: []
+## @param additionalVolumeMounts [object] Extra volumeMounts for the Sealed Secrets Controller container
+## ref: https://kubernetes.io/docs/concepts/storage/volumes/
+##
+additionalVolumeMounts: []
 
 ## @section Traffic Exposure Parameters
 

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -318,6 +318,10 @@ networkPolicy:
 ## ServiceAccount configuration
 ##
 serviceAccount:
+  ## @param serviceAccount.annotations [object] Annotations for Sealed Secret service account
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  annotations: {}
   ## @param serviceAccount.create Specifies whether a ServiceAccount should be created
   ##
   create: true


### PR DESCRIPTION
**Description of the change**

This PR makes within the helm chart the following changes:
 - Allow for extra volumes to be added to the Sealed Secrets controller Deployment.
 - Allow for extra volumeMounts to be added to the Sealed Secrets controller container.
 - Possibility to add annotations only to the service account.

**Benefits**

This would allow Sealed secrets to pick up certificates/secrets installed by the secret store csi driver(https://secrets-store-csi-driver.sigs.k8s.io)

I ran into the issue when combining sealed secrets with ASCP(https://docs.aws.amazon.com/secretsmanager/latest/userguide/integrating_csi_driver.html). I would bootstrap the EKS cluster with an instance of sealed secrets and to get a previously defined certificate as a secret in the cluster, I use the secret store csi driver with the AWS provider. CSI driver has option to reflect a secret volume as a k8s secret object, only after the volume has been mounted by a pod.

Without this change we would have to deploy an additional pod to the same namespace mounting the secret volume. so that then the controller can pick the secret up.

edit: forgot to mention why the SA change is needed.
In EKS pods get linked to an IAM role using an Annotation in the following form: `eks.amazonaws.com/role-arn: arn:aws:iam::XXXXXXXXXXXX:role/eksctl-sandbox-addon-iamserviceaccount-defau-xxx-xxx` .
I don't want the annotation to be added anywhere else, so commonAnnotations is not an option.
