### PR TITLE
Fix doc generated code directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,6 @@
 /docker/controller
 *.iml
 .idea
-gentmp/
 
 # GoReleaser output dir
 dist/

--- a/Makefile
+++ b/Makefile
@@ -46,13 +46,7 @@ GO_LD_FLAGS = -X main.VERSION=$(VERSION)
 all: controller kubeseal
 
 generate: $(GO_FILES)
-	$(GO) mod vendor && $(GO) generate $(GO_PACKAGES)
-	@# TODO: remove as soon as a proper way forward is found:
-	@# code-generator insists in generating the file under directory:
-	@# github.com/bitnami-labs/sealeds-secrets/...
-	@# instead of just updating ./pkg
-	@# for that reason we generate at gentmp and then move it all to ./pkg
-	cp -r gentmp/github.com/bitnami-labs/sealed-secrets/pkg . && rm -rf gentmp/
+	$(GO) generate $(GO_PACKAGES)
 
 manifests:
 	$(CONTROLLER_GEN) crd:generateEmbeddedObjectMeta=true paths="./pkg/apis/..." output:stdout | tail -n +2 > helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -85,7 +85,7 @@ Incomplete release
 ### Changelog
 
 - Automated controller test on Openshift platforms (using ([VMware Image Builder](https://tanzu.vmware.com/image-builder)) ([#1107](https://github.com/bitnami-labs/sealed-secrets/pull/1107)).
-- We now generate a Carvel package distrinbution of the controller ([#1104](https://github.com/bitnami-labs/sealed-secrets/pull/1104)).
+- We now generate a Carvel package distribution of the controller ([#1104](https://github.com/bitnami-labs/sealed-secrets/pull/1104)).
 - Bump golang.org/x/crypto from 0.5.0 to 0.6.0 ([#1108](https://github.com/bitnami-labs/sealed-secrets/pull/1108)).
 - Bump github.com/onsi/gomega from 1.25.0 to 1.26.0 ([#1103](https://github.com/bitnami-labs/sealed-secrets/pull/1103)).
 - Bump k8s.io/code-generator from 0.26.0 to 0.26.1 ([#1102](https://github.com/bitnami-labs/sealed-secrets/pull/1102)).
@@ -207,7 +207,7 @@ Incomplete release
 
 - Unseal templates even when encryptedData is empty ([#653](https://github.com/bitnami-labs/sealed-secrets/pull/653))
 - Add new RBAC rules to make Sealed Secret compatible with K8s environments with RBAC enabled ([#715](https://github.com/bitnami-labs/sealed-secrets/pull/715))
-- Allow rencrypt/validate functionalities to work with named ports defined in the Sealed Secret service ([#726](https://github.com/bitnami-labs/sealed-secrets/pull/726))
+- Allow re-encrypt/validate functionalities to work with named ports defined in the Sealed Secret service ([#726](https://github.com/bitnami-labs/sealed-secrets/pull/726))
 - Fix verbose logging ([#727](https://github.com/bitnami-labs/sealed-secrets/pull/727))
 
 ## v0.17.2
@@ -623,7 +623,7 @@ This potential problem has been introduced v0.8.0 when kubeseal learned how to p
 
 Please check your existing sealed secret sources for any annotation `kubectl.kubernetes.io/last-applied-configuration`, because that annotation would contain your original secrets in clear.
 
-This release strips this annotation (and a similar annotation created by the `kubcfg` tool)
+This release strips this annotation (and a similar annotation created by the `kubecfg` tool)
 
 ### Changelog
 
@@ -699,7 +699,7 @@ Big change for this release is the switch to **per-key encrypted values**.
 
 - Add CRD definition and TPR->CRD migration documentation
 - Add `kubeseal --fetch-cert` to dump server cert to stdout, for later offline use with `kubeseal --cert`
-- Better sanitisation of input object to `kubeseal`
+- Better sanitization of input object to `kubeseal`
 
 (v0.5.1 fixes a travis/github release issue with v0.5.0)
 

--- a/pkg/apis/sealedsecrets/v1alpha1/doc.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 // go mod vendor doesn't preserve executable perm bits
-//go:generate bash -c "go mod download && bash $(go list -m -f '{{.Dir}}' k8s.io/code-generator)/generate-groups.sh all github.com/bitnami-labs/sealed-secrets/pkg/client github.com/bitnami-labs/sealed-secrets/pkg/apis sealedsecrets:v1alpha1 --go-header-file boilerplate.go.txt --output-base ../../../../gentmp"
+//go:generate bash -c "go mod download && cd ../../../.. && bash $(go list -mod=mod -m -f '{{.Dir}}' k8s.io/code-generator)/generate-groups.sh all github.com/bitnami-labs/sealed-secrets/pkg/client github.com/bitnami-labs/sealed-secrets/pkg/apis sealedsecrets:v1alpha1 --go-header-file pkg/apis/sealedsecrets/v1alpha1/boilerplate.go.txt --trim-path-prefix github.com/bitnami-labs/sealed-secrets"
 // +k8s:deepcopy-gen=package,register
 
 // +groupName=bitnami.com


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.

Some typo fixes were also included.
 -->

**Description of the change**

Avoid the logic of copying the generated code to the proper directory. Instead use the flag `--trim-path-prefix` to generate the code in the right place and without the unwanted prefix directories.

https://github.com/kubernetes/code-generator/blob/db4dff4b8168dd37724b89025de5f5be71db6a4f/cmd/go-to-protobuf/protobuf/cmd.go#L99

I also fixed some typos.

**Benefits**

Now `go generate ./...` just does the whole thing properly, including leaving files at the right place.
