### PR TITLE
feat: add replicas default value to the deployment manifest

### DIFF
--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations: {{- toYaml .Values.commonAnnotations | nindent 4 }}
   {{- end }}
 spec:
+  replicas: 1
   selector:
     matchLabels: {{- include "sealed-secrets.matchLabels" . | nindent 6 }}
   template:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

I added the replicas field to the deployment manifest to solve an issue discovered by kube-score.

**Benefits**
Kubernetes reliability and security will be improved

**Possible drawbacks**

There will be no impact

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes # https://github.com/bitnami-labs/sealed-secrets/issues/1218

**Additional information**

