### PR TITLE
Generate embedded ObjectMeta in CRD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ generate: $(GO_FILES)
 	cp -r gentmp/github.com/bitnami-labs/sealed-secrets/pkg . && rm -rf gentmp/
 
 manifests:
-	$(CONTROLLER_GEN) crd paths="./pkg/apis/..." output:stdout | tail -n +2 > helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
+	$(CONTROLLER_GEN) crd:generateEmbeddedObjectMeta=true paths="./pkg/apis/..." output:stdout | tail -n +2 > helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
 	yq '.spec.versions[0].schema' < helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml > schema-v1alpha1.yaml
 
 controller: $(GO_FILES)

--- a/helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
+++ b/helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: sealedsecrets.bitnami.com
 spec:
@@ -59,6 +59,23 @@ spec:
                   metadata:
                     description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
                     nullable: true
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      finalizers:
+                        items:
+                          type: string
+                        type: array
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        type: string
+                      namespace:
+                        type: string
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   type:

--- a/pkg/apis/sealedsecrets/v1alpha1/types.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/types.go
@@ -36,7 +36,7 @@ type SecretTemplateSpec struct {
 	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
 	// +optional
 	// +nullable
-	// +kubebuilder:validation:XPreserveUnknownFields
+	// +kubebuilder:pruning:PreserveUnknownFields
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Used to facilitate programmatic handling of secret data.
@@ -61,7 +61,7 @@ type SealedSecretSpec struct {
 	EncryptedData SealedSecretEncryptedData `json:"encryptedData"`
 }
 
-// +kubebuilder:validation:XPreserveUnknownFields
+// +kubebuilder:pruning:PreserveUnknownFields
 type SealedSecretEncryptedData map[string]string
 
 func (s *SealedSecretEncryptedData) UnmarshalJSON(data []byte) error {

--- a/schema-v1alpha1.yaml
+++ b/schema-v1alpha1.yaml
@@ -33,6 +33,23 @@ openAPIV3Schema:
             metadata:
               description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
               nullable: true
+              properties:
+                annotations:
+                  additionalProperties:
+                    type: string
+                  type: object
+                finalizers:
+                  items:
+                    type: string
+                  type: array
+                labels:
+                  additionalProperties:
+                    type: string
+                  type: object
+                name:
+                  type: string
+                namespace:
+                  type: string
               type: object
               x-kubernetes-preserve-unknown-fields: true
             type:


### PR DESCRIPTION
**Description of the change**
Add ObjectMeta fields to the CRD to validate fields such as `spec.template.metadata.labels`. This is generated by `controller-gen` by setting `crd:generateEmbeddedObjectMeta=true`.

This prevents Kubernetes from accepting invalid values in these metadata fields, such as reported in #1171. When trying to apply a resource with such an invalid value, an error like this will be shown:

```
The SealedSecret "my-secret" is invalid: spec.template.metadata.labels.hi: Invalid value: "boolean": spec.template.metadata.labels.hi in body must be of type string: "boolean"
```

It also replaces the deprecated tag `+kubebuilder:validation:XPreserveUnknownFields` with the newer `+kubebuilder:pruning:PreserveUnknownFields`.

**Applicable issues**
- #1171 
