### PR TITLE
Include golang unit test report in the GitHub PR context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,13 @@ jobs:
         go install gotest.tools/gotestsum@v${{ matrix.gotestsum }}
 
     - name: Test
-      run: make test
+      run: make GO_FLAGS="--junitfile report.xml --format testname" test
+
+    - name: Test Summary
+      uses: test-summary/action@v2
+      with:
+        paths: |
+          report.xml
 
   container:
     needs: load-versions

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ dist/
 
 # Vendor folder
 vendor/
+report.xml


### PR DESCRIPTION
Signed-off-by: Alfredo Garcia <algarcia@vmware.com>


**Description of the change**

GitHub PRs context and visibility can be significantly enhanced by providing test report information in the UI. This can be achieved by exporting the unit test report into a specific [format/artifact](https://docs.gitlab.com/ee/ci/testing/unit_test_report_examples.html#go), and then use a [GitHub Action](https://github.com/marketplace/actions/testforest-dashboard) to publish the results into the PR context.
