### PR TITLE
Fix fulfilled error executing update integration test

### DIFF
--- a/integration/controller_test.go
+++ b/integration/controller_test.go
@@ -187,6 +187,14 @@ var _ = Describe("create", func() {
 		Context("With existing object (update)", func() {
 			JustBeforeEach(func() {
 				var err error
+
+				Eventually(func() (*ssv1alpha1.SealedSecret, error) {
+					return ssc.BitnamiV1alpha1().SealedSecrets(ss.Namespace).Get(context.Background(), secretName, metav1.GetOptions{})
+				}, Timeout, PollingInterval).ShouldNot(WithTransform(getStatus, BeNil()))
+
+				ss, err = ssc.BitnamiV1alpha1().SealedSecrets(ss.Namespace).Get(context.Background(), secretName, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
 				resVer := ss.ResourceVersion
 
 				// update
@@ -206,7 +214,7 @@ var _ = Describe("create", func() {
 				}
 				Eventually(func() (*v1.Secret, error) {
 					return c.Secrets(ns).Get(ctx, secretName, metav1.GetOptions{})
-				}, 5*time.Second).Should(WithTransform(getData, Equal(expected)))
+				}, Timeout, PollingInterval).Should(WithTransform(getData, Equal(expected)))
 				Eventually(func() (*ssv1alpha1.SealedSecret, error) {
 					return ssc.BitnamiV1alpha1().SealedSecrets(ns).Get(context.Background(), secretName, metav1.GetOptions{})
 				}, Timeout, PollingInterval).ShouldNot(WithTransform(getStatus, BeNil()))


### PR DESCRIPTION
**Description of the change**

During our integration test execution, we are reproducing fulfilled and timeout errors executing the update integration test:

`"Operation cannot be fulfilled on sealedsecrets.bitnami.com \"testsecret\": the object has been modified; please apply your changes to the latest version and try again"`

This patch solves them.
