### PR TITLE
Verify and update our GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3.1.0
       - id: load-versions
         run: |
           source $GITHUB_WORKSPACE/versions.env
@@ -41,13 +41,13 @@ jobs:
         golangci-lint: ["1.49.0"]
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3.3.0
       with:
         go-version: ${{ matrix.go }}
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.1.0
 
     - name: Install dependencies
       run: |
@@ -67,13 +67,13 @@ jobs:
         gosec: ["2.12.0"]
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3.3.0
       with:
         go-version: ${{ matrix.go }}
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.1.0
 
     - name: Install dependencies
       run: |
@@ -94,13 +94,13 @@ jobs:
     steps:
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3.3.0
       with:
         go-version: ${{ matrix.go }}
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.1.0
 
     - name: Install dependencies
       run: |
@@ -119,10 +119,10 @@ jobs:
         echo "CONTROLLER_IMAGE=$controller_registry/$controller_repository:$controller_tag" >> $GITHUB_ENV
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.1.0
 
     - name: Install Cosign
-      uses: sigstore/cosign-installer@v2.5.0
+      uses: sigstore/cosign-installer@v2.7.0
 
     - name: Distroless verify
       run: |
@@ -142,7 +142,7 @@ jobs:
         chmod +x ~/bin/kubecfg
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3.3.0
       with:
         go-version: ${{ needs.load-versions.outputs.go_version }}
       id: go
@@ -156,13 +156,13 @@ jobs:
         docker save $CONTROLLER_IMAGE -o /tmp/controller-image.tar
 
     - name: Upload manifest artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.0
       with:
         name: controller-manifest
         path: controller.yaml
 
     - name: Upload container image artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.0
       with:
         name: controller-image
         path: /tmp/controller-image.tar
@@ -184,7 +184,7 @@ jobs:
         echo "CONTROLLER_IMAGE=$controller_registry/$controller_repository:$controller_tag" >> $GITHUB_ENV
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3.3.0
       with:
         go-version: ${{ needs.load-versions.outputs.go_version }}
       id: go
@@ -194,9 +194,9 @@ jobs:
         go install github.com/onsi/ginkgo/ginkgo@v1.16.4
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.1.0
 
-    - uses: opsgang/ga-setup-minikube@v0.1.1
+    - uses: opsgang/ga-setup-minikube@v0.1.2
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       with:
@@ -214,12 +214,12 @@ jobs:
         kubectl cluster-info
 
     - name: Download manifest artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3.0.0
       with:
         name: controller-manifest
 
     - name: Download container image artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3.0.0
       with:
         name: controller-image
 
@@ -254,7 +254,7 @@ jobs:
         echo "CONTROLLER_IMAGE=$controller_registry/$controller_repository:$controller_tag" >> $GITHUB_ENV
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3.3.0
       with:
         go-version: ${{ needs.load-versions.outputs.go_version }}
       id: go
@@ -264,9 +264,9 @@ jobs:
         go install github.com/onsi/ginkgo/ginkgo@v1.16.4
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.1.0
 
-    - uses: opsgang/ga-setup-minikube@v0.1.1
+    - uses: opsgang/ga-setup-minikube@v0.1.2
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       with:
@@ -274,7 +274,7 @@ jobs:
         k8s-version: ${{ matrix.k8s }}
 
     - name: Install Helm
-      uses: azure/setup-helm@v1
+      uses: azure/setup-helm@v3.3
       with:
         version: v3.4.2
 
@@ -289,7 +289,7 @@ jobs:
         kubectl cluster-info
 
     - name: Download container image artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3.0.0
       with:
         name: controller-image
 

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -23,12 +23,12 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3.3
         with:
           version: v3.4.2
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
+        uses: helm/chart-releaser-action@v1.4.1
         with:
           charts_dir: helm
         env:

--- a/.github/workflows/helm-vib.yaml
+++ b/.github/workflows/helm-vib.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Lint chart
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
     name: Verify chart in ${{ matrix.target-platform}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
     types:
       - opened
-
+# TODO: evaluate the upstream actions/labelerv4.0.1 action
 jobs:
   label_issues:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,13 +17,13 @@ jobs:
     steps:
       # Checkout and set env
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
       - id: load-version
         run: |
           source $GITHUB_WORKSPACE/versions.env
           echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3.3.0
         with:
           go-version: $GO_VERSION
       - name: Setup kubecfg
@@ -48,16 +48,16 @@ jobs:
 
       # Setup env for multi-arch builds
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2.0.0
         with:
           image: tonistiigi/binfmt:latest
           platforms: arm64,arm
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2.0.0
 
       # Setup Cosign
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v2.5.0
+        uses: sigstore/cosign-installer@v2.7.0
       - name: Write Cosign key
         run: echo "$COSIGN_KEY" > /tmp/cosign.key
         env:
@@ -76,26 +76,26 @@ jobs:
 
       # Build & Publish multi-arch image
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Login to GHRC
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker controller image
         id: meta_controller
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4.0.1
         with:
           images: |
             ${{ env.controller_dockerhub_image_name }}
             ${{ env.controller_ghcr_image_name }}
       - name: Build and push controller image
         id: docker_build_controller
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3.1.1
         with:
           context: .
           file: ./docker/controller.Dockerfile
@@ -104,7 +104,7 @@ jobs:
           tags: ${{ steps.meta_controller.outputs.tags }}
       - name: Extract metadata (tags, labels) for Docker kubeseal image
         id: meta_kubeseal
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4.0.1
         with:
           images: |
             ${{ env.kubeseal_dockerhub_image_name }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v6.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This Issue has been automatically marked as "stale" because it has not had recent activity (for 15 days). It will be closed if no further activity occurs. Thanks for the feedback.'


### PR DESCRIPTION
Signed-off-by: Alfredo Garcia <algarcia@vmware.com>

**Description of the change**

Verify and update our GitHub Actions dependencies. The PR includes updated, pinned versions of the GH actions where we can upgrade without breaking changes. 

 
**Benefits**

Running more secure and controlled pipelines, since the change is pinning the GH action with the semversion tag.  

Closes #762 