### PR TITLE
change drop capabilities to uppercase

### DIFF
--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
     url: https://github.com/bitnami-labs/sealed-secrets
 name: sealed-secrets
 type: application
-version: 2.7.5
+version: 2.7.6

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -160,7 +160,7 @@ containerSecurityContext:
   runAsUser: 1001
   capabilities:
     drop:
-      - all
+      - ALL
 
 ## @param automountServiceAccountToken whether to automatically mount the service account API-token to a particular pod
 automountServiceAccountToken: ""


### PR DESCRIPTION
**Description of the change**
Changes the drop all capability to uppercase to make it correctly work with the `pod-security.kubernetes.io/enforce: restricted` namespace label. 

**Benefits**
Kubernetes needs it to be uppercase instead of lowercase, while most deployments will not break it might break in some cases.

**Possible drawbacks**
None

**Applicable issues**

- fixes #1123
