### PR TITLE
Add recommended Kubernetes label app.kubernetes.io/part-of to the Helm chart

### DIFF
--- a/helm/sealed-secrets/templates/_helpers.tpl
+++ b/helm/sealed-secrets/templates/_helpers.tpl
@@ -57,6 +57,7 @@ helm.sh/chart: {{ include "sealed-secrets.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/part-of: sealed-secrets
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Add recommended Kubernetes label app.kubernetes.io/part-of to the Helm chart
Signed-off-by: Ilia Medvedev <ilia.medvedev@codefresh.io>

**Description of the change**
Add recommended Kubernetes label (https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels) app.kubernetes.io/part-of to the Helm chart.

**Benefits**
Identifying resources with common well known labels.

**Possible drawbacks**

None

