### PR TITLE
Distinguish std & k8s errors

### DIFF
--- a/integration/controller_test.go
+++ b/integration/controller_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/onsi/gomega/types"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -363,7 +363,7 @@ var _ = Describe("create", func() {
 				Consistently(func() error {
 					_, err := c.Secrets(ns).Get(ctx, secretName, metav1.GetOptions{})
 					return err
-				}).Should(WithTransform(errors.IsNotFound, Equal(true)))
+				}).Should(WithTransform(k8serrors.IsNotFound, Equal(true)))
 			})
 		})
 	})
@@ -383,7 +383,7 @@ var _ = Describe("create", func() {
 			Consistently(func() error {
 				_, err := c.Secrets(ns).Get(ctx, secretName, metav1.GetOptions{})
 				return err
-			}).Should(WithTransform(errors.IsNotFound, Equal(true)))
+			}).Should(WithTransform(k8serrors.IsNotFound, Equal(true)))
 		})
 
 		It("should produce an error Event", func() {
@@ -440,7 +440,7 @@ var _ = Describe("create", func() {
 				Consistently(func() error {
 					_, err := c.Secrets(ns).Get(ctx, secretName2, metav1.GetOptions{})
 					return err
-				}).Should(WithTransform(errors.IsNotFound, Equal(true)))
+				}).Should(WithTransform(k8serrors.IsNotFound, Equal(true)))
 			})
 
 			It("should produce an error Event", func() {
@@ -468,7 +468,7 @@ var _ = Describe("create", func() {
 				Consistently(func() error {
 					_, err := c.Secrets(ns2).Get(ctx, secretName, metav1.GetOptions{})
 					return err
-				}).Should(WithTransform(errors.IsNotFound, Equal(true)))
+				}).Should(WithTransform(k8serrors.IsNotFound, Equal(true)))
 			})
 
 			It("should produce an error Event", func() {
@@ -595,7 +595,7 @@ var _ = Describe("create", func() {
 				Consistently(func() error {
 					_, err := c.Secrets(ns2).Get(ctx, secretName, metav1.GetOptions{})
 					return err
-				}).Should(WithTransform(errors.IsNotFound, Equal(true)))
+				}).Should(WithTransform(k8serrors.IsNotFound, Equal(true)))
 			})
 		})
 	})

--- a/integration/controller_test.go
+++ b/integration/controller_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/onsi/gomega/types"
 	v1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -363,7 +363,7 @@ var _ = Describe("create", func() {
 				Consistently(func() error {
 					_, err := c.Secrets(ns).Get(ctx, secretName, metav1.GetOptions{})
 					return err
-				}).Should(WithTransform(k8serrors.IsNotFound, Equal(true)))
+				}).Should(WithTransform(errors.IsNotFound, Equal(true)))
 			})
 		})
 	})
@@ -383,7 +383,7 @@ var _ = Describe("create", func() {
 			Consistently(func() error {
 				_, err := c.Secrets(ns).Get(ctx, secretName, metav1.GetOptions{})
 				return err
-			}).Should(WithTransform(k8serrors.IsNotFound, Equal(true)))
+			}).Should(WithTransform(errors.IsNotFound, Equal(true)))
 		})
 
 		It("should produce an error Event", func() {
@@ -440,7 +440,7 @@ var _ = Describe("create", func() {
 				Consistently(func() error {
 					_, err := c.Secrets(ns).Get(ctx, secretName2, metav1.GetOptions{})
 					return err
-				}).Should(WithTransform(k8serrors.IsNotFound, Equal(true)))
+				}).Should(WithTransform(errors.IsNotFound, Equal(true)))
 			})
 
 			It("should produce an error Event", func() {
@@ -468,7 +468,7 @@ var _ = Describe("create", func() {
 				Consistently(func() error {
 					_, err := c.Secrets(ns2).Get(ctx, secretName, metav1.GetOptions{})
 					return err
-				}).Should(WithTransform(k8serrors.IsNotFound, Equal(true)))
+				}).Should(WithTransform(errors.IsNotFound, Equal(true)))
 			})
 
 			It("should produce an error Event", func() {
@@ -595,7 +595,7 @@ var _ = Describe("create", func() {
 				Consistently(func() error {
 					_, err := c.Secrets(ns2).Get(ctx, secretName, metav1.GetOptions{})
 					return err
-				}).Should(WithTransform(k8serrors.IsNotFound, Equal(true)))
+				}).Should(WithTransform(errors.IsNotFound, Equal(true)))
 			})
 		})
 	})

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rsa"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -56,7 +57,7 @@ const (
 
 var (
 	// ErrCast happens when a K8s any type cannot be casted to the expected type
-	ErrCast = fmt.Errorf("cast error")
+	ErrCast = errors.New("cast error")
 )
 
 // Controller implements the main sealed-secrets-controller loop.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -10,7 +10,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -128,7 +128,7 @@ func NewController(clientset kubernetes.Interface, ssclientset ssclientset.Inter
 
 			ssecret, err := ssclientset.BitnamiV1alpha1().SealedSecrets(ns).Get(context.Background(), name, metav1.GetOptions{})
 			if err != nil {
-				if !errors.IsNotFound(err) {
+				if !k8serrors.IsNotFound(err) {
 					log.Printf("failed to get SealedSecret: %v", err)
 				}
 				return
@@ -247,7 +247,7 @@ func (c *Controller) unseal(ctx context.Context, key string) (unsealErr error) {
 				return err
 			}
 			err = c.sclient.Secrets(ns).Delete(ctx, name, metav1.DeleteOptions{})
-			if err != nil && !errors.IsNotFound(err) {
+			if err != nil && !k8serrors.IsNotFound(err) {
 				return err
 			}
 		}
@@ -282,7 +282,7 @@ func (c *Controller) unseal(ctx context.Context, key string) (unsealErr error) {
 	}
 
 	secret, err := c.sclient.Secrets(ssecret.GetObjectMeta().GetNamespace()).Get(ctx, newSecret.GetObjectMeta().GetName(), metav1.GetOptions{})
-	if errors.IsNotFound(err) {
+	if k8serrors.IsNotFound(err) {
 		secret, err = c.sclient.Secrets(ssecret.GetObjectMeta().GetNamespace()).Create(ctx, newSecret, metav1.CreateOptions{})
 	}
 	if err != nil {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Use `errors.New()` for non formatted errors. The `errors` from the `stdlib` should be the default ones, when both are in use.
