### PR TITLE
Add additionalPrinterColumns for status and age

### DIFF
--- a/helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
+++ b/helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: sealedsecrets.bitnami.com
 spec:
   group: bitnami.com
@@ -14,7 +13,17 @@ spec:
     singular: sealedsecret
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].message
+      name: Status
+      type: string
+    - jsonPath: .status.conditions[0].status
+      name: Synced
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: SealedSecret is the K8s representation of a "sealed Secret" -

--- a/pkg/apis/sealedsecrets/v1alpha1/types.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/types.go
@@ -114,6 +114,8 @@ type SealedSecretStatus struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].message"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +genclient
 
 // SealedSecret is the K8s representation of a "sealed Secret" - a

--- a/pkg/apis/sealedsecrets/v1alpha1/types.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/types.go
@@ -115,6 +115,7 @@ type SealedSecretStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].message"
+// +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=".status.conditions[0].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +genclient
 


### PR DESCRIPTION
Signed-off-by: Karel Vanden Houte <karel.vandenhoute@gmail.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This is a  change to the SealedSecret CRD. It will add a column "Status" and "Synced" with the latest status (message & status) of a secret.
Before, when doing `kubectl get sealedsecret` you would see:
```
NAME          AGE
my-secret     6m35s
````
After this change, you will see:
```
NAME        STATUS                                   SYNCED   AGE
my-secret   no key could decrypt secret (password)   False    25m
````
**Benefits**

You can see the status of your secrets easier. When you have a lot of secrets in a cluster and would like to see which ones can't be decrypted, this comes in handy.

**Possible drawbacks**
None AFAIK

**Applicable issues**

**Additional information**
