### PR TITLE
Autogenerate schema-v1alpha1.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ generate: $(GO_FILES)
 
 manifests:
 	$(CONTROLLER_GEN) crd paths="./pkg/apis/..." output:stdout | tail -n +2 > helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
+	yq '.spec.versions[0].schema' < helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml > schema-v1alpha1.yaml
 
 controller: $(GO_FILES)
 	$(GO) build -o $@ $(GO_FLAGS) -ldflags "$(GO_LD_FLAGS)" ./cmd/controller

--- a/schema-v1alpha1.yaml
+++ b/schema-v1alpha1.yaml
@@ -1,17 +1,11 @@
 openAPIV3Schema:
-  description: SealedSecret is the K8s representation of a "sealed Secret" -
-    a regular k8s Secret that has been sealed (encrypted) using the controller's
-    key.
+  description: SealedSecret is the K8s representation of a "sealed Secret" - a regular k8s Secret that has been sealed (encrypted) using the controller's key.
   properties:
     apiVersion:
-      description: 'APIVersion defines the versioned schema of this representation
-        of an object. Servers should convert recognized schemas to the latest
-        internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+      description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
       type: string
     kind:
-      description: 'Kind is a string value representing the REST resource this
-        object represents. Servers may infer this from the endpoint the client
-        submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+      description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
       type: string
     metadata:
       type: object
@@ -19,8 +13,7 @@ openAPIV3Schema:
       description: SealedSecretSpec is the specification of a SealedSecret
       properties:
         data:
-          description: Data is deprecated and will be removed eventually. Use
-            per-value EncryptedData instead.
+          description: Data is deprecated and will be removed eventually. Use per-value EncryptedData instead.
           format: byte
           type: string
         encryptedData:
@@ -29,8 +22,7 @@ openAPIV3Schema:
           type: object
           x-kubernetes-preserve-unknown-fields: true
         template:
-          description: Template defines the structure of the Secret that will
-            be created from this sealed secret.
+          description: Template defines the structure of the Secret that will be created from this sealed secret.
           properties:
             data:
               additionalProperties:
@@ -43,27 +35,22 @@ openAPIV3Schema:
               type: object
               x-kubernetes-preserve-unknown-fields: true
             type:
-              description: Used to facilitate programmatic handling of secret
-                data.
+              description: Used to facilitate programmatic handling of secret data.
               type: string
           type: object
       required:
-      - encryptedData
+        - encryptedData
       type: object
     status:
-      description: SealedSecretStatus is the most recently observed status of
-        the SealedSecret.
+      description: SealedSecretStatus is the most recently observed status of the SealedSecret.
       properties:
         conditions:
-          description: Represents the latest available observations of a sealed
-            secret's current state.
+          description: Represents the latest available observations of a sealed secret's current state.
           items:
-            description: SealedSecretCondition describes the state of a sealed
-              secret at a certain point.
+            description: SealedSecretCondition describes the state of a sealed secret at a certain point.
             properties:
               lastTransitionTime:
-                description: Last time the condition transitioned from one status
-                  to another.
+                description: Last time the condition transitioned from one status to another.
                 format: date-time
                 type: string
               lastUpdateTime:
@@ -71,31 +58,27 @@ openAPIV3Schema:
                 format: date-time
                 type: string
               message:
-                description: A human readable message indicating details about
-                  the transition.
+                description: A human readable message indicating details about the transition.
                 type: string
               reason:
                 description: The reason for the condition's last transition.
                 type: string
               status:
-                description: 'Status of the condition for a sealed secret. Valid
-                  values for "Synced": "True", "False", or "Unknown".'
+                description: 'Status of the condition for a sealed secret. Valid values for "Synced": "True", "False", or "Unknown".'
                 type: string
               type:
-                description: 'Type of condition for a sealed secret. Valid value:
-                  "Synced"'
+                description: 'Type of condition for a sealed secret. Valid value: "Synced"'
                 type: string
             required:
-            - status
-            - type
+              - status
+              - type
             type: object
           type: array
         observedGeneration:
-          description: ObservedGeneration reflects the generation most recently
-            observed by the sealed-secrets controller.
+          description: ObservedGeneration reflects the generation most recently observed by the sealed-secrets controller.
           format: int64
           type: integer
       type: object
   required:
-  - spec
+    - spec
   type: object


### PR DESCRIPTION
**Description of the change**
- Add a command so that `make manifests` also updates the `schema-v1alpha1.yaml` file, used to generate the `controller.yaml` files.
- Run `make manifests`