### PR TITLE
Fix set-output warnings upgrading github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         golangci-lint: ["1.49.0"]
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v3.3.0
+      uses: actions/setup-go@v3.3.1
       with:
         go-version: ${{ matrix.go }}
       id: go
@@ -67,7 +67,7 @@ jobs:
         gosec: ["2.12.0"]
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v3.3.0
+      uses: actions/setup-go@v3.3.1
       with:
         go-version: ${{ matrix.go }}
       id: go
@@ -94,7 +94,7 @@ jobs:
     steps:
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v3.3.0
+      uses: actions/setup-go@v3.3.1
       with:
         go-version: ${{ matrix.go }}
       id: go
@@ -148,7 +148,7 @@ jobs:
         chmod +x ~/bin/kubecfg
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v3.3.0
+      uses: actions/setup-go@v3.3.1
       with:
         go-version: ${{ needs.load-versions.outputs.go_version }}
       id: go
@@ -190,7 +190,7 @@ jobs:
         echo "CONTROLLER_IMAGE=$controller_registry/$controller_repository:$controller_tag" >> $GITHUB_ENV
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v3.3.0
+      uses: actions/setup-go@v3.3.1
       with:
         go-version: ${{ needs.load-versions.outputs.go_version }}
       id: go
@@ -258,7 +258,7 @@ jobs:
         echo "CONTROLLER_IMAGE=$controller_registry/$controller_repository:$controller_tag" >> $GITHUB_ENV
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v3.3.0
+      uses: actions/setup-go@v3.3.1
       with:
         go-version: ${{ needs.load-versions.outputs.go_version }}
       id: go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,7 @@ jobs:
         kubernetes-version: ${{ matrix.k8s }}
 
     - name: Install Helm
-      uses: azure/setup-helm@v3.3
+      uses: azure/setup-helm@v3.4
       with:
         version: v3.4.2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,12 +218,12 @@ jobs:
         kubectl cluster-info
 
     - name: Download manifest artifact
-      uses: actions/download-artifact@v3.0.0
+      uses: actions/download-artifact@v3.0.1
       with:
         name: controller-manifest
 
     - name: Download container image artifact
-      uses: actions/download-artifact@v3.0.0
+      uses: actions/download-artifact@v3.0.1
       with:
         name: controller-image
 
@@ -291,7 +291,7 @@ jobs:
         kubectl cluster-info
 
     - name: Download container image artifact
-      uses: actions/download-artifact@v3.0.0
+      uses: actions/download-artifact@v3.0.1
       with:
         name: controller-image
 

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -23,7 +23,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v3.3
+        uses: azure/setup-helm@v3.4
         with:
           version: v3.4.2
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
           source $GITHUB_WORKSPACE/versions.env
           echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
       - name: Set up Go
-        uses: actions/setup-go@v3.3.0
+        uses: actions/setup-go@v3.3.1
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Setup kubecfg


### PR DESCRIPTION
Signed-off-by: Jose Luis Vazquez Gonzalez <josvaz@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Upgrading:
- `actions/setup-go@v3.3.0` to `@v3.3.1`
- `action/download-artifact@v3.0.0` to `@v3.0.1`
- `azure/setup-helm@v3.3` to `@v3.4` 

Gets rid of all the warnings now.

**Benefits**

Less noise in the CI.
