### PR TITLE
Fix empty Group Version Kind

### DIFF
--- a/integration/controller_test.go
+++ b/integration/controller_test.go
@@ -370,12 +370,12 @@ var _ = Describe("create", func() {
 
 	Describe("Same name, wrong key", func() {
 		BeforeEach(func() {
-			// NB: weak keysize - this is just a test case
-			wrongkey, err := rsa.GenerateKey(rand.Reader, 1024)
+			// NB: weak key-size - this is just a test case
+			wrongKey, err := rsa.GenerateKey(rand.Reader, 1024)
 			Expect(err).NotTo(HaveOccurred())
 
 			fmt.Fprintf(GinkgoWriter, "Resealing with wrong key\n")
-			ss, err = ssv1alpha1.NewSealedSecret(scheme.Codecs, &wrongkey.PublicKey, s)
+			ss, err = ssv1alpha1.NewSealedSecret(scheme.Codecs, &wrongKey.PublicKey, s)
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
@@ -322,10 +322,7 @@ func (s *SealedSecret) Unseal(codecs runtimeserializer.CodecFactory, privKeys ma
 	secret.SetNamespace(smeta.GetNamespace())
 	secret.SetName(smeta.GetName())
 
-	// This is sometimes empty?  Fine - we know what the answer is
-	// going to be anyway.
-	//gvk := s.GetObjectKind().GroupVersionKind()
-	gvk := SchemeGroupVersion.WithKind("SealedSecret")
+	gvk := s.GetObjectKind().GroupVersionKind()
 
 	// Refer back to owning SealedSecret
 	ownerRefs := []metav1.OwnerReference{

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -248,7 +249,10 @@ func (c *Controller) unseal(ctx context.Context, key string) (unsealErr error) {
 		return nil
 	}
 
-	ssecret := obj.(*ssv1alpha1.SealedSecret)
+	ssecret, err := convertSealedSecret(obj)
+	if err != nil {
+		return err
+	}
 	log.Printf("Updating %s", key)
 
 	// any exit of this function at this point will cause an update to the status subresource
@@ -309,6 +313,22 @@ func (c *Controller) unseal(ctx context.Context, key string) (unsealErr error) {
 
 	c.recorder.Event(ssecret, corev1.EventTypeNormal, SuccessUnsealed, "SealedSecret unsealed successfully")
 	return nil
+}
+
+func convertSealedSecret(obj any) (*ssv1alpha1.SealedSecret, error) {
+	sealedSecret, ok := (obj).(*ssv1alpha1.SealedSecret)
+	if !ok {
+		return nil, fmt.Errorf("failed to cast %v into SealedSecret", obj)
+	}
+	if sealedSecret.APIVersion == "" || sealedSecret.Kind == "" {
+		// https://github.com/operator-framework/operator-sdk/issues/727
+		log.Printf("WARNING: Empty API version & kind, filling it...")
+		gv := schema.GroupVersion{Group: ssv1alpha1.GroupName, Version: "v1alpha1"}
+		gvk := gv.WithKind("SealedSecret")
+		sealedSecret.APIVersion = gvk.GroupVersion().String()
+		sealedSecret.Kind = gvk.Kind
+	}
+	return sealedSecret, nil
 }
 
 func (c *Controller) updateSealedSecretStatus(ssecret *ssv1alpha1.SealedSecret, unsealError error) error {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -54,6 +54,11 @@ const (
 	ErrUnsealFailed = "ErrUnsealFailed"
 )
 
+var (
+	// ErrCast happens when a K8s any type cannot be casted to the expected type
+	ErrCast = fmt.Errorf("cast error")
+)
+
 // Controller implements the main sealed-secrets-controller loop.
 type Controller struct {
 	queue       workqueue.RateLimitingInterface
@@ -318,7 +323,7 @@ func (c *Controller) unseal(ctx context.Context, key string) (unsealErr error) {
 func convertSealedSecret(obj any) (*ssv1alpha1.SealedSecret, error) {
 	sealedSecret, ok := (obj).(*ssv1alpha1.SealedSecret)
 	if !ok {
-		return nil, fmt.Errorf("failed to cast %v into SealedSecret", obj)
+		return nil, fmt.Errorf("%w: failed to cast %v into SealedSecret", ErrCast, obj)
 	}
 	if sealedSecret.APIVersion == "" || sealedSecret.Kind == "" {
 		// https://github.com/operator-framework/operator-sdk/issues/727

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,0 +1,47 @@
+package controller
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	ssv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealedsecrets/v1alpha1"
+)
+
+func TestConvert2SealedSecretBadType(t *testing.T) {
+	obj := struct{}{}
+	_, got := convertSealedSecret(obj)
+	want := ErrCast
+	if !errors.Is(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestConvert2SealedSecretFills(t *testing.T) {
+	sealedSecret := ssv1alpha1.SealedSecret{}
+
+	result, err := convertSealedSecret(any(&sealedSecret))
+	if err != nil {
+		t.Fatalf("unexpected failure converting to a sealed secret: %v", err)
+	}
+	got := fmt.Sprintf("%s %s", result.APIVersion, result.Kind)
+	want := "bitnami.com/v1alpha1 SealedSecret"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestConvert2SealedSecretPassThrough(t *testing.T) {
+	sealedSecret := ssv1alpha1.SealedSecret{}
+	sealedSecret.APIVersion = "bitnami.com/v1alpha1"
+	sealedSecret.Kind = "SealedSecrets"
+
+	want := &sealedSecret
+	got, err := convertSealedSecret(any(want))
+	if err != nil {
+		t.Fatalf("unexpected failure converting to a sealed secret: %v", err)
+	}
+	if got != want {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}

--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -30,7 +30,7 @@ func PublicKeyFingerprint(rp *rsa.PublicKey) (string, error) {
 }
 
 // HybridEncrypt performs a regular AES-GCM + RSA-OAEP encryption.
-// The output bytestring is:
+// The output byte string is:
 //
 //	RSA ciphertext length || RSA ciphertext || AES ciphertext
 func HybridEncrypt(rnd io.Reader, pubKey *rsa.PublicKey, plaintext, label []byte) ([]byte, error) {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Fix empty Group Version Kind fields which can happen at times. See:
https://github.com/operator-framework/operator-sdk/issues/727

Some typos have also been opportunistically fixed.

**Benefits**

The Object is completed at generation/cast time, so it can be relied to be completed later on.
