### PR TITLE
Add option to patch secrets instead of clobbering them

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,8 @@ If you want the Sealed Secrets controller to manage an existing `Secret`, you ca
 
 ### Patching existing secrets
 
+> New in v0.23.0
+
 There are some use cases in which you don't want to replace the whole `Secret` but just add or modify some keys from the existing `Secret`. For this, you can annotate your `Secret` with `sealedsecrets.bitnami.com/patch: "true"`. Using this annotation will make sure that secret keys, labels and annotatations in the `Secret` that are not present in the `SealedSecret` won't be deleted, and those present in the `SealedSecret` will be added to the `Secret` (secret keys, labels and annotations that exist both in the `Secret` and the `SealedSecret` will be modified by the `SealedSecret`).
 
 This annotation does not make the `SealedSecret` take ownership of the `Secret`. You can add both the `patch` and `managed` annotations to obtain the patching behaviour while also taking ownership of the `Secret`.

--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ If you want the Sealed Secrets controller to manage an existing `Secret`, you ca
 
 > New in v0.23.0
 
-There are some use cases in which you don't want to replace the whole `Secret` but just add or modify some keys from the existing `Secret`. For this, you can annotate your `Secret` with `sealedsecrets.bitnami.com/patch: "true"`. Using this annotation will make sure that secret keys, labels and annotatations in the `Secret` that are not present in the `SealedSecret` won't be deleted, and those present in the `SealedSecret` will be added to the `Secret` (secret keys, labels and annotations that exist both in the `Secret` and the `SealedSecret` will be modified by the `SealedSecret`).
+There are some use cases in which you don't want to replace the whole `Secret` but just add or modify some keys from the existing `Secret`. For this, you can annotate your `Secret` with `sealedsecrets.bitnami.com/patch: "true"`. Using this annotation will make sure that secret keys, labels and annotations in the `Secret` that are not present in the `SealedSecret` won't be deleted, and those present in the `SealedSecret` will be added to the `Secret` (secret keys, labels and annotations that exist both in the `Secret` and the `SealedSecret` will be modified by the `SealedSecret`).
 
 This annotation does not make the `SealedSecret` take ownership of the `Secret`. You can add both the `patch` and `managed` annotations to obtain the patching behaviour while also taking ownership of the `Secret`.
 

--- a/README.md
+++ b/README.md
@@ -449,11 +449,13 @@ only change from existing Kubernetes is that the *contents* of the
 
 ### Managing existing secrets
 
