### PR TITLE
Support to recreate a deleted secret generated by the controller

### DIFF
--- a/controller.jsonnet
+++ b/controller.jsonnet
@@ -23,7 +23,7 @@ controller {
       {
         apiGroups: [''],
         resources: ['secrets'],
-        verbs: ['get', 'list', 'create', 'update', 'delete'],
+        verbs: ['get', 'list', 'create', 'update', 'delete', 'watch'],
       },
       {
         apiGroups: [''],

--- a/helm/sealed-secrets/templates/cluster-role.yaml
+++ b/helm/sealed-secrets/templates/cluster-role.yaml
@@ -32,6 +32,7 @@ rules:
       - create
       - update
       - delete
+      - watch
   - apiGroups:
       - ""
     resources:

--- a/integration/controller_test.go
+++ b/integration/controller_test.go
@@ -276,7 +276,7 @@ var _ = Describe("create", func() {
 				err:= c.Secrets(ns).Delete(ctx, secretName, metav1.DeleteOptions{})
 				Expect(err).NotTo(HaveOccurred())
 			})
-			It("should the Secret exists", func() {
+			It("should recreate the secret", func() {
 				expected := map[string][]byte{
 					"foo": []byte("bar"),
 				}

--- a/integration/controller_test.go
+++ b/integration/controller_test.go
@@ -267,8 +267,10 @@ var _ = Describe("create", func() {
 				}, Timeout, PollingInterval).Should(WithTransform(getFirstOwnerName, Equal(ss.GetName())))
 			})
 		})
+	})
 
