### PR TITLE
Fix cosign command for goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,6 +49,7 @@ signs:
       - 'sign-blob'
       - '--key=/tmp/cosign.key'
       - '--output-signature=${signature}'
+      - '--yes'
       - '${artifact}'
 release:
   name_template: "{{ .ProjectName }}-v{{ .Version }}"


### PR DESCRIPTION
**Description of the change**
Update the `cosign` command in GoReleaser for Cosign v2. Cosign was updated in #1176 but the change in the GoReleaser configuration was missed.
