### PR TITLE
Allow automountServiceAccountToken to be set to false

### DIFF
--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -46,9 +46,7 @@ spec:
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "sealed-secrets.serviceAccountName" . }}
-      {{- if .Values.automountServiceAccountToken }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
-      {{- end }}
       {{- if .Values.hostNetwork }}
       hostNetwork: true
       {{- end }}

--- a/helm/sealed-secrets/templates/service-account.yaml
+++ b/helm/sealed-secrets/templates/service-account.yaml
@@ -1,9 +1,7 @@
 {{ if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
-{{- if .Values.serviceAccount.automountServiceAccountToken }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
-{{- end }}
 metadata:
   name: {{ include "sealed-secrets.serviceAccountName" . }}
   namespace: {{ include "sealed-secrets.namespace" . }}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -163,7 +163,7 @@ containerSecurityContext:
       - ALL
 
 ## @param automountServiceAccountToken whether to automatically mount the service account API-token to a particular pod
-automountServiceAccountToken: ""
+automountServiceAccountToken: true
 
 ## @param podLabels [object] Extra labels for Sealed Secret pods
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
@@ -341,7 +341,7 @@ serviceAccount:
   ##
   name: ""
   ## @param serviceAccount.automountServiceAccountToken Specifies, whether to mount the service account API-token
-  automountServiceAccountToken: ""
+  automountServiceAccountToken: true
 ## RBAC configuration
 ##
 rbac:


### PR DESCRIPTION
**Description of the change**
This fixes the logic so that `automountServiceAccountToken` can be explicitly set to false to opt out of this feature, as documented here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting

**Applicable issues**
- fixes #1125 

