### PR TITLE
Add option for custom annotations and labels on sealing keypairs

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -42,6 +42,8 @@ func bindControllerFlags(f *controller.Flags, fs *flag.FlagSet) {
 	fs.StringVar(&f.LabelSelector, "label-selector", "", "Label selector which can be used to filter sealed secrets.")
 	fs.IntVar(&f.RateLimitPerSecond, "rate-limit", 2, "Number of allowed sustained request per second for verify endpoint")
 	fs.IntVar(&f.RateLimitBurst, "rate-limit-burst", 2, "Number of requests allowed to exceed the rate limit per second for verify endpoint")
+	fs.StringVar(&f.PrivateKeyAnnotations, "privatekey-annotations", "", "Comma-separated list of additional annotations to be put on renewed sealing keys.")
+	fs.StringVar(&f.PrivateKeyLabels, "privatekey-labels", "", "Comma-separated list of additional labels to be put on renewed sealing keys.")
 
 	fs.BoolVar(&f.OldGCBehavior, "old-gc-behavior", false, "Revert to old GC behavior where the controller deletes secrets instead of delegating that to k8s itself.")
 

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -96,7 +96,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `rateLimit`                                       | Number of allowed sustained request per second for verify endpoint                     | `""`                                |
 | `rateLimitBurst`                                  | Number of requests allowed to exceed the rate limit per second for verify endpoint     | `""`                                |
 | `additionalNamespaces`                            | List of namespaces used to manage the Sealed Secrets                                   | `[]`      
-| `privateKeyAnnotations`                            | Map of annotations to be set on the sealing keypairs                                   | `{}`      
+| `privateKeyAnnotations`                           | Map of annotations to be set on the sealing keypairs                                   | `{}`                                |
 | `privateKeyLabels`                                | Map of labels to be set on the sealing keypairs                                   | `{}`                                |
 | `logInfoStdout`                                   | Specifies whether the Sealed Secrets controller will log info to stdout                | `false`                             |
 | `command`                                         | Override default container command                                                     | `[]`                                |

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -95,7 +95,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `keyrenewperiod`                                  | Specifies key renewal period. Default 30 days                                          | `""`                                |
 | `rateLimit`                                       | Number of allowed sustained request per second for verify endpoint                     | `""`                                |
 | `rateLimitBurst`                                  | Number of requests allowed to exceed the rate limit per second for verify endpoint     | `""`                                |
-| `additionalNamespaces`                            | List of namespaces used to manage the Sealed Secrets                                   | `[]`                                |
+| `additionalNamespaces`                            | List of namespaces used to manage the Sealed Secrets                                   | `[]`      
+| `privateKeyAnnotations`                            | Map of annotations to be set on the sealing keypairs                                   | `{}`      
+| `privateKeyLabels`                            | Map of labels to be set on the sealing keypairs                                   | `{}`                                |
 | `logInfoStdout`                                   | Specifies whether the Sealed Secrets controller will log info to stdout                | `false`                             |
 | `command`                                         | Override default container command                                                     | `[]`                                |
 | `args`                                            | Override default container args                                                        | `[]`                                |

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -97,7 +97,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `rateLimitBurst`                                  | Number of requests allowed to exceed the rate limit per second for verify endpoint     | `""`                                |
 | `additionalNamespaces`                            | List of namespaces used to manage the Sealed Secrets                                   | `[]`      
 | `privateKeyAnnotations`                            | Map of annotations to be set on the sealing keypairs                                   | `{}`      
-| `privateKeyLabels`                            | Map of labels to be set on the sealing keypairs                                   | `{}`                                |
+| `privateKeyLabels`                                | Map of labels to be set on the sealing keypairs                                   | `{}`                                |
 | `logInfoStdout`                                   | Specifies whether the Sealed Secrets controller will log info to stdout                | `false`                             |
 | `command`                                         | Override default container command                                                     | `[]`                                |
 | `args`                                            | Override default container args                                                        | `[]`                                |

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -89,6 +89,28 @@ spec:
             - --additional-namespaces
             - {{ join "," .Values.additionalNamespaces | quote }}
             {{- end }}
+            {{- if $.Values.privateKeyAnnotations }}
+            {{- $privatekeyAnnotations := ""}}
+            {{- range $k, $v := $.Values.privateKeyAnnotations }}
+              {{- if not (and $v (kindIs "string" $v)) }}
+                {{ fail "Annotation values have to be strings"}}
+              {{- end }}
+              {{- $privatekeyAnnotations = printf "%s=%s,%s" $k $v $privatekeyAnnotations}}
+            {{- end }}
+            - --privatekey-annotations
+            - {{ trimSuffix "," $privatekeyAnnotations | quote }}
+            {{- end }}            
+            {{- if $.Values.privateKeyLabels }}
+            {{- $privateKeyLabels := ""}}
+            {{- range $k, $v := $.Values.privateKeyLabels }}
+              {{- if not (and $v (kindIs "string" $v)) }}
+                {{ fail "Label values have to be strings"}}
+              {{- end }}
+              {{- $privateKeyLabels = printf "%s=%s,%s" $k $v $privateKeyLabels}}
+            {{- end }}
+            - --privatekey-labels
+            - {{ trimSuffix "," $privateKeyLabels | quote }}
+            {{- end }}
             {{- if .Values.logInfoStdout }}
             - --log-info-stdout
             {{- end }}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -76,6 +76,12 @@ rateLimitBurst: ""
 ## @param additionalNamespaces List of namespaces used to manage the Sealed Secrets
 ##
 additionalNamespaces: []
+## @param privateKeyAnnotations Map of annotations to be set on the sealing keypairs
+## 
+privateKeyAnnotations: {}
+## @param privateKeyLabels Map of labels to be set on the sealing keypairs
+## 
+privateKeyLabels: {}
 ## @param logInfoStdout Specifies whether the Sealed Secrets controller will log info to stdout
 ##
 logInfoStdout: false

--- a/pkg/controller/keyregistry.go
+++ b/pkg/controller/keyregistry.go
@@ -47,13 +47,13 @@ func NewKeyRegistry(client kubernetes.Interface, namespace, keyPrefix, keyLabel 
 	}
 }
 
