### PR TITLE
Replace minikube action to use Node 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,12 +196,10 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3.1.0
 
-    - uses: opsgang/ga-setup-minikube@v0.1.2
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+    - uses: medyagh/setup-minikube@v0.0.8
       with:
         minikube-version: 1.26.1
-        k8s-version: ${{ matrix.k8s }}
+        kubernetes-version: ${{ matrix.k8s }}
 
     # need to delete old state of the cluster, see:
     # https://github.com/kubernetes/minikube/issues/8765


### PR DESCRIPTION
Signed-off-by: Alejandro Moreno <amorenoc@vmware.com>

**Description of the change**
GitHub has deprecated Node 12 actions. This PR replaces the Minikube setup action for another one using Node 16.

