### PR TITLE
order certs by notBefore date

### DIFF
--- a/pkg/controller/keyregistry.go
+++ b/pkg/controller/keyregistry.go
@@ -20,7 +20,7 @@ type Key struct {
 	private      *rsa.PrivateKey
 	cert         *x509.Certificate
 	fingerprint  string
-	creationTime time.Time
+	orderingTime time.Time
 }
 
 // A KeyRegistry manages the key pairs used to (un)seal secrets.
@@ -66,7 +66,7 @@ func (kr *KeyRegistry) generateKey(ctx context.Context, validFor time.Duration, 
 	return generatedName, nil
 }
 
-func (kr *KeyRegistry) registerNewKey(keyName string, privKey *rsa.PrivateKey, cert *x509.Certificate, creationTime time.Time) error {
+func (kr *KeyRegistry) registerNewKey(keyName string, privKey *rsa.PrivateKey, cert *x509.Certificate, orderingTime time.Time) error {
 	fingerprint, err := crypto.PublicKeyFingerprint(&privKey.PublicKey)
 	if err != nil {
 		return err
@@ -76,11 +76,11 @@ func (kr *KeyRegistry) registerNewKey(keyName string, privKey *rsa.PrivateKey, c
 		private:      privKey,
 		cert:         cert,
 		fingerprint:  fingerprint,
-		creationTime: creationTime,
+		orderingTime: orderingTime,
 	}
 	kr.keys[k.fingerprint] = k
 
-	if kr.mostRecentKey == nil || kr.mostRecentKey.creationTime.Before(creationTime) {
+	if kr.mostRecentKey == nil || kr.mostRecentKey.orderingTime.Before(orderingTime) {
 		kr.mostRecentKey = k
 	}
 

--- a/pkg/controller/keys_test.go
+++ b/pkg/controller/keys_test.go
@@ -28,6 +28,10 @@ func signKey(r io.Reader, key *rsa.PrivateKey) (*x509.Certificate, error) {
 	return crypto.SignKey(r, key, time.Hour, "testcn")
 }
 
+func signKeyWithNotBefore(r io.Reader, key *rsa.PrivateKey, notBefore time.Time) (*x509.Certificate, error) {
+	return crypto.SignKeyWithNotBefore(r, key, notBefore, time.Hour, "testcn")
+}
+
 func TestReadKey(t *testing.T) {
 	rand := testRand()
 

--- a/pkg/controller/main.go
+++ b/pkg/controller/main.go
@@ -82,8 +82,7 @@ func initKeyRegistry(ctx context.Context, client kubernetes.Interface, r io.Read
 		if err != nil {
 			log.Printf("Error reading key %s: %v", secret.Name, err)
 		}
-		ct := secret.CreationTimestamp
-		if err := keyRegistry.registerNewKey(secret.Name, key, certs[0], ct.Time); err != nil {
+		if err := keyRegistry.registerNewKey(secret.Name, key, certs[0], certs[0].NotBefore); err != nil {
 			return nil, err
 		}
 		log.Printf("----- %s", secret.Name)

--- a/pkg/controller/main.go
+++ b/pkg/controller/main.go
@@ -111,7 +111,7 @@ func myNamespace() string {
 func initKeyRenewal(ctx context.Context, registry *KeyRegistry, period, validFor time.Duration, cutoffTime time.Time, cn string) (func(), error) {
 	// Create a new key if it's the first key,
 	// or if it's older than cutoff time.
-	if len(registry.keys) == 0 || registry.mostRecentKey.creationTime.Before(cutoffTime) {
+	if len(registry.keys) == 0 || registry.mostRecentKey.orderingTime.Before(cutoffTime) {
 		if _, err := registry.generateKey(ctx, validFor, cn); err != nil {
 			return nil, err
 		}
@@ -129,7 +129,7 @@ func initKeyRenewal(ctx context.Context, registry *KeyRegistry, period, validFor
 
 	// If key rotation is enabled, we'll rotate the key when the most recent
 	// key becomes stale (older than period).
-	mostRecentKeyAge := time.Since(registry.mostRecentKey.creationTime)
+	mostRecentKeyAge := time.Since(registry.mostRecentKey.orderingTime)
 	initialDelay := period - mostRecentKeyAge
 	if initialDelay < 0 {
 		initialDelay = 0

--- a/pkg/crypto/keys.go
+++ b/pkg/crypto/keys.go
@@ -29,7 +29,13 @@ func SignKey(r io.Reader, key *rsa.PrivateKey, validFor time.Duration, cn string
 	// TODO: use certificates API to get this signed by the cluster root CA
 	// See https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/
 
-	notBefore := time.Now()
+	return SignKeyWithNotBefore(r, key, time.Now(), validFor, cn)
+}
+
+// SignKeyWithNotBefore returns a signed certificate with custom notBefore.
+func SignKeyWithNotBefore(r io.Reader, key *rsa.PrivateKey, notBefore time.Time, validFor time.Duration, cn string) (*x509.Certificate, error) {
+	// TODO: use certificates API to get this signed by the cluster root CA
+	// See https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/
 
 	serialNo, err := rand.Int(r, new(big.Int).Lsh(big.NewInt(1), 128))
 	if err != nil {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Use notbefore date to sort certs instead of creationtimestamp

**Benefits**

We create our certificates externally and sync them into a new cluster. In our case, the secret creationTimestamp isn't equal to the TLS notbefore date. Sometimes we hit a race condition during the sync so that an already out-date certificate has a newer creationTimestamp than a newer certificate which is valid and kubeseal requires that the certificate is valid (not before to not after range).

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
