### PR TITLE
Draft: Update minikube K8S versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s: ["1.22.15","1.23.14","1.24.8","1.25.4"]
+        k8s: ["1.24.15","1.25.11","1.26.6","1.27.3"]
     env:
       MINIKUBE_WANTUPDATENOTIFICATION: "false"
       MINIKUBE_WANTREPORTERRORPROMPT: "false"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,9 +271,9 @@ jobs:
         kubernetes-version: ${{ matrix.k8s }}
 
     - name: Install Helm
-      uses: azure/setup-helm@v3.4
+      uses: azure/setup-helm@v3.5
       with:
-        version: v3.4.2
+        version: v3.12.0
 
     # need to delete old state of the cluster, see:
     # https://github.com/kubernetes/minikube/issues/8765

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s: ["1.22.15","1.23.14","1.24.8","1.25.4"]
+        k8s: ["1.24.15","1.25.11","1.26.6","1.27.3"]
     env:
       MINIKUBE_WANTUPDATENOTIFICATION: "false"
       MINIKUBE_WANTREPORTERRORPROMPT: "false"
@@ -197,9 +197,9 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3.1.0
 
-    - uses: medyagh/setup-minikube@v0.0.8
+    - uses: medyagh/setup-minikube@v0.0.13
       with:
-        minikube-version: 1.28.0
+        minikube-version: 1.30.1
         kubernetes-version: ${{ matrix.k8s }}
 
     # need to delete old state of the cluster, see:
@@ -265,9 +265,9 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3.1.0
 
-    - uses: medyagh/setup-minikube@v0.0.8
+    - uses: medyagh/setup-minikube@v0.0.13
       with:
-        minikube-version: 1.28.0
+        minikube-version: 1.30.1
         kubernetes-version: ${{ matrix.k8s }}
 
     - name: Install Helm


### PR DESCRIPTION
**Description of the change**

Update the minikube k8s versions used during the CI job. This will validate the [currently supported](https://kubernetes.io/releases/) K8S versions. 
