### PR TITLE
Update "bring your own cert" docs to add `-days` option for cert expiry

### DIFF
--- a/docs/bring-your-own-certificates.md
+++ b/docs/bring-your-own-certificates.md
@@ -18,9 +18,9 @@ export SECRETNAME="mycustomkeys"
 ```
 
 ## Generate a new RSA key pair (certificates)
-
+* Note to change `-days` option to set certificate expiry date; default is 1 year
 ```bash
-openssl req -x509 -nodes -newkey rsa:4096 -keyout "$PRIVATEKEY" -out "$PUBLICKEY" -subj "/CN=sealed-secret/O=sealed-secret"
+openssl req -x509 -days 365 -nodes -newkey rsa:4096 -keyout "$PRIVATEKEY" -out "$PUBLICKEY" -subj "/CN=sealed-secret/O=sealed-secret"
 ```
 
 ## Create a tls k8s secret, using your recently created RSA key pair


### PR DESCRIPTION
**Description of the change**
Update docs for "bring your own certs" as per https://github.com/bitnami-labs/sealed-secrets/issues/1126

**Benefits**
Docs work for generating your own certs and sealing them.

**Possible drawbacks**
Need to pick a sane default expiry time for docs

**Applicable issues**
N/A

**Additional information**
N/A