### PR TITLE
remove field 'rules' from templates/psp-clusterrolebinding

### DIFF
--- a/helm/sealed-secrets/templates/psp-clusterrolebinding.yaml
+++ b/helm/sealed-secrets/templates/psp-clusterrolebinding.yaml
@@ -7,7 +7,6 @@ metadata:
     {{- if .Values.rbac.labels }}
     {{- include "sealed-secrets.render" ( dict "value" .Values.rbac.labels "context" $) | nindent 4 }}
     {{- end }}
-rules:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
The template psp-clusterrolebinding.yaml contains an empty filed 'rules:'. This field is not supported on kind 'ClusterRoleBinding' according to 'kubectl explain clusterrolebinding'. Manifest validators like kubeconform fail on this ressource. It might be a copy-paste-error, sincs it's a valid field for [cluster-]roles.

