### PR TITLE
Upgrade VIB GitHub Action to 0.4.7

### DIFF
--- a/.github/workflows/helm-vib.yaml
+++ b/.github/workflows/helm-vib.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
-      - uses: vmware-labs/vmware-image-builder-action@0.4.0
+      - uses: vmware-labs/vmware-image-builder-action@0.4.7
 
   # verify chart in multiple target platforms
   vib-k8s-verify:
@@ -45,7 +45,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - uses: vmware-labs/vmware-image-builder-action@0.4.0
+      - uses: vmware-labs/vmware-image-builder-action@0.4.7
         with:
           pipeline: vib-platform-verify.json
         env:


### PR DESCRIPTION
Signed-off-by: Alfredo Garcia <algarcia@vmware.com>

**Description of the change**

Upgrade the VIB GitHub Action to the latest available version `0.4.7`
**Benefits**

We should fix the `set-output` warning messages in the VIB action. 
**Possible drawbacks**

None