### PR TITLE
Add namespaced roles support to Helm chart

### DIFF
--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -174,6 +174,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `rbac.create`                | Specifies whether RBAC resources should be created            | `true`             |
 | `rbac.clusterRole`           | Specifies whether the Cluster Role resource should be created | `true`             |
 | `rbac.clusterRoleName`       | Specifies the name for the Cluster Role resource              | `secrets-unsealer` |
+| `rbac.namespacedRoles`       | Specifies whether the namespaced Roles should be created (in each of the specified additionalNamespaces) | `false`            |
+| `rbac.namespacedRolesName`   | Specifies the name for the namesapced Role resource           | `secrets-unsealer` |
 | `rbac.labels`                | Extra labels to be added to RBAC resources                    | `{}`               |
 | `rbac.pspEnabled`            | PodSecurityPolicy                                             | `false`            |
 
@@ -237,6 +239,10 @@ Alternatively, you can override `fullnameOverride` on the helm chart install.
 ## Configuration and installation details
 
 - In the case that **serviceAccount.create** is `false` and **rbac.create** is `true` it is expected for a ServiceAccount with the name **serviceAccount.name** to exist _in the same namespace as this chart_ before the installation.
+- If **rbac.create** is `true, by default *clusterRoles* are created. To switch to namespaced *Roles*:
+  1. set the required namespaces in **additionalNamespaces**
+  2. set **rbac.clusterRole** to `false`
+  3. set **rbac.namespacedRoles** to `true`
 - If **serviceAccount.create** is `true` there cannot be an existing service account with the name **serviceAccount.name**.
 - If a secret with name **secretName** does not exist _in the same namespace as this chart_, then on install one will be created. If a secret already exists with this name the keys inside will be used.
 - OpenShift: unset the runAsUser and fsGroup like this when installing in a custom namespace:

--- a/helm/sealed-secrets/templates/cluster-role-binding.yaml
+++ b/helm/sealed-secrets/templates/cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.rbac.create }}
+{{ if and .Values.rbac.create (not .Values.rbac.namespacedRoles)}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/helm/sealed-secrets/templates/cluster-role.yaml
+++ b/helm/sealed-secrets/templates/cluster-role.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.rbac.create .Values.rbac.clusterRole }}
+{{ if and (and .Values.rbac.create .Values.rbac.clusterRole) (not .Values.rbac.namespacedRoles) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/helm/sealed-secrets/templates/role-binding.yaml
+++ b/helm/sealed-secrets/templates/role-binding.yaml
@@ -36,3 +36,27 @@ subjects:
   kind: Group
   name: system:authenticated
 {{ end }}
+---
+{{ if and (and .Values.rbac.create .Values.rbac.namespacedRoles) (not $.Values.rbac.clusterRole) }}
+  {{- range $additionalNamespace := $.Values.additionalNamespaces }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "sealed-secrets.fullname" $ }}
+  namespace: {{ $additionalNamespace }}
+  labels: {{- include "sealed-secrets.labels" $ | nindent 4 }}
+    {{- if $.Values.rbac.labels }}
+    {{- include "sealed-secrets.render" ( dict "value" $.Values.rbac.labels "context" $) | nindent 4 }}
+    {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $.Values.rbac.namespacedRolesName }}
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ include "sealed-secrets.serviceAccountName" $ }}
+    namespace: {{ include "sealed-secrets.namespace" $ }}
+---
+  {{ end }}
+{{ end }}

--- a/helm/sealed-secrets/templates/role.yaml
+++ b/helm/sealed-secrets/templates/role.yaml
@@ -55,3 +55,59 @@ rules:
       - create
       - get
 {{ end }}
+---
+{{ if and (and .Values.rbac.create .Values.rbac.namespacedRoles) (not $.Values.rbac.clusterRole) }}
+  {{- range $additionalNamespace := $.Values.additionalNamespaces }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $.Values.rbac.namespacedRolesName }}
+  namespace: {{ $additionalNamespace }}
+  labels: {{- include "sealed-secrets.labels" $ | nindent 4 }}
+    {{- if $.Values.rbac.labels }}
+    {{- include "sealed-secrets.render" ( dict "value" $.Values.rbac.labels "context" $) | nindent 4 }}
+    {{- end }}
+rules:
+  - apiGroups:
+      - bitnami.com
+    resources:
+      - sealedsecrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - bitnami.com
+    resources:
+      - sealedsecrets/status
+    verbs:
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    resourceNames:
+      {{- include "sealed-secrets.render" (dict "value" $.Values.additionalNamespaces "context" $) | nindent 6 }}
+    verbs:
+      - get
+---
+  {{- end }}
+{{ end }}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -356,6 +356,12 @@ rbac:
   ## @param rbac.clusterRoleName Specifies the name for the Cluster Role resource
   ##
   clusterRoleName: "secrets-unsealer"
+  ## @param rbac.namespacedRoles Specifies whether the namespaced Roles should be created (in each of the specified additionalNamespaces)
+  ##
+  namespacedRoles: false
+  ## @param rbac.namespacedRolesName Specifies the name for the namesapced Role resource
+  ##
+  namespacedRolesName: "secrets-unsealer"
   ## @param rbac.labels Extra labels to be added to RBAC resources
   ##
   labels: {}


### PR DESCRIPTION
Signed-off-by: Karel Vanden Houte <karel.vandenhoute@gmail.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
This PR solves https://github.com/bitnami-labs/sealed-secrets/issues/1142
Add support for using Roles instead of ClusterRoles, based on additionalNamespaces

**Benefits**
Cluster wide roles are problematic, as not all environments allow end users to rely on them.

For instance, multi-tenant environments do not allow for Cluster Roles or impose important restrictions to include custom permissions as one off special requests.

This change allows to *not* use ClusterRoles, but Roles for each of the additionalNamespaces instead
**Possible drawbacks**
None, default values still have the same behavior as before.

**Applicable issues**
#1142
- fixes #

**Additional information**

