### PR TITLE
Fix metadata validation issues

### DIFF
--- a/helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
+++ b/helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
@@ -58,6 +58,7 @@ spec:
                     type: object
                   metadata:
                     description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+                    nullable: true
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   type:

--- a/pkg/apis/sealedsecrets/v1alpha1/types.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/types.go
@@ -35,6 +35,7 @@ type SecretTemplateSpec struct {
 	// Standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
 	// +optional
+	// +nullable
 	// +kubebuilder:validation:XPreserveUnknownFields
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 

--- a/schema-v1alpha1.yaml
+++ b/schema-v1alpha1.yaml
@@ -32,6 +32,7 @@ openAPIV3Schema:
               type: object
             metadata:
               description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+              nullable: true
               type: object
               x-kubernetes-preserve-unknown-fields: true
             type:


### PR DESCRIPTION
**Description of the change**
Allow `SealedSecret.spec.template.metadata` to be `null`. This is a fix for #971.