### PR TITLE
Add missing document seperator

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,6 +702,8 @@ If you do want to make a backup of the encryption private keys, it's easy to do 
 
 ```bash
 kubectl get secret -n kube-system -l sealedsecrets.bitnami.com/sealed-secrets-key -o yaml >main.key
+
+echo "---" >> main.key
 kubectl get secret -n kube-system sealed-secrets-key -o yaml >>main.key
 ```
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Fix documentation for users that  ever installed sealed-secrets older than version 0.9.x on their cluster.

**Benefits**

Documentation now lead to a working key restore.

**Possible drawbacks**

None.

**Applicable issues**

Might be related to #923 

**Additional information**

Currently the documentation simply redirects the second output of `kubectl get secrets` at the end of the first.

This leads to 'kinda' broken yaml, as there is no document seperator. The key is just added to the last key in the file.
As a result , the `sealed-secrets-key` won't be added to the server. So pretty old secrets can't get decrypted. 

Fixing this is easy, by just adding the 'thre-dot-seperator' to the document. Now the old key gets created nicely and everything is fine.


I am not sure why there is no seperator at first, or if kubectl got rid of them.