### PR TITLE
Parametrize cluster role name

### DIFF
--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -166,17 +166,18 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Other Parameters
 
-| Name                                          | Description                                                   | Value   |
-| --------------------------------------------- | ------------------------------------------------------------- | ------- |
-| `serviceAccount.annotations`                  | Annotations for Sealed Secret service account                 | `{}`    |
-| `serviceAccount.create`                       | Specifies whether a ServiceAccount should be created          | `true`  |
-| `serviceAccount.labels`                       | Extra labels to be added to the ServiceAccount                | `{}`    |
-| `serviceAccount.name`                         | The name of the ServiceAccount to use.                        | `""`    |
-| `serviceAccount.automountServiceAccountToken` | Specifies, whether to mount the service account API-token     | `true`  |
-| `rbac.create`                                 | Specifies whether RBAC resources should be created            | `true`  |
-| `rbac.clusterRole`                            | Specifies whether the Cluster Role resource should be created | `true`  |
-| `rbac.labels`                                 | Extra labels to be added to RBAC resources                    | `{}`    |
-| `rbac.pspEnabled`                             | PodSecurityPolicy                                             | `false` |
+| Name                                          | Description                                                   | Value              |
+| --------------------------------------------- | ------------------------------------------------------------- | ------------------ |
+| `serviceAccount.annotations`                  | Annotations for Sealed Secret service account                 | `{}`               |
+| `serviceAccount.create`                       | Specifies whether a ServiceAccount should be created          | `true`             |
+| `serviceAccount.labels`                       | Extra labels to be added to the ServiceAccount                | `{}`               |
+| `serviceAccount.name`                         | The name of the ServiceAccount to use.                        | `""`               |
+| `serviceAccount.automountServiceAccountToken` | Specifies, whether to mount the service account API-token     | `true`             |
+| `rbac.create`                                 | Specifies whether RBAC resources should be created            | `true`             |
+| `rbac.clusterRole`                            | Specifies whether the Cluster Role resource should be created | `true`             |
+| `rbac.clusterRoleName`                        | Specifies the name for the Cluster Role resource              | `secrets-unsealer` |
+| `rbac.labels`                                 | Extra labels to be added to RBAC resources                    | `{}`               |
+| `rbac.pspEnabled`                             | PodSecurityPolicy                                             | `false`            |
 
 ### Metrics parameters
 

--- a/helm/sealed-secrets/templates/cluster-role-binding.yaml
+++ b/helm/sealed-secrets/templates/cluster-role-binding.yaml
@@ -10,7 +10,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: secrets-unsealer
+  name: {{ .Values.rbac.clusterRoleName }}
 subjects:
   - apiGroup: ""
     kind: ServiceAccount

--- a/helm/sealed-secrets/templates/cluster-role.yaml
+++ b/helm/sealed-secrets/templates/cluster-role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: secrets-unsealer
+  name: {{ .Values.rbac.clusterRoleName }}
   labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
     {{- if .Values.rbac.labels }}
     {{- include "sealed-secrets.render" ( dict "value" .Values.rbac.labels "context" $) | nindent 4 }}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -358,6 +358,9 @@ rbac:
   ## @param rbac.clusterRole Specifies whether the Cluster Role resource should be created
   ##
   clusterRole: true
+  ## @param rbac.clusterRoleName Specifies the name for the Cluster Role resource
+  ##
+  clusterRoleName: "secrets-unsealer"
   ## @param rbac.labels Extra labels to be added to RBAC resources
   ##
   labels: {}


### PR DESCRIPTION
**Description of the change**
Allow users to set the cluster role name. This is important as the hardcoded name can cause conflicts with other cluster roles already installed in the environment.

**Applicable issues**
- fixes #1082 
