### PR TITLE
Remove automountServiceAccountToken parameter

### DIFF
--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -128,7 +128,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `containerSecurityContext.runAsNonRoot`           | Indicates that the Sealed Secret container must run as a non-root user                 | `true`                              |
 | `containerSecurityContext.runAsUser`              | Set Sealed Secret containers' Security Context runAsUser                               | `1001`                              |
 | `containerSecurityContext.capabilities`           | Adds and removes POSIX capabilities from running containers (see `values.yaml`)        |                                     |
-| `automountServiceAccountToken`                    | whether to automatically mount the service account API-token to a particular pod       | `true`                              |
 | `podLabels`                                       | Extra labels for Sealed Secret pods                                                    | `{}`                                |
 | `podAnnotations`                                  | Annotations for Sealed Secret pods                                                     | `{}`                                |
 | `priorityClassName`                               | Sealed Secret pods' priorityClassName                                                  | `""`                                |
@@ -166,18 +165,17 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Other Parameters
 
-| Name                                          | Description                                                   | Value              |
-| --------------------------------------------- | ------------------------------------------------------------- | ------------------ |
-| `serviceAccount.annotations`                  | Annotations for Sealed Secret service account                 | `{}`               |
-| `serviceAccount.create`                       | Specifies whether a ServiceAccount should be created          | `true`             |
-| `serviceAccount.labels`                       | Extra labels to be added to the ServiceAccount                | `{}`               |
-| `serviceAccount.name`                         | The name of the ServiceAccount to use.                        | `""`               |
-| `serviceAccount.automountServiceAccountToken` | Specifies, whether to mount the service account API-token     | `true`             |
-| `rbac.create`                                 | Specifies whether RBAC resources should be created            | `true`             |
-| `rbac.clusterRole`                            | Specifies whether the Cluster Role resource should be created | `true`             |
-| `rbac.clusterRoleName`                        | Specifies the name for the Cluster Role resource              | `secrets-unsealer` |
-| `rbac.labels`                                 | Extra labels to be added to RBAC resources                    | `{}`               |
-| `rbac.pspEnabled`                             | PodSecurityPolicy                                             | `false`            |
+| Name                         | Description                                                   | Value              |
+| ---------------------------- | ------------------------------------------------------------- | ------------------ |
+| `serviceAccount.annotations` | Annotations for Sealed Secret service account                 | `{}`               |
+| `serviceAccount.create`      | Specifies whether a ServiceAccount should be created          | `true`             |
+| `serviceAccount.labels`      | Extra labels to be added to the ServiceAccount                | `{}`               |
+| `serviceAccount.name`        | The name of the ServiceAccount to use.                        | `""`               |
+| `rbac.create`                | Specifies whether RBAC resources should be created            | `true`             |
+| `rbac.clusterRole`           | Specifies whether the Cluster Role resource should be created | `true`             |
+| `rbac.clusterRoleName`       | Specifies the name for the Cluster Role resource              | `secrets-unsealer` |
+| `rbac.labels`                | Extra labels to be added to RBAC resources                    | `{}`               |
+| `rbac.pspEnabled`            | PodSecurityPolicy                                             | `false`            |
 
 ### Metrics parameters
 

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -46,7 +46,6 @@ spec:
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "sealed-secrets.serviceAccountName" . }}
-      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.hostNetwork }}
       hostNetwork: true
       {{- end }}

--- a/helm/sealed-secrets/templates/service-account.yaml
+++ b/helm/sealed-secrets/templates/service-account.yaml
@@ -1,7 +1,6 @@
 {{ if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "sealed-secrets.serviceAccountName" . }}
   namespace: {{ include "sealed-secrets.namespace" . }}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -169,9 +169,6 @@ containerSecurityContext:
     drop:
       - ALL
 
-## @param automountServiceAccountToken whether to automatically mount the service account API-token to a particular pod
-automountServiceAccountToken: true
-
 ## @param podLabels [object] Extra labels for Sealed Secret pods
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
@@ -347,8 +344,6 @@ serviceAccount:
   ## If not set and create is true, a name is generated using the sealed-secrets.fullname template
   ##
   name: ""
-  ## @param serviceAccount.automountServiceAccountToken Specifies, whether to mount the service account API-token
-  automountServiceAccountToken: true
 ## RBAC configuration
 ##
 rbac:


### PR DESCRIPTION
**Description of the change**
The controller requires the token to be mounted in the pod, so it doesn't make sense to allow users to disable the automounting behavior.

**Applicable issues**

- fixes #1161 