### PR TITLE
Enable logging info to stdout

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -49,6 +49,8 @@ func bindControllerFlags(f *controller.Flags, fs *flag.FlagSet) {
 
 	fs.BoolVar(&f.SkipRecreate, "skip-recreate", false, "if true the controller will skip listening for managed secret changes to recreate them. This helps on limited permission environments.")
 
+	fs.BoolVar(&f.LogInfoToStdout, "log-info-stdout", false, "if true the controller will log info to stdout.")
+
 	fs.DurationVar(&f.KeyRenewPeriod, "rotate-period", defaultKeyRenewPeriod, "")
 	_ = fs.MarkDeprecated("rotate-period", "please use key-renew-period instead")
 }

--- a/pkg/controller/keyregistry.go
+++ b/pkg/controller/keyregistry.go
@@ -6,11 +6,11 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"log"
 	"sync"
 	"time"
 
 	"github.com/bitnami-labs/sealed-secrets/pkg/crypto"
+	"github.com/bitnami-labs/sealed-secrets/pkg/log"
 	"k8s.io/client-go/kubernetes"
 	certUtil "k8s.io/client-go/util/cert"
 )
@@ -61,8 +61,8 @@ func (kr *KeyRegistry) generateKey(ctx context.Context, validFor time.Duration, 
 	if err := kr.registerNewKey(generatedName, key, cert, time.Now()); err != nil {
 		return "", err
 	}
-	log.Printf("New key written to %s/%s\n", kr.namespace, generatedName)
-	log.Printf("Certificate is \n%s\n", pem.EncodeToMemory(&pem.Block{Type: certUtil.CertificateBlockType, Bytes: cert.Raw}))
+	log.Infof("New key written to %s/%s\n", kr.namespace, generatedName)
+	log.Infof("Certificate is \n%s\n", pem.EncodeToMemory(&pem.Block{Type: certUtil.CertificateBlockType, Bytes: cert.Raw}))
 	return generatedName, nil
 }
 

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,36 @@
+package log
+
+import (
+	"log"
+	"os"
+)
+
+var (
+	infoLogger  *log.Logger
+	errorLogger *log.Logger
+)
+
+func init() {
+	infoLogger = log.New(os.Stderr, "", 0)
+	errorLogger = log.New(os.Stderr, "", 0)
+}
+
+func SetInfoToStdout() {
+	infoLogger.SetOutput(os.Stdout)
+}
+
+func Infof(format string, v ...interface{}) {
+	infoLogger.Printf(format, v...)
+}
+
+func Errorf(format string, v ...interface{}) {
+	errorLogger.Printf(format, v...)
+}
+
+func Fatal(v ...any) {
+	errorLogger.Fatal(v...)
+}
+
+func Panic(v ...any) {
+	errorLogger.Panic(v...)
+}


### PR DESCRIPTION
**Description of the change**

This commit introduces a logging package that utilizes https://pkg.go.dev/log as before, but now includes `Infof` and `Errorf` methods. The controller's code has been updated to use these methods. When the `log-info-stdout` flag is enabled, `Infof` logs will be directed to stdout instead of stderr. By default, the controller continues to log information to stderr to maintain compatibility with existing behavior.

**Known limitations**

- You may prefer to switch to a different logging package rather than using a custom one.
- By default, informational messages are still logged to stderr.

**Benefits**

The native Golang log library logs by default to stderr with Println, which is suitable for most messages logged by the controller, as they are usually warnings or errors. However, in some instances, informational messages are logged, which also go to stderr. This can cause issues when using log management tools.

**Applicable issues**

#396 