### PR TITLE
Bump Chart version to release 'Allow additional volumes deployment'

### DIFF
--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
     url: https://github.com/bitnami-labs/sealed-secrets
 name: sealed-secrets
 type: application
-version: 2.6.2
+version: 2.6.3


### PR DESCRIPTION
**Description of the change**

Bump chart version to fix an unresolved conflict with this new PR:

https://github.com/bitnami-labs/sealed-secrets/pull/945

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #945
