### PR TITLE
Release Helm & Carvel to use v0.21.0

### DIFF
--- a/carvel/package.yaml
+++ b/carvel/package.yaml
@@ -45,7 +45,7 @@ spec:
             tag:
               type: string
               description: Sealed Secrets image tag (immutable tags are recommended)
-              default: v0.20.5
+              default: v0.21.0
             pullPolicy:
               type: string
               description: Sealed Secrets image pull policy

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: DeveloperTools
 apiVersion: v2
-appVersion: v0.20.5
+appVersion: v0.21.0
 description: Helm chart for the sealed-secrets controller.
 home: https://github.com/bitnami-labs/sealed-secrets
 icon: https://bitnami.com/assets/stacks/sealed-secrets/img/sealed-secrets-stack-220x234.png

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -85,7 +85,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------------------------- | -------------------------------------------------------------------------------------- | ----------------------------------- |
 | `image.registry`                                  | Sealed Secrets image registry                                                          | `docker.io`                         |
 | `image.repository`                                | Sealed Secrets image repository                                                        | `bitnami/sealed-secrets-controller` |
-| `image.tag`                                       | Sealed Secrets image tag (immutable tags are recommended)                              | `v0.20.5`                           |
+| `image.tag`                                       | Sealed Secrets image tag (immutable tags are recommended)                              | `v0.2021.0`                           |
 | `image.pullPolicy`                                | Sealed Secrets image pull policy                                                       | `IfNotPresent`                      |
 | `image.pullSecrets`                               | Sealed Secrets image pull secrets                                                      | `[]`                                |
 | `createController`                                | Specifies whether the Sealed Secrets controller should be created                      | `true`                              |

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -33,7 +33,7 @@ commonAnnotations: {}
 image:
   registry: docker.io
   repository: bitnami/sealed-secrets-controller
-  tag: v0.20.5
+  tag: v0.21.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Release the Helm Chart and Carvel changes pointing to the latest container image from v0.21.0.