### PR TITLE
Release Helm Chart 2.7.1 to use release 0.19.2

### DIFF
--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: DeveloperTools
 apiVersion: v2
-appVersion: v0.19.1
+appVersion: v0.19.2
 description: Helm chart for the sealed-secrets controller.
 home: https://github.com/bitnami-labs/sealed-secrets
 icon: https://bitnami.com/assets/stacks/sealed-secrets/img/sealed-secrets-stack-220x234.png
@@ -14,4 +14,4 @@ maintainers:
     url: https://github.com/bitnami-labs/sealed-secrets
 name: sealed-secrets
 type: application
-version: 2.7.0
+version: 2.8.0

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
     url: https://github.com/bitnami-labs/sealed-secrets
 name: sealed-secrets
 type: application
-version: 2.8.0
+version: 2.7.1

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -86,7 +86,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------------------------- | ------------------------------------------------------------------------------------ | ----------------------------------- |
 | `image.registry`                                  | Sealed Secrets image registry                                                        | `docker.io`                         |
 | `image.repository`                                | Sealed Secrets image repository                                                      | `bitnami/sealed-secrets-controller` |
-| `image.tag`                                       | Sealed Secrets image tag (immutable tags are recommended)                            | `v0.19.1`                           |
+| `image.tag`                                       | Sealed Secrets image tag (immutable tags are recommended)                            | `v0.19.2`                           |
 | `image.pullPolicy`                                | Sealed Secrets image pull policy                                                     | `IfNotPresent`                      |
 | `image.pullSecrets`                               | Sealed Secrets image pull secrets                                                    | `[]`                                |
 | `createController`                                | Specifies whether the Sealed Secrets controller should be created                    | `true`                              |

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -33,7 +33,7 @@ commonAnnotations: {}
 image:
   registry: docker.io
   repository: bitnami/sealed-secrets-controller
-  tag: v0.19.1
+  tag: v0.19.2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: Alfredo Garcia <algarcia@vmware.com>

**Description of the change**

Bump chart release to 2.7.1 to use Sealed Secrets latest release