### PR TITLE
Update generated code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	k8s.io/code-generator v0.27.2
 	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.100.1
+	sigs.k8s.io/structured-merge-diff/v4 v4.2.3
 )
 
 require (
@@ -70,6 +71,5 @@ require (
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect
 	k8s.io/utils v0.0.0-20230209194617-a36077c30491 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
-	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/pkg/apis/sealedsecrets/v1alpha1/doc.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 // go mod vendor doesn't preserve executable perm bits
-//go:generate bash -c "go mod download && cd ../../../.. && bash $(go list -mod=mod -m -f '{{.Dir}}' k8s.io/code-generator)/generate-groups.sh all github.com/bitnami-labs/sealed-secrets/pkg/client github.com/bitnami-labs/sealed-secrets/pkg/apis sealedsecrets:v1alpha1 --go-header-file pkg/apis/sealedsecrets/v1alpha1/boilerplate.go.txt --trim-path-prefix github.com/bitnami-labs/sealed-secrets"
+//go:generate bash -c "go mod download && cd ../../../.. && bash $(go list -mod=mod -m -f '{{.Dir}}' k8s.io/code-generator)/generate-groups.sh deepcopy,client,informer,lister github.com/bitnami-labs/sealed-secrets/pkg/client github.com/bitnami-labs/sealed-secrets/pkg/apis sealedsecrets:v1alpha1 --go-header-file pkg/apis/sealedsecrets/v1alpha1/boilerplate.go.txt --trim-path-prefix github.com/bitnami-labs/sealed-secrets"
 // +k8s:deepcopy-gen=package,register
 
 // +groupName=bitnami.com

--- a/pkg/client/clientset/versioned/typed/sealedsecrets/v1alpha1/fake/fake_sealedsecret.go
+++ b/pkg/client/clientset/versioned/typed/sealedsecrets/v1alpha1/fake/fake_sealedsecret.go
@@ -8,7 +8,6 @@ import (
 	v1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealedsecrets/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
-	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
@@ -20,9 +19,9 @@ type FakeSealedSecrets struct {
 	ns   string
 }
 
-var sealedsecretsResource = schema.GroupVersionResource{Group: "bitnami.com", Version: "v1alpha1", Resource: "sealedsecrets"}
+var sealedsecretsResource = v1alpha1.SchemeGroupVersion.WithResource("sealedsecrets")
 
-var sealedsecretsKind = schema.GroupVersionKind{Group: "bitnami.com", Version: "v1alpha1", Kind: "SealedSecret"}
+var sealedsecretsKind = v1alpha1.SchemeGroupVersion.WithKind("SealedSecret")
 
 // Get takes name of the sealedSecret, and returns the corresponding sealedSecret object, and an error if there is any.
 func (c *FakeSealedSecrets) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.SealedSecret, err error) {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Result of `make generate` / `go generate ./...`.

Seems latest code generation library version produces code for `applyconfiguration`. As we do not use or need it, we moved our generation spec to explicitly enumerate the generators we require: `deepcopy,client,informer,lister`.

**Benefits**

Generated code is in line with the latest code generation library.

Signed-off-by: Jose Luis Vazquez Gonzalez <josvaz@vmware.com>
