### PR TITLE
securityContext adjusted

### DIFF
--- a/controller-norbac.jsonnet
+++ b/controller-norbac.jsonnet
@@ -40,6 +40,11 @@ local namespace = 'kube-system';
         spec+: {
           securityContext+: {
             fsGroup: 65534,
+            runAsNonRoot: true,
+            runAsUser: 1001,
+            seccompProfile+: {
+              type: 'RuntimeDefault',
+            }
           },
           containers_+: {
             controller: kube.Container('sealed-secrets-controller') {
@@ -54,9 +59,11 @@ local namespace = 'kube-system';
                 http: { containerPort: 8080 },
               },
               securityContext+: {
+                allowPrivilegeEscalation: false,
+                capabilities+: {
+                  drop: [ 'ALL' ],
+                },
                 readOnlyRootFilesystem: true,
-                runAsNonRoot: true,
-                runAsUser: 1001,
               },
               volumeMounts_+: {
                 tmp: {


### PR DESCRIPTION
allow installation and execution in restricted namespaces

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

adjust securityContext on pod/container level so installation and execution is possible in restricted namespace


**Benefits**

make deployment full compatible with new Security Context

**Possible drawbacks**

local kustomize patches for securityContext can be removed / should be adjusted 