-func (kr *KeyRegistry) generateKey(ctx context.Context, validFor time.Duration, cn string) (string, error) {
+func (kr *KeyRegistry) generateKey(ctx context.Context, validFor time.Duration, cn string, privateKeyAnnotations string, privateKeyLabels string) (string, error) {
 	key, cert, err := generatePrivateKeyAndCert(kr.keysize, validFor, cn)
 	if err != nil {
 		return "", err
 	}
 	certs := []*x509.Certificate{cert}
-	generatedName, err := writeKey(ctx, kr.client, key, certs, kr.namespace, kr.keyLabel, kr.keyPrefix)
+	generatedName, err := writeKey(ctx, kr.client, key, certs, kr.namespace, kr.keyLabel, kr.keyPrefix, privateKeyAnnotations, privateKeyLabels)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/controller/main_test.go
+++ b/pkg/controller/main_test.go
@@ -57,7 +57,7 @@ func TestInitKeyRegistry(t *testing.T) {
 	// Add a key to the controller for second test
 	validFor := time.Hour
 	cn := "my-cn"
-	_, err = registry.generateKey(ctx, validFor, cn)
+	_, err = registry.generateKey(ctx, validFor, cn, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +91,7 @@ func TestInitKeyRotation(t *testing.T) {
 
 	validFor := time.Hour
 	cn := "my-cn"
-	keyGenTrigger, err := initKeyRenewal(ctx, registry, 0, validFor, time.Time{}, cn)
+	keyGenTrigger, err := initKeyRenewal(ctx, registry, 0, validFor, time.Time{}, cn, "", "")
 	if err != nil {
 		t.Fatalf("initKeyRenewal() returned err: %v", err)
 	}
@@ -132,7 +132,7 @@ func TestInitKeyRotationTick(t *testing.T) {
 
 	validFor := time.Hour
 	cn := "my-cn"
-	_, err = initKeyRenewal(ctx, registry, 100*time.Millisecond, validFor, time.Time{}, cn)
+	_, err = initKeyRenewal(ctx, registry, 100*time.Millisecond, validFor, time.Time{}, cn, "", "")
 	if err != nil {
 		t.Fatalf("initKeyRenewal() returned err: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestReuseKey(t *testing.T) {
 	client := fake.NewSimpleClientset()
 	client.PrependReactor("create", "secrets", generateNameReactor)
 
-	_, err = writeKey(ctx, client, key, []*x509.Certificate{cert}, "namespace", SealedSecretsKeyLabel, "prefix")
+	_, err = writeKey(ctx, client, key, []*x509.Certificate{cert}, "namespace", SealedSecretsKeyLabel, "prefix", "", "")
 	if err != nil {
 		t.Errorf("writeKey() failed with: %v", err)
 	}
@@ -187,7 +187,7 @@ func TestReuseKey(t *testing.T) {
 
 	validFor := time.Hour
 	cn := "my-cn"
-	_, err = initKeyRenewal(ctx, registry, 0, validFor, time.Time{}, cn)
+	_, err = initKeyRenewal(ctx, registry, 0, validFor, time.Time{}, cn, "", "")
 	if err != nil {
 		t.Fatalf("initKeyRenewal() returned err: %v", err)
 	}
@@ -222,7 +222,7 @@ func TestRenewStaleKey(t *testing.T) {
 	client := fake.NewSimpleClientset()
 	client.PrependReactor("create", "secrets", generateNameReactor)
 
-	_, err = writeKey(ctx, client, key, []*x509.Certificate{cert}, "namespace", SealedSecretsKeyLabel, "prefix")
+	_, err = writeKey(ctx, client, key, []*x509.Certificate{cert}, "namespace", SealedSecretsKeyLabel, "prefix", "", "")
 	if err != nil {
 		t.Errorf("writeKey() failed with: %v", err)
 	}
@@ -234,7 +234,7 @@ func TestRenewStaleKey(t *testing.T) {
 
 	validFor := time.Hour
 	cn := "my-cn"
-	_, err = initKeyRenewal(ctx, registry, period, validFor, time.Time{}, cn)
+	_, err = initKeyRenewal(ctx, registry, period, validFor, time.Time{}, cn, "", "")
 	if err != nil {
 		t.Fatalf("initKeyRenewal() returned err: %v", err)
 	}
@@ -278,7 +278,7 @@ func TestKeyCutoff(t *testing.T) {
 	client := fake.NewSimpleClientset()
 	client.PrependReactor("create", "secrets", generateNameReactor)
 
-	_, err = writeKey(ctx, client, key, []*x509.Certificate{cert}, "namespace", SealedSecretsKeyLabel, "prefix",
+	_, err = writeKey(ctx, client, key, []*x509.Certificate{cert}, "namespace", SealedSecretsKeyLabel, "prefix", "", "",
 		writeKeyWithCreationTime(metav1.NewTime(time.Now().Add(-oldAge))))
 	if err != nil {
 		t.Errorf("writeKey() failed with: %v", err)
@@ -294,7 +294,7 @@ func TestKeyCutoff(t *testing.T) {
 	// by setting cutoff to "now" we effectively force the creation of a new key.
 	validFor := time.Hour
 	cn := "my-cn"
-	_, err = initKeyRenewal(ctx, registry, period, validFor, time.Now(), cn)
+	_, err = initKeyRenewal(ctx, registry, period, validFor, time.Now(), cn, "", "")
 	if err != nil {
 		t.Fatalf("initKeyRenewal() returned err: %v", err)
 	}
@@ -358,7 +358,7 @@ func TestLegacySecret(t *testing.T) {
 
 	validFor := time.Hour
 	cn := "my-cn"
-	_, err = initKeyRenewal(ctx, registry, 0, validFor, time.Time{}, cn)
+	_, err = initKeyRenewal(ctx, registry, 0, validFor, time.Time{}, cn, "", "")
 	if err != nil {
 		t.Fatalf("initKeyRenewal() returned err: %v", err)
 	}


### PR DESCRIPTION
**Description of the change**
Add possibility to add labels / annotations to the generated keypairs  to seal secrets

**Benefits**
The usual benefit of labels and annotations

**Possible drawbacks**
None

**Applicable issues**
#949 

**Additional information**
I don't know whether  *privatekey-labels* and *privatekey-annotations* are a good naming choice, I just used the ones from the issue
