### PR TITLE
fix: CRDs should not include unnecessary dashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ generate: $(GO_FILES)
 	cp -r gentmp/github.com/bitnami-labs/sealed-secrets/pkg . && rm -rf gentmp/
 
 manifests:
-	$(CONTROLLER_GEN) crd paths="./pkg/apis/..."  output:crd:artifacts:config=helm/sealed-secrets/crds/
+	$(CONTROLLER_GEN) crd paths="./pkg/apis/..." output:stdout | tail -n +2 > helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
 
 controller: $(GO_FILES)
 	$(GO) build -o $@ $(GO_FLAGS) -ldflags "$(GO_LD_FLAGS)" ./cmd/controller

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
     url: https://github.com/bitnami-labs/sealed-secrets
 name: sealed-secrets
 type: application
-version: 2.6.5
+version: 2.6.6

--- a/helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
+++ b/helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
Signed-off-by: juan131 <juan.ariza.1311993@gmail.com>

### Description of the change

The Sealed Secrets chart's CRD start with 3 dashes that are not necessary since these are only required as a separator when N directives are included in a single YAML file (which is not the case). Indeed, if you render the templates including the CRDs (e.g. running  `helm template sealed-secrets sealed-secrets/sealed-secrets --include-crds > foo.yaml` and inspect the output, you'll find blocks such as the one below:

```
---
# Source: crds/bitnami.com_sealedsecrets.yaml
---
```

This is interpreted as an empty directive which doesn't make sense.

### Benefits

Charts compatible with `helm template --include-crds ...`.

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

This bug was introduced at https://github.com/bitnami-labs/sealed-secrets/commit/7d6ae6e2cc013f3f760ca8748057f68195f5d833