### PR TITLE
add --log-info-stdout to chart

### DIFF
--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -96,6 +96,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `rateLimit`                                       | Number of allowed sustained request per second for verify endpoint                     | `""`                                |
 | `rateLimitBurst`                                  | Number of requests allowed to exceed the rate limit per second for verify endpoint     | `""`                                |
 | `additionalNamespaces`                            | List of namespaces used to manage the Sealed Secrets                                   | `[]`                                |
+| `logInfoStdout`                                   | Specifies whether the Sealed Secrets controller will log info to stdout                | `false`                             |
 | `command`                                         | Override default container command                                                     | `[]`                                |
 | `args`                                            | Override default container args                                                        | `[]`                                |
 | `livenessProbe.enabled`                           | Enable livenessProbe on Sealed Secret containers                                       | `true`                              |

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -89,6 +89,9 @@ spec:
             - --additional-namespaces
             - {{ join "," .Values.additionalNamespaces | quote }}
             {{- end }}
+            {{- if .Values.logInfoStdout }}
+            - --log-info-stdout
+            {{- end }}
           {{- end }}
           image: {{ printf "%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -76,6 +76,9 @@ rateLimitBurst: ""
 ## @param additionalNamespaces List of namespaces used to manage the Sealed Secrets
 ##
 additionalNamespaces: []
+## @param logInfoStdout Specifies whether the Sealed Secrets controller will log info to stdout
+##
+logInfoStdout: false
 ## @param command Override default container command
 ##
 command: []


### PR DESCRIPTION
**Description of the change**

Enables use of the newly introduced flag `--log-info-stdout` for logging to stdout introduced in https://github.com/bitnami-labs/sealed-secrets/pull/1195

**Benefits**

Users of the helm charts will not have to override `args`

**Possible drawbacks**

Probably none?

**Applicable issues**
- https://github.com/bitnami-labs/sealed-secrets/pull/1195

