### PR TITLE
Fix go generate to use module dep instead of vendor dir

### DIFF
--- a/pkg/apis/sealedsecrets/v1alpha1/doc.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 // go mod vendor doesn't preserve executable perm bits
-//go:generate bash ../../../../vendor/k8s.io/code-generator/generate-groups.sh all github.com/bitnami-labs/sealed-secrets/pkg/client github.com/bitnami-labs/sealed-secrets/pkg/apis sealedsecrets:v1alpha1 --go-header-file boilerplate.go.txt --output-base ../../../../gentmp
+//go:generate bash -c "go mod download && bash $(go list -m -f '{{.Dir}}' k8s.io/code-generator)/generate-groups.sh all github.com/bitnami-labs/sealed-secrets/pkg/client github.com/bitnami-labs/sealed-secrets/pkg/apis sealedsecrets:v1alpha1 --go-header-file boilerplate.go.txt --output-base ../../../../gentmp"
 // +k8s:deepcopy-gen=package,register
 
 // +groupName=bitnami.com


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

We used to vendor our dependencies but then we got rid of vendoring in favour of using modern go modules and module cache.

However the `go generate` targets were still referencing the vendoring dir in order to execute code generation scripts for sealed-secrets CRD.

This PR fixes the go:generate stanza so that it locates the script from go module directory.

(Forcing a `go download` before `go list` is necessary to ensure that the `Dir` field is populated. If the cache is warm go download is a no-op).

**Benefits**

`go generate ./...` now works

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
