### PR TITLE
Release Carvel from Helm Chart v2.9.0

### DIFF
--- a/carvel/package.yaml
+++ b/carvel/package.yaml
@@ -1,10 +1,10 @@
 apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
-  name: "sealedsecrets.bitnami.com.2.8.2"
+  name: "sealedsecrets.bitnami.com.2.9.0"
 spec:
   refName: "sealedsecrets.bitnami.com"
-  version: "2.8.2"
+  version: "2.9.0"
   valuesSchema:
     openAPIv3:
       title: Chart Values
@@ -45,7 +45,7 @@ spec:
             tag:
               type: string
               description: Sealed Secrets image tag (immutable tags are recommended)
-              default: v0.20.5
+              default: v0.21.0
             pullPolicy:
               type: string
               description: Sealed Secrets image pull policy
@@ -424,7 +424,7 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
-          image: ghcr.io/bitnami-labs/sealed-secrets-carvel:sha256-367bf2772f9be7c53e49dfb696d7b4344a86589b9c2d35487237d8861006ad4e.imgpkg
+          image: ghcr.io/bitnami-labs/sealed-secrets-carvel:sha256-024e3595e6109ede34ad6802dbafd1d84ce88bbf2362bada9d61a18f030947e7.imgpkg
       template:
       - helmTemplate:
           path: sealed-secrets


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Release the Carvel package from the Helm Chart at version 2.9.0 and container image version 0.21.0.
