### PR TITLE
Add namespace flag to ginkgo tests

### DIFF
--- a/integration/controller_test.go
+++ b/integration/controller_test.go
@@ -58,7 +58,7 @@ func getSecretType(s *v1.Secret) v1.SecretType {
 }
 
 func fetchKeys(ctx context.Context, c corev1.SecretsGetter) (map[string]*rsa.PrivateKey, []*x509.Certificate, error) {
-	list, err := c.Secrets("kube-system").List(ctx, metav1.ListOptions{
+	list, err := c.Secrets(*controllerNs).List(ctx, metav1.ListOptions{
 		LabelSelector: keySelector,
 	})
 	if err != nil {
@@ -292,7 +292,7 @@ var _ = Describe("create", func() {
 				Eventually(func() (*v1.Secret, error) {
 					return c.Secrets(ns).Get(ctx, secretName, metav1.GetOptions{})
 				}, Timeout, PollingInterval).Should(WithTransform(getFirstOwnerName, Equal(ss.GetName())))
-				err:= c.Secrets(ns).Delete(ctx, secretName, metav1.DeleteOptions{})
+				err := c.Secrets(ns).Delete(ctx, secretName, metav1.DeleteOptions{})
 				Expect(err).NotTo(HaveOccurred())
 			})
 			It("should recreate the secret", func() {
@@ -321,7 +321,7 @@ var _ = Describe("create", func() {
 				c.Secrets(ns).Create(ctx, s, metav1.CreateOptions{})
 			})
 			JustBeforeEach(func() {
-				err:= c.Secrets(ns).Delete(ctx, secretName, metav1.DeleteOptions{})
+				err := c.Secrets(ns).Delete(ctx, secretName, metav1.DeleteOptions{})
 				Expect(err).NotTo(HaveOccurred())
 			})
 			It("should recreate the secret", func() {
@@ -344,12 +344,11 @@ var _ = Describe("create", func() {
 
 		Context("With unowned secret without managed annotation", func() {
 			BeforeEach(func() {
-				s.Annotations = map[string]string{
-				}
+				s.Annotations = map[string]string{}
 				c.Secrets(ns).Create(ctx, s, metav1.CreateOptions{})
 			})
 			JustBeforeEach(func() {
-				err:= c.Secrets(ns).Delete(ctx, secretName, metav1.DeleteOptions{})
+				err := c.Secrets(ns).Delete(ctx, secretName, metav1.DeleteOptions{})
 				Expect(err).NotTo(HaveOccurred())
 			})
 			It("should not recreate the secret", func() {

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 var kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+var controllerNs = flag.String("namespace", "kube-system", "namespace where the controller is installed")
 var kubesealBin = flag.String("kubeseal-bin", "kubeseal", "path to kubeseal executable under test")
 var controllerBin = flag.String("controller-bin", "controller", "path to controller executable under test")
 

--- a/integration/kubeseal_test.go
+++ b/integration/kubeseal_test.go
@@ -360,7 +360,7 @@ var _ = Describe("kubeseal --recovery-unseal", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 	BeforeEach(func() {
-		key, err := c.Secrets("kube-system").List(ctx, metav1.ListOptions{
+		key, err := c.Secrets(*controllerNs).List(ctx, metav1.ListOptions{
 			LabelSelector: keySelector,
 		})
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Signed-off-by: Alejandro Moreno <amorenoc@vmware.com>

**Description of the change**
Add a `-namespace` flag to tell Ginkgo where is the controller installed. The default value is the previous hardcoded namespace `kube-system`.

**Benefits**
Integration tests can be run on any namespace.
