### PR TITLE
Helm chart: field 'rules' removed from 'templates/psp-clusterrolebind…

### DIFF
--- a/helm/sealed-secrets/templates/psp-clusterrolebinding.yaml
+++ b/helm/sealed-secrets/templates/psp-clusterrolebinding.yaml
@@ -7,7 +7,6 @@ metadata:
     {{- if .Values.rbac.labels }}
     {{- include "sealed-secrets.render" ( dict "value" .Values.rbac.labels "context" $) | nindent 4 }}
     {{- end }}
-rules:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
…ing.yaml'

Signed-off-by: Gerhard Sprenger <spreger5@yahoo.de>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
The template psp-clusterrolebinding.yaml contains an empty filed 'rules:'. This field is not supported on kind 'ClusterRoleBinding' according to 'kubectl explain clusterrolebinding'. Manifest validators like kubeconform fail on this ressource. It might be a copy-paste-error, sincs it's a valid field for [cluster-]roles.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
