### PR TITLE
Fix status sub-resource not found error on updating status

### DIFF
--- a/helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
+++ b/helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
@@ -120,3 +120,5 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/pkg/apis/sealedsecrets/v1alpha1/types.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/types.go
@@ -112,6 +112,7 @@ type SealedSecretStatus struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:subresource:status
 // +genclient
 
 // SealedSecret is the K8s representation of a "sealed Secret" - a


### PR DESCRIPTION
**Description of the change**

Add missing sub-resource for status, which causes error on updating status.

**Benefits**

SealedSecret resources in my Argo CD no longer stuck after this patchset.

**Possible drawbacks**

Nothing.

**Applicable issues**

- fixes #961

**Additional information**

See #961 for details, the issue was introduced in #941 when generating CRD with `controller-gen`, and `subresources` was missed from generation, however `status` sub-resource is used in https://github.com/bitnami-labs/sealed-secrets/blob/0e3ca3f4b8d10299e24cf4dd932eea2afb2ee11c/pkg/client/clientset/versioned/typed/sealedsecrets/v1alpha1/sealedsecret.go#L131 which causes the error
