### PR TITLE
Remove owner entry

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,4 +1,1 @@
 repositoryID: 1b0ab9f2-0c99-4f74-b818-deaaf9fed5b5
-owners:
-  - name: mkm
-    email: mmikulicic@gmail.com


### PR DESCRIPTION
**Description of the change**
The `owners` entry points to a previous owner of the project. This field [is only needed to claim repository ownership](https://github.com/artifacthub/hub/blob/master/docs/metadata/artifacthub-repo.yml). As we already are [owners of the repository in ArtifactHub](https://artifacthub.io/packages/helm/bitnami-labs/sealed-secrets), we don't need the `owners` entry.