-		Context("With secret being deleted", func() {
+	Describe("Secret Recreation", func() {
+		Context("With owned secret", func() {
 			JustBeforeEach(func() {
 				Eventually(func() (*v1.Secret, error) {
 					return c.Secrets(ns).Get(ctx, secretName, metav1.GetOptions{})
@@ -291,6 +293,53 @@ var _ = Describe("create", func() {
 				Eventually(func() (*v1.Secret, error) {
 					return c.Secrets(ns).Get(ctx, secretName, metav1.GetOptions{})
 				}, Timeout, PollingInterval).Should(WithTransform(getFirstOwnerName, Equal(ss.GetName())))
+			})
+		})
+
+		Context("With unowned secret with managed annotation", func() {
+			BeforeEach(func() {
+				s.Annotations = map[string]string{
+					ssv1alpha1.SealedSecretManagedAnnotation: "true",
+				}
+				c.Secrets(ns).Create(ctx, s, metav1.CreateOptions{})
+			})
+			JustBeforeEach(func() {
+				err:= c.Secrets(ns).Delete(ctx, secretName, metav1.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("should recreate the secret", func() {
+				expected := map[string][]byte{
+					"foo": []byte("bar"),
+				}
+				Eventually(func() (*v1.Secret, error) {
+					return c.Secrets(ns).Get(ctx, secretName, metav1.GetOptions{})
+				}, Timeout, PollingInterval).Should(WithTransform(getData, Equal(expected)))
+				Eventually(func() (*v1.EventList, error) {
+					return c.Events(ns).Search(scheme.Scheme, ss)
+				}, Timeout, PollingInterval).Should(
+					containEventWithReason(Equal("Unsealed")),
+				)
+				Eventually(func() (*v1.Secret, error) {
+					return c.Secrets(ns).Get(ctx, secretName, metav1.GetOptions{})
+				}, Timeout, PollingInterval).Should(WithTransform(getFirstOwnerName, Equal(ss.GetName())))
+			})
+		})
+
+		Context("With unowned secret without managed annotation", func() {
+			BeforeEach(func() {
+				s.Annotations = map[string]string{
+				}
+				c.Secrets(ns).Create(ctx, s, metav1.CreateOptions{})
+			})
+			JustBeforeEach(func() {
+				err:= c.Secrets(ns).Delete(ctx, secretName, metav1.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("should not recreate the secret", func() {
+				Consistently(func() error {
+					_, err := c.Secrets(ns).Get(ctx, secretName, metav1.GetOptions{})
+					return err
+				}).Should(WithTransform(errors.IsNotFound, Equal(true)))
 			})
 		})
 	})

--- a/integration/controller_test.go
+++ b/integration/controller_test.go
@@ -269,8 +269,12 @@ var _ = Describe("create", func() {
 		})
 
 		Context("Secret recreation", func() {
-			BeforeEach(func() {
-				c.Secrets(ns).Delete(ctx, secretName, metav1.DeleteOptions{})
+			JustBeforeEach(func() {
+				Eventually(func() (*v1.Secret, error) {
+					return c.Secrets(ns).Get(ctx, secretName, metav1.GetOptions{})
+				}, Timeout, PollingInterval).Should(WithTransform(getFirstOwnerName, Equal(ss.GetName())))
+				err:= c.Secrets(ns).Delete(ctx, secretName, metav1.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred())
 			})
 			It("should the Secret exists", func() {
 				expected := map[string][]byte{

--- a/integration/controller_test.go
+++ b/integration/controller_test.go
@@ -268,7 +268,7 @@ var _ = Describe("create", func() {
 			})
 		})
 
-		Context("Secret recreation", func() {
+		Context("With secret being deleted", func() {
 			JustBeforeEach(func() {
 				Eventually(func() (*v1.Secret, error) {
 					return c.Secrets(ns).Get(ctx, secretName, metav1.GetOptions{})

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -56,7 +56,7 @@ const (
 // Controller implements the main sealed-secrets-controller loop.
 type Controller struct {
 	queue       workqueue.RateLimitingInterface
-	ssInformer    cache.SharedIndexInformer
+	ssInformer  cache.SharedIndexInformer
 	sInformer   cache.SharedIndexInformer
 	sclient     v1.SecretsGetter
 	ssclient    ssv1alpha1client.SealedSecretsGetter

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -68,7 +68,7 @@ type Controller struct {
 }
 
 // NewController returns the main sealed-secrets controller loop.
-func NewController(clientset kubernetes.Interface, ssclientset ssclientset.Interface, ssinformer ssinformer.SharedInformerFactory, keyRegistry *KeyRegistry) *Controller {
+func NewController(clientset kubernetes.Interface, ssclientset ssclientset.Interface, ssinformer ssinformer.SharedInformerFactory, sinformer informers.SharedInformerFactory, keyRegistry *KeyRegistry) *Controller {
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 
 	utilruntime.Must(ssscheme.AddToScheme(scheme.Scheme))
@@ -105,7 +105,7 @@ func NewController(clientset kubernetes.Interface, ssclientset ssclientset.Inter
 		},
 	})
 
-	sInformer := informers.NewSharedInformerFactory(clientset, 0).Core().V1().Secrets().Informer()
+	sInformer := sinformer.Core().V1().Secrets().Informer()
 	sInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: func(obj interface{}) {
 			key, err := cache.MetaNamespaceKeyFunc(obj)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -117,7 +117,7 @@ func NewController(clientset kubernetes.Interface, ssclientset ssclientset.Inter
 
 			ns, name, err := cache.SplitMetaNamespaceKey(skey)
 			if err != nil {
-				log.Printf("failed to split metadatada namespace: %v", err)
+				log.Printf("failed to get namespace and name from key: %v", err)
 				return
 			}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log"
 	"time"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -123,7 +123,7 @@ func NewController(clientset kubernetes.Interface, ssclientset ssclientset.Inter
 
 			ssecret, err := ssclientset.BitnamiV1alpha1().SealedSecrets(ns).Get(context.Background(), name, metav1.GetOptions{})
 			if err != nil {
-				if !strings.Contains(err.Error(), "not found") {
+				if !errors.IsNotFound(err) {
 					log.Printf("failed to find the Sealed Secret associated: %v", err)
 				}
 				return

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -67,9 +67,9 @@ type Controller struct {
 	updateStatus  bool // feature flag that enables updating the status subresource.
 }
 
-func findOwnerReferenceSS(obj interface{}) (bool) {
+func findOwnerReferenceSS(obj interface{}) bool {
 	for _, sownerref := range obj.(*corev1.Secret).GetOwnerReferences() {
-		if (sownerref.Kind == "SealedSecret") {
+		if sownerref.Kind == "SealedSecret" {
 			return true
 		}
 	}
@@ -124,8 +124,7 @@ func NewController(clientset kubernetes.Interface, ssclientset ssclientset.Inter
 				return
 			}
 
-
-			if (!findOwnerReferenceSS(obj) && !isAnnotatedToBeManaged(obj.(*corev1.Secret))) {
+			if !findOwnerReferenceSS(obj) && !isAnnotatedToBeManaged(obj.(*corev1.Secret)) {
 				return
 			}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -135,7 +135,7 @@ func NewController(clientset kubernetes.Interface, ssclientset ssclientset.Inter
 
 			sskey, err := cache.MetaNamespaceKeyFunc(ssecret)
 			if err != nil {
-				log.Printf("failed to fetch Sealed Secret key: %v", err)
+				log.Printf("failed to fetch SealedSecret key: %v", err)
 				return
 			}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -125,10 +125,8 @@ func NewController(clientset kubernetes.Interface, ssclientset ssclientset.Inter
 			}
 
 
-			if (!findOwnerReferenceSS(obj)) {
-				if (!isAnnotatedToBeManaged(obj.(*corev1.Secret))) {
-					return
-				}
+			if (!findOwnerReferenceSS(obj) && !isAnnotatedToBeManaged(obj.(*corev1.Secret))) {
+				return
 			}
 
 			ns, name, err := cache.SplitMetaNamespaceKey(skey)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -124,7 +124,7 @@ func NewController(clientset kubernetes.Interface, ssclientset ssclientset.Inter
 			ssecret, err := ssclientset.BitnamiV1alpha1().SealedSecrets(ns).Get(context.Background(), name, metav1.GetOptions{})
 			if err != nil {
 				if !errors.IsNotFound(err) {
-					log.Printf("failed to find the Sealed Secret associated: %v", err)
+					log.Printf("failed to get SealedSecret: %v", err)
 				}
 				return
 			}

--- a/pkg/controller/main.go
+++ b/pkg/controller/main.go
@@ -209,7 +209,7 @@ func Main(f *Flags, version string) error {
 	if f.AdditionalNamespaces != "" {
 		addNS := removeDuplicates(strings.Split(f.AdditionalNamespaces, ","))
 
-		var inf ssinformers.SharedInformerFactory
+		var ssinf ssinformers.SharedInformerFactory
 		var sinf informers.SharedInformerFactory
 		var ctlr *Controller
 
@@ -222,9 +222,9 @@ func Main(f *Flags, version string) error {
 				return err
 			}
 			if ns != namespace {
-				inf = ssinformers.NewFilteredSharedInformerFactory(ssclientset, 0, ns, tweakopts)
+				ssinf = ssinformers.NewFilteredSharedInformerFactory(ssclientset, 0, ns, tweakopts)
 				sinf = informers.NewFilteredSharedInformerFactory(clientset, 0, ns, tweakopts)
-				ctlr = NewController(clientset, ssclientset, inf, sinf, keyRegistry)
+				ctlr = NewController(clientset, ssclientset, ssinf, sinf, keyRegistry)
 				ctlr.oldGCBehavior = f.OldGCBehavior
 				ctlr.updateStatus = f.UpdateStatus
 				log.Printf("Starting informer for namespace: %s\n", ns)


### PR DESCRIPTION
**Description of the change**

Recreate secrets generated by the Sealed Secrets when they were deleted.

**Benefits**

Secrets generated by the Sealed Secrets will always be existed

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #224
- fixes #952
