### PR TITLE
ci(release): Fix wrong tag format in generated manifest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,9 @@ jobs:
       - name: K8s manifests
         run: |
           export PATH=~/bin:$PATH
-          make CONTROLLER_IMAGE=${{ env.controller_dockerhub_image_name }}:${{ github.ref_name }} controller.yaml controller-norbac.yaml
+          export TAG_NAME="${{ github.ref_name }}"
+          export TAG_NAME="${TAG_NAME/\//-}"
+          make CONTROLLER_IMAGE="${{ env.controller_dockerhub_image_name }}:${TAG_NAME}" controller.yaml controller-norbac.yaml
 
       # Setup env for multi-arch builds
       - name: Set up QEMU


### PR DESCRIPTION
Signed-off-by: Vincent Boutour <bob@vibioh.fr>

**Description of the change**

On the latest release `v0.19.0`, the image name in the controller's manifest is incorrectly formated `docker.io/bitnami/sealed-secrets-controller:release/v0.19.0`.

We should replace the `/` in the tag by a `-`.

**Benefits**

Having a working controller in the release's manifest.

**Possible drawbacks**

Using bash scripting / substitution in Github Action

**Applicable issues**

**Additional information**
