### PR TITLE
Decouple the kubeseal CLI from the kubeseal library

### DIFF
--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -1,14 +1,20 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	goflag "flag"
 
+	ssv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealedsecrets/v1alpha1"
+	"github.com/google/renameio"
+	"github.com/mattn/go-isatty"
 	flag "github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 
@@ -30,7 +36,55 @@ var (
 	VERSION = buildinfo.DefaultVersion
 )
 
-func bindFlags(f *kubeseal.Flags, fs *flag.FlagSet) {
+type Flags struct {
+	CertURL        string
+	ControllerNs   string
+	ControllerName string
+	OutputFormat   string
+	OutputFileName string
+	InputFileName  string
+	Kubeconfig     string
+	DumpCert       bool
+	AllowEmptyData bool
+	ValidateSecret bool
+	MergeInto      string
+	Raw            bool
+	SecretName     string
+	FromFile       []string
+	SealingScope   ssv1alpha1.SealingScope
+	ReEncrypt      bool
+	Unseal         bool
+	PrivKeys       []string
+}
+
+type Config struct {
+	flags          *Flags
+	clientConfig   clientcmd.ClientConfig
+	ctx            context.Context
+	solveNamespace kubeseal.NamespaceFn
+}
+
+func newConfig(clientConfig clientcmd.ClientConfig, flags *Flags) *Config {
+	return &Config{
+		flags:          flags,
+		clientConfig:   clientConfig,
+		ctx:            context.Background(),
+		solveNamespace: initNamespaceFuncFromClient(clientConfig),
+	}
+}
+
+func initNamespaceFuncFromClient(clientConfig clientcmd.ClientConfig) kubeseal.NamespaceFn {
+	return func() (string, bool, error) { return clientConfig.Namespace() }
+}
+
+func initClient(kubeConfigPath string, cfgOverrides *clientcmd.ConfigOverrides, r io.Reader) clientcmd.ClientConfig {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
+	loadingRules.ExplicitPath = kubeConfigPath
+	return clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, cfgOverrides, r)
+}
+
+func bindFlags(f *Flags, fs *flag.FlagSet) {
 	// TODO: Verify k8s server signature against cert in kube client config.
 	fs.StringVar(&f.CertURL, "cert", "", "Certificate / public key file/URL to use for encryption. Overrides --controller-*")
 	fs.StringVar(&f.ControllerNs, "controller-namespace", metav1.NamespaceSystem, "Namespace of sealed-secrets controller.")
@@ -74,8 +128,136 @@ func initUsualKubectlFlags(overrides *clientcmd.ConfigOverrides, fs *flag.FlagSe
 	clientcmd.BindOverrideFlags(overrides, fs, kflags)
 }
 
+func runKubeseal(w io.Writer, cfg *Config) (err error) {
+	flags := cfg.flags
+	if len(flags.FromFile) != 0 && !flags.Raw {
+		return fmt.Errorf("--from-file requires --raw")
+	}
+
+	var input io.Reader = os.Stdin
+	if flags.InputFileName != "" {
+		// #nosec G304 -- should open user provided file
+		f, err := os.Open(flags.InputFileName)
+		if err != nil {
+			return nil
+		}
+		// #nosec: G307 -- this deferred close is fine because it is not on a writable file
+		defer f.Close()
+
+		input = f
+	} else if !flags.Raw && !flags.DumpCert {
+		if isatty.IsTerminal(os.Stdin.Fd()) {
+			fmt.Fprintf(os.Stderr, "(tty detected: expecting json/yaml k8s resource in stdin)\n")
+		}
+	}
+
+	// reEncrypt is the only "in-place" update subcommand. When the user only provides one file (the input file)
+	// we'll use the same file for output (see #405).
+	if flags.ReEncrypt && (flags.OutputFileName == "" && flags.InputFileName != "") {
+		flags.OutputFileName = flags.InputFileName
+	}
+	if flags.OutputFileName != "" {
+		if ext := filepath.Ext(flags.OutputFileName); ext == ".yaml" || ext == ".yml" {
+			flags.OutputFormat = "yaml"
+		}
+
+		var f *renameio.PendingFile
+		f, err = renameio.TempFile("", flags.OutputFileName)
+		if err != nil {
+			return err
+		}
+		// only write the output file if the run function exits without errors.
+		defer func() {
+			if err == nil {
+				_ = f.CloseAtomicallyReplace()
+			}
+		}()
+
+		w = f
+	}
+
+	if flags.Unseal {
+		return kubeseal.UnsealSealedSecret(w, input, flags.PrivKeys, flags.OutputFormat, scheme.Codecs)
+	}
+	if len(flags.PrivKeys) != 0 && isatty.IsTerminal(os.Stderr.Fd()) {
+		fmt.Fprintf(os.Stderr, "warning: ignoring --recovery-private-key because unseal command not chosen with --recovery-unseal\n")
+	}
+
+	if flags.ValidateSecret {
+		return kubeseal.ValidateSealedSecret(cfg.ctx, cfg.clientConfig, flags.ControllerNs, flags.ControllerName, input)
+	}
+
+	if flags.ReEncrypt {
+		return kubeseal.ReEncryptSealedSecret(cfg.ctx, cfg.clientConfig, flags.ControllerNs, flags.ControllerName, flags.OutputFormat, input, w, scheme.Codecs)
+	}
+
+	f, err := kubeseal.OpenCert(cfg.ctx, cfg.clientConfig, flags.ControllerNs, flags.ControllerName, flags.CertURL)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if flags.DumpCert {
+		_, err := io.Copy(w, f)
+		return err
+	}
+
+	pubKey, err := kubeseal.ParseKey(f)
+	if err != nil {
+		return err
+	}
+
+	if flags.MergeInto != "" {
+		return kubeseal.SealMergingInto(cfg.solveNamespace, flags.OutputFormat, input, flags.MergeInto, scheme.Codecs, pubKey, flags.SealingScope, flags.AllowEmptyData)
+	}
+
+	if flags.Raw {
+		var (
+			ns  string
+			err error
+		)
+		if flags.SealingScope < ssv1alpha1.ClusterWideScope {
+			ns, _, err = cfg.solveNamespace()
+			if err != nil {
+				return err
+			}
+
+			if ns == "" {
+				return fmt.Errorf("must provide the --namespace flag with --raw and --scope %s", flags.SealingScope.String())
+			}
+
+			if flags.SecretName == "" && flags.SealingScope < ssv1alpha1.NamespaceWideScope {
+				return fmt.Errorf("must provide the --name flag with --raw and --scope %s", flags.SealingScope.String())
+			}
+		}
+
+		var data []byte
+		if len(flags.FromFile) > 0 {
+			if len(flags.FromFile) > 1 {
+				return fmt.Errorf("must provide only one --from-file when encrypting a single item with --raw")
+			}
+
+			_, filename := kubeseal.ParseFromFile(flags.FromFile[0])
+			// #nosec G304 -- should open user provided file
+			data, err = os.ReadFile(filename)
+		} else {
+			if isatty.IsTerminal(os.Stdin.Fd()) {
+				fmt.Fprintf(os.Stderr, "(tty detected: expecting a secret to encrypt in stdin)\n")
+			}
+			data, err = io.ReadAll(os.Stdin)
+		}
+		if err != nil {
+			return err
+		}
+
+		return kubeseal.EncryptSecretItem(w, flags.SecretName, ns, data, flags.SealingScope, pubKey)
+	}
+
+	return kubeseal.Seal(cfg.solveNamespace, flags.OutputFormat, input, w, scheme.Codecs, pubKey, flags.SealingScope, flags.AllowEmptyData, flags.SecretName, "")
+}
+
 func mainE(w io.Writer, fs *flag.FlagSet, gofs *goflag.FlagSet, args []string) error {
-	var flags kubeseal.Flags
+	var flags Flags
 	var printVersion bool
 	var overrides clientcmd.ConfigOverrides
 	buildinfo.FallbackVersion(&VERSION, buildinfo.DefaultVersion)
@@ -95,9 +277,9 @@ func mainE(w io.Writer, fs *flag.FlagSet, gofs *goflag.FlagSet, args []string) e
 		return nil
 	}
 
-	clientConfig := kubeseal.InitClient(flags.Kubeconfig, &overrides, os.Stdout)
-	cfg := kubeseal.NewConfig(clientConfig, &flags)
-	return kubeseal.Run(w, cfg)
+	clientConfig := initClient(flags.Kubeconfig, &overrides, os.Stdout)
+	cfg := newConfig(clientConfig, &flags)
+	return runKubeseal(w, cfg)
 }
 
 func main() {

--- a/cmd/kubeseal/main_test.go
+++ b/cmd/kubeseal/main_test.go
@@ -44,9 +44,9 @@ func testClientConfig() clientcmd.ClientConfig {
 	return initClient("", testConfigOverrides(), os.Stdin)
 }
 
-func testConfig(flags *Flags) *Config {
+func testConfig(flags *cliFlags) *config {
 	clientConfig := testClientConfig()
-	return &Config{
+	return &config{
 		flags:        flags,
 		clientConfig: clientConfig,
 		ctx:          context.Background(),
@@ -72,7 +72,7 @@ func testConfigOverrides() *clientcmd.ConfigOverrides {
 
 func TestMainError(t *testing.T) {
 	badFileName := filepath.Join("this", "file", "cannot", "possibly", "exist", "can", "it?")
-	flags := Flags{CertURL: badFileName}
+	flags := cliFlags{certURL: badFileName}
 
 	err := runCLI(io.Discard, testConfig(&flags))
 	if err == nil || !os.IsNotExist(err) {
@@ -161,10 +161,10 @@ data:
 	defer os.RemoveAll(out.Name())
 
 	var buf bytes.Buffer
-	flags := Flags{
-		InputFileName:  in.Name(),
-		OutputFileName: out.Name(),
-		CertURL:        certFilename,
+	flags := cliFlags{
+		inputFileName:  in.Name(),
+		outputFileName: out.Name(),
+		certURL:        certFilename,
 	}
 
 	if err := runCLI(&buf, testConfig(&flags)); err != nil {
@@ -214,10 +214,10 @@ metadata:
 	defer os.RemoveAll(out.Name())
 
 	var buf bytes.Buffer
-	flags := Flags{
-		InputFileName:  in.Name(),
-		OutputFileName: out.Name(),
-		CertURL:        certFilename,
+	flags := cliFlags{
+		inputFileName:  in.Name(),
+		outputFileName: out.Name(),
+		certURL:        certFilename,
 	}
 
 	if err := runCLI(&buf, testConfig(&flags)); err == nil {
@@ -239,7 +239,7 @@ metadata:
 
 func Test_runCLI(t *testing.T) {
 	type args struct {
-		cfg *Config
+		cfg *config
 	}
 	tests := []struct {
 		name    string
@@ -285,12 +285,12 @@ func trySealTestItem(certFilename, secretNS, secretName, secretValue string, sco
 
 	fromFile := []string{dataFile}
 	var buf bytes.Buffer
-	flags := Flags{
-		SealingScope: scope,
-		SecretName:   secretName,
-		CertURL:      certFilename,
-		Raw:          true,
-		FromFile:     fromFile,
+	flags := cliFlags{
+		sealingScope: scope,
+		secretName:   secretName,
+		certURL:      certFilename,
+		raw:          true,
+		fromFile:     fromFile,
 	}
 	cfg := testConfig(&flags)
 	cfg.clientConfig = &tweakedClientConfig{cfg.clientConfig, secretNS}

--- a/cmd/kubeseal/main_test.go
+++ b/cmd/kubeseal/main_test.go
@@ -2,10 +2,28 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/pem"
 	goflag "flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
+	ssv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealedsecrets/v1alpha1"
+	"github.com/bitnami-labs/sealed-secrets/pkg/crypto"
+	"github.com/bitnami-labs/sealed-secrets/pkg/kubeseal"
 	flag "github.com/spf13/pflag"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	certUtil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/keyutil"
 )
 
 func TestVersion(t *testing.T) {
@@ -19,5 +37,298 @@ func TestVersion(t *testing.T) {
 
 	if got, want := buf.String(), "kubeseal version: UNKNOWN\n"; got != want {
 		t.Errorf("got: %q, want: %q", got, want)
+	}
+}
+
+func testClientConfig() clientcmd.ClientConfig {
+	return initClient("", testConfigOverrides(), os.Stdin)
+}
+
+func testConfig(flags *Flags) *Config {
+	clientConfig := testClientConfig()
+	return &Config{
+		flags:        flags,
+		clientConfig: clientConfig,
+		ctx:          context.Background(),
+	}
+}
+
+func initUsualKubectlFlagsForTests(overrides *clientcmd.ConfigOverrides, flagset *flag.FlagSet) {
+	kflags := clientcmd.RecommendedConfigOverrideFlags("")
+	clientcmd.BindOverrideFlags(overrides, flagset, kflags)
+}
+
+func testConfigOverrides() *clientcmd.ConfigOverrides {
+	flagset := flag.NewFlagSet("test", flag.PanicOnError)
+	var overrides clientcmd.ConfigOverrides
+	initUsualKubectlFlagsForTests(&overrides, flagset)
+	err := flagset.Parse([]string{"-n", "default"})
+	if err != nil {
+		fmt.Printf("flagset parse err: %v\n", err)
+		os.Exit(1)
+	}
+	return &overrides
+}
+
+func TestMainError(t *testing.T) {
+	badFileName := filepath.Join("this", "file", "cannot", "possibly", "exist", "can", "it?")
+	flags := Flags{CertURL: badFileName}
+
+	err := runCLI(io.Discard, testConfig(&flags))
+	if err == nil || !os.IsNotExist(err) {
+		t.Fatalf("expecting not exist error, got: %v", err)
+	}
+}
+
+// writeTempFile creates a temporary file, writes data into it and closes it.
+func writeTempFile(b []byte) (string, error) {
+	tmp, err := os.CreateTemp("", "")
+	if err != nil {
+		return "", err
+	}
+	defer tmp.Close()
+
+	if _, err := tmp.Write(b); err != nil {
+		os.RemoveAll(tmp.Name())
+		return "", err
+	}
+
+	return tmp.Name(), nil
+}
+
+func newTestKeyPairSingle(t *testing.T) (*rsa.PublicKey, *rsa.PrivateKey) {
+	privKey, _, err := crypto.GeneratePrivateKeyAndCert(2048, time.Hour, "testcn")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &privKey.PublicKey, privKey
+}
+
+// testingKeypairFiles returns a path to a PEM encoded certificate and a PEM encoded private key
+// along with a function to be called to cleanup those files.
+func testingKeypairFiles(t *testing.T) (string, string, func()) {
+	_, pk := newTestKeyPairSingle(t)
+
+	cert, err := crypto.SignKey(rand.Reader, pk, time.Hour, "testcn")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	certFile, err := writeTempFile(pem.EncodeToMemory(&pem.Block{Type: certUtil.CertificateBlockType, Bytes: cert.Raw}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pkPEM, err := keyutil.MarshalPrivateKeyToPEM(pk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkFile, err := writeTempFile(pkPEM)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return certFile, pkFile, func() {
+		os.RemoveAll(certFile)
+		os.RemoveAll(pkFile)
+	}
+}
+
+func TestWriteToFile(t *testing.T) {
+	certFilename, _, cleanup := testingKeypairFiles(t)
+	defer cleanup()
+
+	in, err := os.CreateTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(in.Name())
+	fmt.Fprintf(in, `apiVersion: v1
+kind: Secret
+metadata:
+  name: foo
+  namespace: bar
+data:
+  super: c2VjcmV0
+`)
+	in.Close()
+
+	out, err := os.CreateTemp("", "*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	out.Close()
+	defer os.RemoveAll(out.Name())
+
+	var buf bytes.Buffer
+	flags := Flags{
+		InputFileName:  in.Name(),
+		OutputFileName: out.Name(),
+		CertURL:        certFilename,
+	}
+
+	if err := runCLI(&buf, testConfig(&flags)); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := buf.Len(), 0; got != want {
+		t.Errorf("got: %d, want: %d", got, want)
+	}
+
+	b, err := os.ReadFile(out.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sub := "kind: SealedSecret"; !bytes.Contains(b, []byte(sub)) {
+		t.Errorf("expecting to find %q in %q", sub, b)
+	}
+}
+
+func TestFailToWriteToFile(t *testing.T) {
+	certFilename, _, cleanup := testingKeypairFiles(t)
+	defer cleanup()
+
+	in, err := os.CreateTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(in.Name())
+	fmt.Fprintf(in, `apiVersion: v1
+kind: BadInput
+metadata:
+  name: foo
+  namespace: bar
+`)
+	in.Close()
+
+	out, err := os.CreateTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// if sealing error happens, the old content of the output file shouldn't be truncated.
+	const testOldContent = "previous content"
+
+	fmt.Fprint(out, testOldContent)
+	out.Close()
+	defer os.RemoveAll(out.Name())
+
+	var buf bytes.Buffer
+	flags := Flags{
+		InputFileName:  in.Name(),
+		OutputFileName: out.Name(),
+		CertURL:        certFilename,
+	}
+
+	if err := runCLI(&buf, testConfig(&flags)); err == nil {
+		t.Errorf("expecting error")
+	}
+
+	if got, want := buf.Len(), 0; got != want {
+		t.Errorf("got: %d, want: %d", got, want)
+	}
+
+	b, err := os.ReadFile(out.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(b), testOldContent; got != want {
+		t.Errorf("got: %q, want: %q", got, want)
+	}
+}
+
+func Test_runCLI(t *testing.T) {
+	type args struct {
+		cfg *Config
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantW   string
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &bytes.Buffer{}
+			if err := runCLI(w, tt.args.cfg); (err != nil) != tt.wantErr {
+				t.Errorf("runCLI() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotW := w.String(); gotW != tt.wantW {
+				t.Errorf("runCLI() = %v, want %v", gotW, tt.wantW)
+			}
+		})
+	}
+}
+
+type tweakedClientConfig struct {
+	ccfg      kubeseal.ClientConfig
+	namespace string
+}
+
+func (tcc *tweakedClientConfig) Namespace() (string, bool, error) {
+	return tcc.namespace, false, nil
+}
+
+func (tcc *tweakedClientConfig) ClientConfig() (*rest.Config, error) {
+	return tcc.ccfg.ClientConfig()
+}
+
+func trySealTestItem(certFilename, secretNS, secretName, secretValue string, scope ssv1alpha1.SealingScope) (string, error) {
+	dataFile, err := writeTempFile([]byte(secretValue))
+	if err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(dataFile)
+
+	fromFile := []string{dataFile}
+	var buf bytes.Buffer
+	flags := Flags{
+		SealingScope: scope,
+		SecretName:   secretName,
+		CertURL:      certFilename,
+		Raw:          true,
+		FromFile:     fromFile,
+	}
+	cfg := testConfig(&flags)
+	cfg.clientConfig = &tweakedClientConfig{cfg.clientConfig, secretNS}
+
+	if err := runCLI(&buf, cfg); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+func TestRawSealErrors(t *testing.T) {
+	certFilename, _, cleanup := testingKeypairFiles(t)
+	defer cleanup()
+
+	const (
+		secretNS    = "myns"
+		secretName  = "mysecret"
+		secretValue = "supersecret"
+	)
+
+	testCases := []struct {
+		ns      string
+		name    string
+		scope   ssv1alpha1.SealingScope
+		sealErr string
+	}{
+		{ns: "", name: "", sealErr: "must provide the --namespace flag with --raw and --scope strict"},
+		{ns: secretNS, name: "", sealErr: "must provide the --name flag with --raw and --scope strict"},
+		{scope: ssv1alpha1.NamespaceWideScope, name: secretName, sealErr: "must provide the --namespace flag with --raw and --scope namespace-wide"},
+	}
+	for i, tc := range testCases {
+		// try to encrypt an item and check error response
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			_, err := trySealTestItem(certFilename, tc.ns, tc.name, secretValue, tc.scope)
+			if got, want := fmt.Sprint(err), tc.sealErr; !strings.HasPrefix(got, want) {
+				t.Fatalf("got: %v, want: %v", err, want)
+			}
+		})
 	}
 }

--- a/pkg/kubeseal/kubeseal.go
+++ b/pkg/kubeseal/kubeseal.go
@@ -13,15 +13,12 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
 	ssv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealedsecrets/v1alpha1"
 	"github.com/bitnami-labs/sealed-secrets/pkg/crypto"
 	"github.com/bitnami-labs/sealed-secrets/pkg/multidocyaml"
-	"github.com/google/renameio"
-	"github.com/mattn/go-isatty"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,60 +27,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/kubernetes/scheme"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/keyutil"
 )
 
-type Flags struct {
-	CertURL        string
-	ControllerNs   string
-	ControllerName string
-	OutputFormat   string
-	OutputFileName string
-	InputFileName  string
-	Kubeconfig     string
-	DumpCert       bool
-	AllowEmptyData bool
-	ValidateSecret bool
-	MergeInto      string
-	Raw            bool
-	SecretName     string
-	FromFile       []string
-	SealingScope   ssv1alpha1.SealingScope
-	ReEncrypt      bool
-	Unseal         bool
-	PrivKeys       []string
-}
-
-type ClientConfig interface {
-	ClientConfig() (*rest.Config, error)
-	Namespace() (string, bool, error)
-}
-
-type Config struct {
-	flags        *Flags
-	clientConfig ClientConfig
-	ctx          context.Context
-}
-
-func NewConfig(clientConfig clientcmd.ClientConfig, flags *Flags) *Config {
-	return &Config{
-		flags:        flags,
-		clientConfig: clientConfig,
-		ctx:          context.Background(),
-	}
-}
-
-func InitClient(kubeConfigPath string, cfgOverrides *clientcmd.ConfigOverrides, r io.Reader) clientcmd.ClientConfig {
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
-	loadingRules.ExplicitPath = kubeConfigPath
-	return clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, cfgOverrides, r)
-}
-
-func parseKey(r io.Reader) (*rsa.PublicKey, error) {
+func ParseKey(r io.Reader) (*rsa.PublicKey, error) {
 	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -212,12 +161,12 @@ func openCertCluster(ctx context.Context, c corev1.CoreV1Interface, namespace, n
 	return cert, nil
 }
 
-func openCert(cfg *Config, certURL string) (io.ReadCloser, error) {
+func OpenCert(ctx context.Context, clientConfig clientcmd.ClientConfig, controllerNs, controllerName string, certURL string) (io.ReadCloser, error) {
 	if certURL != "" {
 		return openCertLocal(certURL)
 	}
 
-	conf, err := cfg.clientConfig.ClientConfig()
+	conf, err := clientConfig.ClientConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -226,13 +175,13 @@ func openCert(cfg *Config, certURL string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	return openCertCluster(cfg.ctx, restClient, cfg.flags.ControllerNs, cfg.flags.ControllerName)
+	return openCertCluster(ctx, restClient, controllerNs, controllerName)
 }
 
 // Seal reads a k8s Secret resource parsed from an input reader by a given codec, encrypts all its secrets
 // with a given public key, using the name and namespace found in the input secret, unless explicitly overridden
 // by the overrideName and overrideNamespace arguments.
-func seal(cfg *Config, in io.Reader, out io.Writer, codecs runtimeserializer.CodecFactory, pubKey *rsa.PublicKey, scope ssv1alpha1.SealingScope, allowEmptyData bool, overrideName, overrideNamespace string) error {
+func Seal(solveNamespace NamespaceFn, outputFormat string, in io.Reader, out io.Writer, codecs runtimeserializer.CodecFactory, pubKey *rsa.PublicKey, scope ssv1alpha1.SealingScope, allowEmptyData bool, overrideName, overrideNamespace string) error {
 	secret, err := readSecret(codecs.UniversalDecoder(), in)
 	if err != nil {
 		return err
@@ -259,7 +208,7 @@ func seal(cfg *Config, in io.Reader, out io.Writer, codecs runtimeserializer.Cod
 	}
 
 	if ssv1alpha1.SecretScope(secret) != ssv1alpha1.ClusterWideScope && secret.GetNamespace() == "" {
-		ns, _, err := cfg.clientConfig.Namespace()
+		ns, _, err := solveNamespace()
 		if clientcmd.IsEmptyConfig(err) {
 			return fmt.Errorf("input secret has no namespace and cannot infer the namespace automatically when no kube config is available")
 		} else if err != nil {
@@ -281,15 +230,14 @@ func seal(cfg *Config, in io.Reader, out io.Writer, codecs runtimeserializer.Cod
 	if err != nil {
 		return err
 	}
-	if err = sealedSecretOutput(out, cfg.flags, codecs, ssecret); err != nil {
+	if err = sealedSecretOutput(out, outputFormat, codecs, ssecret); err != nil {
 		return err
 	}
 	return nil
 }
 
-func validateSealedSecret(cfg *Config, in io.Reader) error {
-	flags := cfg.flags
-	conf, err := cfg.clientConfig.ClientConfig()
+func ValidateSealedSecret(ctx context.Context, clientConfig clientcmd.ClientConfig, controllerNs, controllerName string, in io.Reader) error {
+	conf, err := clientConfig.ClientConfig()
 	if err != nil {
 		return err
 	}
@@ -297,7 +245,7 @@ func validateSealedSecret(cfg *Config, in io.Reader) error {
 	if err != nil {
 		return err
 	}
-	portName, err := getServicePortName(cfg.ctx, restClient, flags.ControllerNs, flags.ControllerName)
+	portName, err := getServicePortName(ctx, restClient, controllerNs, controllerName)
 	if err != nil {
 		return err
 	}
@@ -308,14 +256,14 @@ func validateSealedSecret(cfg *Config, in io.Reader) error {
 	}
 
 	req := restClient.RESTClient().Post().
-		Namespace(flags.ControllerNs).
+		Namespace(controllerNs).
 		Resource("services").
 		SubResource("proxy").
-		Name(net.JoinSchemeNamePort("http", flags.ControllerName, portName)).
+		Name(net.JoinSchemeNamePort("http", controllerName, portName)).
 		Suffix("/v1/verify")
 
 	req.Body(content)
-	res := req.Do(cfg.ctx)
+	res := req.Do(ctx)
 	if err := res.Error(); err != nil {
 		if status, ok := err.(*k8serrors.StatusError); ok && status.Status().Code == http.StatusConflict {
 			return fmt.Errorf("unable to decrypt sealed secret")
@@ -326,9 +274,8 @@ func validateSealedSecret(cfg *Config, in io.Reader) error {
 	return nil
 }
 
-func reEncryptSealedSecret(cfg *Config, in io.Reader, out io.Writer, codecs runtimeserializer.CodecFactory) error {
-	flags := cfg.flags
-	conf, err := cfg.clientConfig.ClientConfig()
+func ReEncryptSealedSecret(ctx context.Context, clientConfig clientcmd.ClientConfig, controllerNs, controllerName, outputFormat string, in io.Reader, out io.Writer, codecs runtimeserializer.CodecFactory) error {
+	conf, err := clientConfig.ClientConfig()
 	if err != nil {
 		return err
 	}
@@ -336,7 +283,7 @@ func reEncryptSealedSecret(cfg *Config, in io.Reader, out io.Writer, codecs runt
 	if err != nil {
 		return err
 	}
-	portName, err := getServicePortName(cfg.ctx, restClient, flags.ControllerNs, flags.ControllerName)
+	portName, err := getServicePortName(ctx, restClient, controllerNs, controllerName)
 	if err != nil {
 		return err
 	}
@@ -347,14 +294,14 @@ func reEncryptSealedSecret(cfg *Config, in io.Reader, out io.Writer, codecs runt
 	}
 
 	req := restClient.RESTClient().Post().
-		Namespace(flags.ControllerNs).
+		Namespace(controllerNs).
 		Resource("services").
 		SubResource("proxy").
-		Name(net.JoinSchemeNamePort("http", flags.ControllerName, portName)).
+		Name(net.JoinSchemeNamePort("http", controllerName, portName)).
 		Suffix("/v1/rotate")
 
 	req.Body(content)
-	res := req.Do(cfg.ctx)
+	res := req.Do(ctx)
 	if err := res.Error(); err != nil {
 		if status, ok := err.(*k8serrors.StatusError); ok && status.Status().Code == http.StatusConflict {
 			return fmt.Errorf("unable to rotate secret")
@@ -372,21 +319,21 @@ func reEncryptSealedSecret(cfg *Config, in io.Reader, out io.Writer, codecs runt
 	ssecret.SetCreationTimestamp(metav1.Time{})
 	ssecret.SetDeletionTimestamp(nil)
 	ssecret.Generation = 0
-	if err = sealedSecretOutput(out, cfg.flags, codecs, ssecret); err != nil {
+	if err = sealedSecretOutput(out, outputFormat, codecs, ssecret); err != nil {
 		return err
 	}
 	return nil
 }
 
-func resourceOutput(out io.Writer, flags *Flags, codecs runtimeserializer.CodecFactory, gv runtime.GroupVersioner, obj runtime.Object) error {
+func resourceOutput(out io.Writer, outputFormat string, codecs runtimeserializer.CodecFactory, gv runtime.GroupVersioner, obj runtime.Object) error {
 	var contentType string
-	switch strings.ToLower(flags.OutputFormat) {
+	switch strings.ToLower(outputFormat) {
 	case "json", "":
 		contentType = runtime.ContentTypeJSON
 	case "yaml":
 		contentType = runtime.ContentTypeYAML
 	default:
-		return fmt.Errorf("unsupported output format: %s", flags.OutputFormat)
+		return fmt.Errorf("unsupported output format: %s", outputFormat)
 	}
 	prettyEnc, err := prettyEncoder(codecs, contentType, gv)
 	if err != nil {
@@ -401,8 +348,8 @@ func resourceOutput(out io.Writer, flags *Flags, codecs runtimeserializer.CodecF
 	return nil
 }
 
-func sealedSecretOutput(out io.Writer, flags *Flags, codecs runtimeserializer.CodecFactory, ssecret *ssv1alpha1.SealedSecret) error {
-	return resourceOutput(out, flags, codecs, ssv1alpha1.SchemeGroupVersion, ssecret)
+func sealedSecretOutput(out io.Writer, outputFormat string, codecs runtimeserializer.CodecFactory, ssecret *ssv1alpha1.SealedSecret) error {
+	return resourceOutput(out, outputFormat, codecs, ssv1alpha1.SchemeGroupVersion, ssecret)
 }
 
 func decodeSealedSecret(codecs runtimeserializer.CodecFactory, b []byte) (*ssv1alpha1.SealedSecret, error) {
@@ -413,7 +360,7 @@ func decodeSealedSecret(codecs runtimeserializer.CodecFactory, b []byte) (*ssv1a
 	return &ss, nil
 }
 
-func sealMergingInto(cfg *Config, in io.Reader, filename string, codecs runtimeserializer.CodecFactory, pubKey *rsa.PublicKey, scope ssv1alpha1.SealingScope, allowEmptyData bool) error {
+func SealMergingInto(solveNamespace NamespaceFn, outputFormat string, in io.Reader, filename string, codecs runtimeserializer.CodecFactory, pubKey *rsa.PublicKey, scope ssv1alpha1.SealingScope, allowEmptyData bool) error {
 	// #nosec G304 -- should open user provided file
 	f, err := os.OpenFile(filename, os.O_RDWR, 0)
 	if err != nil {
@@ -433,7 +380,7 @@ func sealMergingInto(cfg *Config, in io.Reader, filename string, codecs runtimes
 	}
 
 	var buf bytes.Buffer
-	if err := seal(cfg, in, &buf, codecs, pubKey, scope, allowEmptyData, orig.Name, orig.Namespace); err != nil {
+	if err := Seal(solveNamespace, outputFormat, in, &buf, codecs, pubKey, scope, allowEmptyData, orig.Name, orig.Namespace); err != nil {
 		return err
 	}
 
@@ -458,7 +405,7 @@ func sealMergingInto(cfg *Config, in io.Reader, filename string, codecs runtimes
 
 	// updated sealed secret file in-place avoiding clobbering the file upon rendering errors.
 	var out bytes.Buffer
-	if err := sealedSecretOutput(&out, cfg.flags, codecs, orig); err != nil {
+	if err := sealedSecretOutput(&out, outputFormat, codecs, orig); err != nil {
 		return err
 	}
 
@@ -478,7 +425,7 @@ func sealMergingInto(cfg *Config, in io.Reader, filename string, codecs runtimes
 	return nil
 }
 
-func encryptSecretItem(w io.Writer, secretName, ns string, data []byte, scope ssv1alpha1.SealingScope, pubKey *rsa.PublicKey) error {
+func EncryptSecretItem(w io.Writer, secretName, ns string, data []byte, scope ssv1alpha1.SealingScope, pubKey *rsa.PublicKey) error {
 	// TODO(mkm): refactor cluster-wide/namespace-wide to an actual enum so we can have a simple flag
 	// to refer to the scope mode that is not a tuple of booleans.
 	label := ssv1alpha1.EncryptionLabel(ns, secretName, scope)
@@ -492,7 +439,7 @@ func encryptSecretItem(w io.Writer, secretName, ns string, data []byte, scope ss
 
 // parseFromFile parses a value of the kubectl --from-file flag, which can optionally include an item name
 // preceding the first equals sign.
-func parseFromFile(s string) (string, string) {
+func ParseFromFile(s string) (string, string) {
 	c := strings.SplitN(s, "=", 2)
 	if len(c) == 1 {
 		return "", c[0]
@@ -589,8 +536,8 @@ func readPrivKeys(filenames []string) (map[string]*rsa.PrivateKey, error) {
 	return res, nil
 }
 
-func unsealSealedSecret(flags *Flags, w io.Writer, in io.Reader, codecs runtimeserializer.CodecFactory) error {
-	privKeys, err := readPrivKeys(flags.PrivKeys)
+func UnsealSealedSecret(w io.Writer, in io.Reader, privKeysFilenames []string, outputFormat string, codecs runtimeserializer.CodecFactory) error {
+	privKeys, err := readPrivKeys(privKeysFilenames)
 	if err != nil {
 		return err
 	}
@@ -609,133 +556,5 @@ func unsealSealedSecret(flags *Flags, w io.Writer, in io.Reader, codecs runtimes
 		return err
 	}
 
-	return resourceOutput(w, flags, codecs, v1.SchemeGroupVersion, sec)
-}
-
-func Run(w io.Writer, cfg *Config) (err error) {
-	flags := cfg.flags
-	if len(flags.FromFile) != 0 && !flags.Raw {
-		return fmt.Errorf("--from-file requires --raw")
-	}
-
-	var input io.Reader = os.Stdin
-	if flags.InputFileName != "" {
-		// #nosec G304 -- should open user provided file
-		f, err := os.Open(flags.InputFileName)
-		if err != nil {
-			return nil
-		}
-		// #nosec: G307 -- this deferred close is fine because it is not on a writable file
-		defer f.Close()
-
-		input = f
-	} else if !flags.Raw && !flags.DumpCert {
-		if isatty.IsTerminal(os.Stdin.Fd()) {
-			fmt.Fprintf(os.Stderr, "(tty detected: expecting json/yaml k8s resource in stdin)\n")
-		}
-	}
-
-	// reEncrypt is the only "in-place" update subcommand. When the user only provides one file (the input file)
-	// we'll use the same file for output (see #405).
-	if flags.ReEncrypt && (flags.OutputFileName == "" && flags.InputFileName != "") {
-		flags.OutputFileName = flags.InputFileName
-	}
-	if flags.OutputFileName != "" {
-		if ext := filepath.Ext(flags.OutputFileName); ext == ".yaml" || ext == ".yml" {
-			flags.OutputFormat = "yaml"
-		}
-
-		var f *renameio.PendingFile
-		f, err = renameio.TempFile("", flags.OutputFileName)
-		if err != nil {
-			return err
-		}
-		// only write the output file if the run function exits without errors.
-		defer func() {
-			if err == nil {
-				_ = f.CloseAtomicallyReplace()
-			}
-		}()
-
-		w = f
-	}
-
-	if flags.Unseal {
-		return unsealSealedSecret(flags, w, input, scheme.Codecs)
-	}
-	if len(flags.PrivKeys) != 0 && isatty.IsTerminal(os.Stderr.Fd()) {
-		fmt.Fprintf(os.Stderr, "warning: ignoring --recovery-private-key because unseal command not chosen with --recovery-unseal\n")
-	}
-
-	if flags.ValidateSecret {
-		return validateSealedSecret(cfg, input)
-	}
-
-	if flags.ReEncrypt {
-		return reEncryptSealedSecret(cfg, input, w, scheme.Codecs)
-	}
-
-	f, err := openCert(cfg, flags.CertURL)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	if flags.DumpCert {
-		_, err := io.Copy(w, f)
-		return err
-	}
-
-	pubKey, err := parseKey(f)
-	if err != nil {
-		return err
-	}
-
-	if flags.MergeInto != "" {
-		return sealMergingInto(cfg, input, flags.MergeInto, scheme.Codecs, pubKey, flags.SealingScope, flags.AllowEmptyData)
-	}
-
-	if flags.Raw {
-		var (
-			ns  string
-			err error
-		)
-		if flags.SealingScope < ssv1alpha1.ClusterWideScope {
-			ns, _, err = cfg.clientConfig.Namespace()
-			if err != nil {
-				return err
-			}
-
-			if ns == "" {
-				return fmt.Errorf("must provide the --namespace flag with --raw and --scope %s", flags.SealingScope.String())
-			}
-
-			if flags.SecretName == "" && flags.SealingScope < ssv1alpha1.NamespaceWideScope {
-				return fmt.Errorf("must provide the --name flag with --raw and --scope %s", flags.SealingScope.String())
-			}
-		}
-
-		var data []byte
-		if len(flags.FromFile) > 0 {
-			if len(flags.FromFile) > 1 {
-				return fmt.Errorf("must provide only one --from-file when encrypting a single item with --raw")
-			}
-
-			_, filename := parseFromFile(flags.FromFile[0])
-			// #nosec G304 -- should open user provided file
-			data, err = os.ReadFile(filename)
-		} else {
-			if isatty.IsTerminal(os.Stdin.Fd()) {
-				fmt.Fprintf(os.Stderr, "(tty detected: expecting a secret to encrypt in stdin)\n")
-			}
-			data, err = io.ReadAll(os.Stdin)
-		}
-		if err != nil {
-			return err
-		}
-
-		return encryptSecretItem(w, flags.SecretName, ns, data, flags.SealingScope, pubKey)
-	}
-
-	return seal(cfg, input, w, scheme.Codecs, pubKey, flags.SealingScope, flags.AllowEmptyData, flags.SecretName, "")
+	return resourceOutput(w, outputFormat, codecs, v1.SchemeGroupVersion, sec)
 }


### PR DESCRIPTION
Signed-off-by: Alejandro Moreno <amorenoc@vmware.com>

**Description of the change**
Decouple the kubeseal CLI specific code from its library.

Note: **The currently exposed `kubeseal` interface must be considered unstable, it will change going forward**.

**Benefits**
Makes the library easier to reuse.

**Possible drawbacks**
As with all refactors, bugs could be introduced. We will ensure however our test suite continues to pass.