### PR TITLE
feat: Support hostNetwork and dnsPolicy

### DIFF
--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
     url: https://github.com/bitnami-labs/sealed-secrets
 name: sealed-secrets
 type: application
-version: 2.6.4
+version: 2.6.5

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -137,6 +137,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `affinity`                                        | Affinity for Sealed Secret pods assignment                                           | `{}`                                |
 | `nodeSelector`                                    | Node labels for Sealed Secret pods assignment                                        | `{}`                                |
 | `tolerations`                                     | Tolerations for Sealed Secret pods assignment                                        | `[]`                                |
+| `hostNetwork`                                     | Run Sealed Secret pods in the host network of the node where the pod is deployed     | `false`                             |
+| `dnsPolicy`                                       | Sealed Secret pods' dnsPolicy                                                        | `""`                                |
 
 
 ### Traffic Exposure Parameters

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -49,6 +49,12 @@ spec:
       {{- if .Values.automountServiceAccountToken }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- end }}
+      {{- if .Values.hostNetwork }}
+      hostNetwork: true
+      {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- end }}
       containers:
         - name: controller
           command:

--- a/helm/sealed-secrets/templates/psp.yaml
+++ b/helm/sealed-secrets/templates/psp.yaml
@@ -15,7 +15,9 @@ spec:
     - 'secret'
     - 'downwardAPI'
     - 'persistentVolumeClaim'
+  {{- if not .Values.hostNetwork }}
   hostNetwork: false
+  {{- end }}
   hostIPC: false
   hostPID: false
   runAsUser:

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -195,6 +195,10 @@ additionalVolumes: []
 ## ref: https://kubernetes.io/docs/concepts/storage/volumes/
 ##
 additionalVolumeMounts: []
+## @param hostNetwork Sealed Secrets pods' hostNetwork
+hostNetwork: false
+## @param dnsPolicy Sealed Secrets pods' dnsPolicy
+dnsPolicy: ""
 
 ## @section Traffic Exposure Parameters
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

This change adds the `hostNetwork` and `dnsPolicy` pod attributes. This is needed in the case where you're running an EKS cluster with Cilium as a CNI you aren't able to `kubeseal` without:

```yaml
hostNetwork: true
dnsPolicy: ClusterFirstWithHostNet
```

**Benefits**

<!-- What benefits will be realized by the code change? -->

Enables `kubeseal` to work seamlessly using the Kubernetes API when using EKS (and probably other managed clusters) with custom CNIs such as Cilium or Calico. 

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
