### PR TITLE
Feature allow to skip set owner references

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,11 @@ only change from existing Kubernetes is that the *contents* of the
 
 If you want `SealedSecret` controller to take management of an existing `Secret` (i.e. overwrite it when unsealing a `SealedSecret` with the same name and namespace), then you have to annotate that `Secret` with the annotation `sealedsecrets.bitnami.com/managed: "true"` ahead applying the [Usage](#usage) steps.
 
+
+### Seal secret which can skip set owner references
+
+If you want `SealedSecret` and the `Secret` to be independent (which mean when you delete the `SealedSecret` the `Secret` won't disappear with). then you have to annotate that Secret with the annotation `skip-set-owner-references/skip-set-owner-references: "true"` ahead applying the Usage steps. This still add `sealedsecrets.bitnami.com/managed: "true"` to your `Secret` so that your secret will be updated when `SealedSecret` is updated. 
+
 ### Update existing secrets
 
 If you want to add or update existing sealed secrets without having the cleartext for the other items,

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ If you want `SealedSecret` controller to take management of an existing `Secret`
 
 ### Seal secret which can skip set owner references
 
-If you want `SealedSecret` and the `Secret` to be independent (which mean when you delete the `SealedSecret` the `Secret` won't disappear with). then you have to annotate that Secret with the annotation `skip-set-owner-references/skip-set-owner-references: "true"` ahead applying the Usage steps. This still add `sealedsecrets.bitnami.com/managed: "true"` to your `Secret` so that your secret will be updated when `SealedSecret` is updated. 
+If you want `SealedSecret` and the `Secret` to be independent, which mean when you delete the `SealedSecret` the `Secret` won't disappear with it, then you have to annotate that Secret with the annotation `sealedsecrets.bitnami.com/skip-set-owner-references: "true"` ahead of applying the Usage steps. You still may also add `sealedsecrets.bitnami.com/managed: "true"` to your `Secret` so that your secret will be updated when `SealedSecret` is updated. 
 
 ### Update existing secrets
 

--- a/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
@@ -214,14 +214,6 @@ func NewSealedSecret(codecs runtimeserializer.CodecFactory, pubKey *rsa.PublicKe
 		},
 	}
 	secret.ObjectMeta.DeepCopyInto(&s.Spec.Template.ObjectMeta)
-	if checkHasAnnotationToSkipSetOwner(secret) {
-		anno := s.GetAnnotations()
-		if anno == nil {
-			anno = make(map[string]string)
-		}
-		anno[SealedSecretSkipSetOwnerReferencesAnnotation] = "true"
-		s.SetAnnotations(anno)
-	}
 
 	// the input secret could come from a real secret object applied with `kubectl apply` or similar tools
 	// which put a copy of the object version at application time in an annotation in order to support

--- a/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
@@ -344,8 +344,6 @@ func (s *SealedSecret) Unseal(codecs runtimeserializer.CodecFactory, privKeys ma
 			},
 		}
 		secret.SetOwnerReferences(ownerRefs)
-	} else {
-		secret.Annotations[SealedSecretManagedAnnotation] = "true"
 	}
 
 	return &secret, nil

--- a/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
@@ -324,17 +324,19 @@ func (s *SealedSecret) Unseal(codecs runtimeserializer.CodecFactory, privKeys ma
 
 	gvk := s.GetObjectKind().GroupVersionKind()
 
-	// Refer back to owning SealedSecret
-	ownerRefs := []metav1.OwnerReference{
-		{
-			APIVersion: gvk.GroupVersion().String(),
-			Kind:       gvk.Kind,
-			Name:       smeta.GetName(),
-			UID:        smeta.GetUID(),
-			Controller: &boolTrue,
-		},
+	if anno := s.GetAnnotations(); anno[SealedSecretSkipSetOwnerReferencesAnnotation] != "true" {
+		// Refer back to owning SealedSecret
+		ownerRefs := []metav1.OwnerReference{
+			{
+				APIVersion: gvk.GroupVersion().String(),
+				Kind:       gvk.Kind,
+				Name:       smeta.GetName(),
+				UID:        smeta.GetUID(),
+				Controller: &boolTrue,
+			},
+		}
+		secret.SetOwnerReferences(ownerRefs)
 	}
-	secret.SetOwnerReferences(ownerRefs)
 
 	return &secret, nil
 }

--- a/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
@@ -340,11 +340,3 @@ func (s *SealedSecret) Unseal(codecs runtimeserializer.CodecFactory, privKeys ma
 
 	return &secret, nil
 }
-
-func checkHasAnnotationToSkipSetOwner(secret *v1.Secret) bool {
-	anno := secret.Annotations
-	if skipSerOwner, ok := anno[SealedSecretSkipSetOwnerReferencesAnnotation]; ok && skipSerOwner == "true" {
-		return true
-	}
-	return false
-}

--- a/pkg/apis/sealedsecrets/v1alpha1/types.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/types.go
@@ -27,6 +27,10 @@ const (
 	// SealedSecretManagedAnnotation is the name for the annotation for
 	// flaging the existing secrets be managed by SealedSecret controller.
 	SealedSecretManagedAnnotation = annoNs + "managed"
+
+	// SealedSecretSkipSetOwnerReferencesAnnotation is the name for the annotation for
+	// flagging the controller not to set owner reference to secret.
+	SealedSecretSkipSetOwnerReferencesAnnotation = annoNs + "skip-set-owner-references"
 )
 
 // SecretTemplateSpec describes the structure a Secret should have


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
I met an edged use case that I need to keep the _**Secret**_ resource when I delete the _**SealedSecret**_ resource.
Add an annotation that allows a user to skip set **_ownerReferences_**.  

**Benefits**

This prevent the k8s GC to remove the Secret when the _**SealedSecret**_ is removed

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- adds #1199

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