-If you want `SealedSecret` controller to take management of an existing `Secret` (i.e. overwrite it when unsealing a `SealedSecret` with the same name and namespace), then you have to annotate that `Secret` with the annotation `sealedsecrets.bitnami.com/managed: "true"` ahead of following the [Usage](#usage) steps.
+If you want the Sealed Secrets controller to manage an existing `Secret`, you can annotate your `Secret` with the `sealedsecrets.bitnami.com/managed: "true"` annotation. The existing `Secret` will be overwritten when unsealing a `SealedSecret` with the same name and namespace, and the `SealedSecret` will take ownership of the `Secret` (so that when the `SealedSecret` is deleted the `Secret` will also be deleted).
 
-#### Patching existing secrets
+### Patching existing secrets
 
-The default behaviour of Sealed Secrets is to takeover the existing `Secret`, replacing all its data with the encrypted data in the `SealedSecret`. However, there are some use cases in which you don't want to replace the whole `Secret` but just add or modify some keys from the existing `Secret`. For this, you can annotate your `Secret` with the annotation `sealedsecrets.bitnami.com/patch: "true"` (alongisde the `managed` annotation from the section above). With this annotation, keys in the `Secret` that are not present in the `SealedSecret` won't be deleted.
+There are some use cases in which you don't want to replace the whole `Secret` but just add or modify some keys from the existing `Secret`. For this, you can annotate your `Secret` with `sealedsecrets.bitnami.com/patch: "true"`. Using this annotation will make sure that secret keys, labels and annotatations in the `Secret` that are not present in the `SealedSecret` won't be deleted, and those present in the `SealedSecret` will be added to the `Secret` (secret keys, labels and annotations that exist both in the `Secret` and the `SealedSecret` will be modified by the `SealedSecret`).
+
+This annotation does not make the `SealedSecret` take ownership of the `Secret`. You can add both the `patch` and `managed` annotations to obtain the patching behaviour while also taking ownership of the `Secret`.
 
 ### Seal secret which can skip set owner references
 

--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ If you want the Sealed Secrets controller to manage an existing `Secret`, you ca
 
 There are some use cases in which you don't want to replace the whole `Secret` but just add or modify some keys from the existing `Secret`. For this, you can annotate your `Secret` with `sealedsecrets.bitnami.com/patch: "true"`. Using this annotation will make sure that secret keys, labels and annotations in the `Secret` that are not present in the `SealedSecret` won't be deleted, and those present in the `SealedSecret` will be added to the `Secret` (secret keys, labels and annotations that exist both in the `Secret` and the `SealedSecret` will be modified by the `SealedSecret`).
 
-This annotation does not make the `SealedSecret` take ownership of the `Secret`. You can add both the `patch` and `managed` annotations to obtain the patching behaviour while also taking ownership of the `Secret`.
+This annotation does not make the `SealedSecret` take ownership of the `Secret`. You can add both the `patch` and `managed` annotations to obtain the patching behavior while also taking ownership of the `Secret`.
 
 ### Seal secret which can skip set owner references
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ original Secret from the SealedSecret.
 - [Upgrade](#upgrade)
 - [Usage](#usage)
   - [Managing existing secrets](#managing-existing-secrets)
+  - [Patching existing secrets](#patching-existing-secrets)
   - [Update existing secrets](#update-existing-secrets)
   - [Raw mode (experimental)](#raw-mode-experimental)
   - [Validate a Sealed Secret](#validate-a-sealed-secret)
@@ -448,8 +449,11 @@ only change from existing Kubernetes is that the *contents* of the
 
 ### Managing existing secrets
 
-If you want `SealedSecret` controller to take management of an existing `Secret` (i.e. overwrite it when unsealing a `SealedSecret` with the same name and namespace), then you have to annotate that `Secret` with the annotation `sealedsecrets.bitnami.com/managed: "true"` ahead applying the [Usage](#usage) steps.
+If you want `SealedSecret` controller to take management of an existing `Secret` (i.e. overwrite it when unsealing a `SealedSecret` with the same name and namespace), then you have to annotate that `Secret` with the annotation `sealedsecrets.bitnami.com/managed: "true"` ahead of following the [Usage](#usage) steps.
 
+#### Patching existing secrets
+
+The default behaviour of Sealed Secrets is to takeover the existing `Secret`, replacing all its data with the encrypted data in the `SealedSecret`. However, there are some use cases in which you don't want to replace the whole `Secret` but just add or modify some keys from the existing `Secret`. For this, you can annotate your `Secret` with the annotation `sealedsecrets.bitnami.com/patch: "true"` (alongisde the `managed` annotation from the section above). With this annotation, keys in the `Secret` that are not present in the `SealedSecret` won't be deleted.
 
 ### Seal secret which can skip set owner references
 

--- a/integration/controller_test.go
+++ b/integration/controller_test.go
@@ -289,7 +289,7 @@ var _ = Describe("create", func() {
 				s.Labels["anotherlabel"] = "anothervalue"
 				c.Secrets(ns).Create(ctx, s, metav1.CreateOptions{})
 			})
-			It("should take ownership of existing Secret removing removing existing secret keys, labels and annotations", func() {
+			It("should take ownership of the existing Secret overwriting the whole Secret", func() {
 				expectedData := map[string][]byte{
 					"foo": []byte("bar"),
 				}
@@ -334,7 +334,7 @@ var _ = Describe("create", func() {
 				c.Secrets(ns).Create(ctx, s, metav1.CreateOptions{})
 			})
 
-			It("should take ownership of existing Secret maintaining existing secret keys, labels and annotations", func() {
+			It("should take ownership of the existing Secret patching instead of overwriting the whole Secret", func() {
 				expectedData := map[string][]byte{
 					"foo":  []byte("bar"),
 					"foo2": []byte("bar2"),
@@ -347,7 +347,6 @@ var _ = Describe("create", func() {
 					"mylabel":      "myvalue",
 					"anotherlabel": "anothervalue",
 				}
-				c.Secrets(ns).Create(ctx, s, metav1.CreateOptions{})
 				Eventually(func() (*v1.EventList, error) {
 					return c.Events(ns).Search(scheme.Scheme, ss)
 				}, Timeout, PollingInterval).Should(
@@ -384,7 +383,7 @@ var _ = Describe("create", func() {
 				c.Secrets(ns).Create(ctx, s, metav1.CreateOptions{})
 			})
 
-			It("should not take ownership of existing Secret but add and replace secret keys, labels and annotations", func() {
+			It("should not take ownership of existing Secret while patching the Secret", func() {
 				expectedData := map[string][]byte{
 					"foo":  []byte("bar"),
 					"foo2": []byte("bar2"),
@@ -396,7 +395,6 @@ var _ = Describe("create", func() {
 					"mylabel":      "myvalue",
 					"anotherlabel": "anothervalue",
 				}
-				c.Secrets(ns).Create(ctx, s, metav1.CreateOptions{})
 				Eventually(func() (*v1.EventList, error) {
 					return c.Events(ns).Search(scheme.Scheme, ss)
 				}, Timeout, PollingInterval).Should(

--- a/integration/controller_test.go
+++ b/integration/controller_test.go
@@ -275,7 +275,10 @@ var _ = Describe("create", func() {
 	Describe("Secret already exists", func() {
 		Context("With managed annotation", func() {
 			BeforeEach(func() {
-				s.Data["foo2"] = []byte("bar2")
+				s.Data = map[string][]byte{
+					"foo": []byte("bar1"),
+					"foo2": []byte("bar2"),
+				}
 				s.Annotations = map[string]string{
 					ssv1alpha1.SealedSecretManagedAnnotation: "true",
 				}
@@ -314,7 +317,10 @@ var _ = Describe("create", func() {
 		})
 		Context("With managed and patch annotation", func() {
 			BeforeEach(func() {
-				s.Data["foo2"] = []byte("bar2")
+				s.Data = map[string][]byte{
+					"foo": []byte("bar1"),
+					"foo2": []byte("bar2"),
+				}
 				s.Annotations = map[string]string{
 					ssv1alpha1.SealedSecretManagedAnnotation: "true",
 					ssv1alpha1.SealedSecretPatchAnnotation:   "true",

--- a/pkg/apis/sealedsecrets/v1alpha1/types.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/types.go
@@ -25,8 +25,12 @@ const (
 	SealedSecretNamespaceWideAnnotation = annoNs + "namespace-wide"
 
 	// SealedSecretManagedAnnotation is the name for the annotation for
-	// flaging the existing secrets be managed by SealedSecret controller.
+	// flagging existing secrets to be managed by the Sealed Secrets controller.
 	SealedSecretManagedAnnotation = annoNs + "managed"
+
+	// SealedSecretPatchAnnotation is the name for the annotation for
+	// flagging existing secrets to be patched instead of overwritten by the Sealed Secrets controller.
+	SealedSecretPatchAnnotation = annoNs + "patch"
 
 	// SealedSecretSkipSetOwnerReferencesAnnotation is the name for the annotation for
 	// flagging the controller not to set owner reference to secret.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -349,11 +349,26 @@ func (c *Controller) unseal(ctx context.Context, key string) (unsealErr error) {
 	origSecret := secret
 	secret = secret.DeepCopy()
 
-	secret.Data = newSecret.Data
+	if isAnnotatedToBePatched(secret) {
+		for k, v := range newSecret.Data {
+			secret.Data[k] = v
+		}
+
+		for k, v := range newSecret.ObjectMeta.Annotations {
+			secret.ObjectMeta.Annotations[k] = v
+		}
+
+		for k, v := range newSecret.ObjectMeta.Labels {
+			secret.ObjectMeta.Labels[k] = v
+		}
+	} else {
+		secret.Data = newSecret.Data
+		secret.ObjectMeta.Annotations = newSecret.ObjectMeta.Annotations
+		secret.ObjectMeta.Labels = newSecret.ObjectMeta.Labels
+	}
+
 	secret.Type = newSecret.Type
-	secret.ObjectMeta.Annotations = newSecret.ObjectMeta.Annotations
 	secret.ObjectMeta.OwnerReferences = newSecret.ObjectMeta.OwnerReferences
-	secret.ObjectMeta.Labels = newSecret.ObjectMeta.Labels
 
 	if !apiequality.Semantic.DeepEqual(origSecret, secret) {
 		_, err = c.sclient.Secrets(ssecret.GetObjectMeta().GetNamespace()).Update(ctx, secret, metav1.UpdateOptions{})
@@ -435,9 +450,12 @@ func updateSealedSecretsStatusConditions(st *ssv1alpha1.SealedSecretStatus, unse
 	}
 }
 
-// checks if the annotation equals to "true", and it's case-sensitive
 func isAnnotatedToBeManaged(secret *corev1.Secret) bool {
 	return secret.Annotations[ssv1alpha1.SealedSecretManagedAnnotation] == "true"
+}
+
+func isAnnotatedToBePatched(secret *corev1.Secret) bool {
+	return secret.Annotations[ssv1alpha1.SealedSecretPatchAnnotation] == "true"
 }
 
 // AttemptUnseal tries to unseal a secret.


### PR DESCRIPTION
**Description of the change**
Add a new annotation `sealedsecrets.bitnami.com/patch: "true"` to secrets so that instead of replacing the whole secret with the unencrypted sealed secret, only the keys that are present in the sealed secret are added to the secret while the existing keys in the secret remain there.

In case of keys present in both secret and sealed secret, the second one will take precedence and the original value in the secret will be replaced with the one in the sealed secret. 

When annotated with this annotation, the `SealedSecret` won't take ownership of the `Secret`. When combined with the `sealedsecrets.bitnami.com/managed: "true"` annotation, the `SealedSecret` will take ownership of the `Secret` while the patching behavior is maintained.

**Benefits**
Sealed Secrets can control just some of the keys that are present in the Secret. For example, it can be used to manage the webhook secrets in [argocd-secret](https://github.com/argoproj/argo-cd/blob/master/docs/operator-manual/argocd-secret.yaml)

**Possible drawbacks**
 
**Applicable issues**
- #1205
