### PR TITLE
Enable full linter support for golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,291 @@
+# Inspired by https://gist.github.com/maratori/47a4d00457a92aa426dbd48a18776322
+
+# output configuration options
+output:
+  # Format: colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
+  # Default: colored-line-number
+  format: checkstyle:report.xml,colored-line-number:stdout
+
+# Options for analysis running.
+run:
+  # Timeout for analysis, e.g. 30s, 5m.
+  # Default: 1m
+  timeout: 5m
+
+# This file contains only configs which differ from defaults.
+# All possible options can be found here https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
+linters-settings:
+  cyclop:
+    # The maximal code complexity to report.
+    # Default: 10
+    max-complexity: 30
+    # The maximal average package complexity.
+    # If it's higher than 0.0 (float) the check is enabled
+    # Default: 0.0
+    package-average: 10.0
+
+  errcheck:
+    # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
+    # Such cases aren't reported by default.
+    # Default: false
+    check-type-assertions: true
+
+    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`.
+    # Such cases aren't reported by default.
+    # Default: false
+    check-blank: true
+
+  exhaustive:
+    # Program elements to check for exhaustiveness.
+    # Default: [ switch ]
+    check:
+      - switch
+      - map
+
+  exhaustruct:
+    # List of regular expressions to exclude struct packages and names from check.
+    # Default: []
+    exclude:
+      # std libs
+      - "^net/http.Client$"
+      - "^net/http.Cookie$"
+      - "^net/http.Request$"
+      - "^net/http.Response$"
+      - "^net/http.Server$"
+      - "^net/http.Transport$"
+      - "^net/url.URL$"
+      - "^os/exec.Cmd$"
+      - "^reflect.StructField$"
+      # public libs (add more if needed)
+
+  funlen:
+    # Checks the number of lines in a function.
+    # If lower than 0, disable the check.
+    # Default: 60
+    lines: 100
+    # Checks the number of statements in a function.
+    # If lower than 0, disable the check.
+    # Default: 40
+    statements: 50
+
+  gocognit:
+    # Minimal code complexity to report.
+    # Default: 30 (but we recommend 10-20)
+    min-complexity: 20
+
+  goconst:
+    # Minimal length of string constant.
+    # Default: 3
+    min-len: 2
+    # Minimum occurrences of constant string count to trigger issue.
+    # Default: 3
+    min-occurrences: 2
+    # Search also for duplicated numbers.
+    # Default: false
+    numbers: true
+    # Minimum value, only works with goconst.numbers
+    # Default: 3
+    min: 2
+
+  gocritic:
+    # Settings passed to gocritic.
+    # The settings key is the name of a supported gocritic checker.
+    # The list of supported checkers can be find in https://go-critic.github.io/overview.
+    settings:
+      captLocal:
+        # Whether to restrict checker to params only.
+        # Default: true
+        paramsOnly: false
+      underef:
+        # Whether to skip (*x).method() calls where x is a pointer receiver.
+        # Default: true
+        skipRecvDeref: false
+
+  gomnd:
+    # List of function patterns to exclude from analysis.
+    # Values always ignored: `time.Date`,
+    # `strconv.FormatInt`, `strconv.FormatUint`, `strconv.FormatFloat`,
+    # `strconv.ParseInt`, `strconv.ParseUint`, `strconv.ParseFloat`.
+    # Default: []
+    ignored-functions:
+      - os.Chmod
+      - os.Mkdir
+      - os.MkdirAll
+      - os.OpenFile
+      - os.WriteFile
+      - math.*
+      - http.StatusText
+
+  govet:
+    # Enable all analyzers.
+    # Default: false
+    enable-all: true
+
+    # Disable analyzers by name.
+    # Run `go tool vet help` to see all analyzers.
+    # Default: []
+    disable:
+      - fieldalignment # too strict, it warns about struct fields that are not aligned by size
+
+    # Settings per analyzer.
+    settings:
+      shadow:
+        # Whether to be strict about shadowing; can be noisy.
+        # Default: false
+        strict: true
+
+  nakedret:
+    # Make an issue if func has more lines of code than this setting, and it has naked returns.
+    # Default: 30
+    max-func-lines: 0
+
+  nestif:
+    # Minimal complexity of if statements to report.
+    # Default: 5
+    min-complexity: 4
+
+  nolintlint:
+    # Exclude following linters from requiring an explanation.
+    # Default: []
+    allow-no-explanation: [funlen, gocognit, lll]
+    # Enable to require an explanation of nonzero length after each nolint directive.
+    # Default: false
+    require-explanation: true
+    # Enable to require nolint directives to mention the specific linter being suppressed.
+    # Default: false
+    require-specific: true
+
+  lll:
+    # Max line length, lines longer will be reported.
+    # '\t' is counted as 1 character by default, and can be changed with the tab-width option.
+    # Default: 120.
+    line-length: 240
+
+  rowserrcheck:
+    # database/sql is always checked
+    # Default: []
+    packages:
+      - github.com/jmoiron/sqlx
+
+  tenv:
+    # The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.
+    # Otherwise, only methods that take `*testing.T`, `*testing.B`, and `testing.TB` as arguments are checked.
+    # Default: false
+    all: true
+
+  varnamelen:
+    # The minimum length of a variable's name that is considered "long".
+    # Variable names that are at least this long will be ignored.
+    # Default: 3
+    min-name-length: 2
+    # Check method receivers.
+    # Default: false
+    # Ignore "ok" variables that hold the bool return value of a type assertion.
+    # Default: false
+    ignore-type-assert-ok: true
+    # Ignore "ok" variables that hold the bool return value of a map index.
+    # Default: false
+    ignore-map-index-ok: true
+    # Ignore "ok" variables that hold the bool return value of a channel receive.
+    # Default: false
+    ignore-chan-recv-ok: true
+
+linters:
+  disable-all: true
+  enable:
+    - errcheck # checking for unchecked errors, these unchecked errors can be critical bugs in some cases
+    - gosimple # specializes in simplifying a code
+    - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    - ineffassign # detects when assignments to existing variables are not used
+    - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
+    - typecheck # like the front-end of a Go compiler, parses and type-checks Go code
+    - unused # checks for unused constants, variables, functions and types
+    - asasalint # checks for pass []any as any in variadic func(...any)
+    - asciicheck # checks that your code does not contain non-ASCII identifiers
+    - bidichk # checks for dangerous unicode character sequences
+    - bodyclose # checks whether HTTP response body is closed successfully
+    - cyclop # checks function and package cyclomatic complexity
+    - dupl # tool for code clone detection
+    - durationcheck # checks for two durations multiplied together
+    - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
+    - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
+    - execinquery # checks query string in Query function which reads your Go src files and warning it finds
+    - exhaustive # checks exhaustiveness of enum switch statements
+    - exportloopref # checks for pointers to enclosing loop variables
+    - forbidigo # forbids identifiers
+    - funlen # tool for detection of long functions
+    - gochecknoinits # checks that no init functions are present in Go code
+    - gocognit # computes and checks the cognitive complexity of functions
+    - goconst # finds repeated strings that could be replaced by a constant
+    - gocritic # provides diagnostics that check for bugs, performance and style issues
+    - gocyclo # computes and checks the cyclomatic complexity of functions
+    - godot # checks if comments end in a period
+    - goimports # in addition to fixing imports, goimports also formats your code in the same style as gofmt
+    - gomnd # detects magic numbers
+    - gomoddirectives # manages the use of 'replace', 'retract', and 'excludes' directives in go.mod
+    - gomodguard # allow and block lists linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations
+    - goprintffuncname # checks that printf-like functions are named with f at the end
+    - gosec # inspects source code for security problems
+    - lll # reports long lines
+    - loggercheck # checks key value pairs for common logger libraries (kitlog,klog,logr,zap)
+    - makezero # finds slice declarations with non-zero initial length
+    - nakedret # finds naked returns in functions greater than a specified function length
+    - nestif # reports deeply nested if statements
+    - nilerr # finds the code that returns nil even if it checks that the error is not nil
+    - nilnil # checks that there is no simultaneous return of nil error and an invalid value
+    - noctx # finds sending http request without context.Context
+    - nolintlint # reports ill-formed or insufficient nolint directives
+    - nonamedreturns # reports all named returns
+    - nosprintfhostport # checks for misuse of Sprintf to construct a host with port in a URL
+    - predeclared # finds code that shadows one of Go's predeclared identifiers
+    - promlinter # checks Prometheus metrics naming via promlint
+    - reassign # checks that package variables are not reassigned
+    - revive # fast, configurable, extensible, flexible, and beautiful linter for Go, drop-in replacement of golint
+    - rowserrcheck # checks whether Err of rows is checked successfully
+    - sqlclosecheck # checks that sql.Rows and sql.Stmt are closed
+    - stylecheck # is a replacement for golint
+    - tenv # detects using os.Setenv instead of t.Setenv since Go1.17
+    - testableexamples # checks if examples are testable (have an expected output)
+    - testpackage # makes you use a separate _test package
+    - tparallel # detects inappropriate usage of t.Parallel() method in your Go test codes
+    - unconvert # removes unnecessary type conversions
+    - unparam # reports unused function parameters
+    - usestdlibvars # detects the possibility to use variables/constants from the Go standard library
+    - wastedassign # finds wasted assignment statements
+    - whitespace # detects leading and trailing whitespace
+
+    ## you may want to enable
+    - decorder # checks declaration order and count of types, constants, variables and functions
+    - gci # controls golang package import order and makes it always deterministic
+    - goheader # checks is file header matches to pattern
+    - interfacebloat # checks the number of methods inside an interface
+    - prealloc # [premature optimization, but can be used in some cases] finds slice declarations that could potentially be preallocated
+    - varnamelen # [great idea, but too many false positives] checks that the length of a variable's name matches its scope
+    - wrapcheck # checks that errors returned from external packages are wrapped
+    - containedctx # detects struct contained context.Context field
+    - contextcheck # [too many false positives] checks the function whether use a non-inherited context
+    - dogsled # checks assignments with too many blank identifiers (e.g. x, _, _, _, := f())
+    - dupword # [useless without config] checks for duplicate words in the source code
+    - errchkjson # [don't see profit + I'm against of omitting errors like in the first example https://github.com/breml/errchkjson] checks types passed to the json encoding functions. Reports unsupported types and optionally reports occasions, where the check for the returned error can be omitted
+    - goerr113 # [too strict] checks the errors handling expressions
+    - grouper # analyzes expression groups
+    - importas # enforces consistent import aliases
+    - maintidx # measures the maintainability index of each function
+    - misspell # [useless] finds commonly misspelled English words in comments
+    - nlreturn # [too strict and mostly code is not more readable] checks for a new line before return and branch statements to increase code clarity
+    - paralleltest # [too many false positives] detects missing usage of t.Parallel() method in your Go test
+    - tagliatelle # checks the struct tags
+    - thelper # detects golang test helpers without t.Helper() call and checks the consistency of test helpers
+    - wsl # [too strict and mostly code is not more readable] whitespace linter forces you to use empty lines
+
+    ## disabled
+    # - exhaustruct # [highly recommend to enable] checks if all structure fields are initialized
+    # - godox # detects FIXME, TODO and other comment keywords
+    # - gochecknoglobals # checks that no global variables exist
+    # - ireturn # accept interfaces, return concrete types
+
+issues:
+  # Maximum count of issues with the same text.
+  # Set to 0 to disable.
+  # Default: 3
+  max-same-issues: 0

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -190,12 +190,16 @@ linters-settings:
     # Default: false
     ignore-chan-recv-ok: true
 
+  godot:
+    # Check periods at the end of sentences.
+    period: false
+
 linters:
   disable-all: true
   enable:
-    - errcheck # checking for unchecked errors, these unchecked errors can be critical bugs in some cases
+    #- errcheck # checking for unchecked errors, these unchecked errors can be critical bugs in some cases
     - gosimple # specializes in simplifying a code
-    - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    #- govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
     - ineffassign # detects when assignments to existing variables are not used
     - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
     - typecheck # like the front-end of a Go compiler, parses and type-checks Go code
@@ -204,79 +208,79 @@ linters:
     - asciicheck # checks that your code does not contain non-ASCII identifiers
     - bidichk # checks for dangerous unicode character sequences
     - bodyclose # checks whether HTTP response body is closed successfully
-    - cyclop # checks function and package cyclomatic complexity
+    #- cyclop # checks function and package cyclomatic complexity
     - dupl # tool for code clone detection
     - durationcheck # checks for two durations multiplied together
     - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
-    - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
+    #- errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
     - execinquery # checks query string in Query function which reads your Go src files and warning it finds
     - exhaustive # checks exhaustiveness of enum switch statements
     - exportloopref # checks for pointers to enclosing loop variables
-    - forbidigo # forbids identifiers
-    - funlen # tool for detection of long functions
-    - gochecknoinits # checks that no init functions are present in Go code
-    - gocognit # computes and checks the cognitive complexity of functions
-    - goconst # finds repeated strings that could be replaced by a constant
-    - gocritic # provides diagnostics that check for bugs, performance and style issues
-    - gocyclo # computes and checks the cyclomatic complexity of functions
+    #- forbidigo # forbids identifiers
+    #- funlen # tool for detection of long functions
+    #- gochecknoinits # checks that no init functions are present in Go code
+    #- gocognit # computes and checks the cognitive complexity of functions
+    #- goconst # finds repeated strings that could be replaced by a constant
+    #- gocritic # provides diagnostics that check for bugs, performance and style issues
+    #- gocyclo # computes and checks the cyclomatic complexity of functions
     - godot # checks if comments end in a period
     - goimports # in addition to fixing imports, goimports also formats your code in the same style as gofmt
-    - gomnd # detects magic numbers
+    #- gomnd # detects magic numbers
     - gomoddirectives # manages the use of 'replace', 'retract', and 'excludes' directives in go.mod
     - gomodguard # allow and block lists linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations
     - goprintffuncname # checks that printf-like functions are named with f at the end
-    - gosec # inspects source code for security problems
-    - lll # reports long lines
+    #- gosec # inspects source code for security problems
+    #- lll # reports long lines
     - loggercheck # checks key value pairs for common logger libraries (kitlog,klog,logr,zap)
-    - makezero # finds slice declarations with non-zero initial length
+    #- makezero # finds slice declarations with non-zero initial length
     - nakedret # finds naked returns in functions greater than a specified function length
-    - nestif # reports deeply nested if statements
-    - nilerr # finds the code that returns nil even if it checks that the error is not nil
+    #- nestif # reports deeply nested if statements
+    #- nilerr # finds the code that returns nil even if it checks that the error is not nil
     - nilnil # checks that there is no simultaneous return of nil error and an invalid value
-    - noctx # finds sending http request without context.Context
+    #- noctx # finds sending http request without context.Context
     - nolintlint # reports ill-formed or insufficient nolint directives
-    - nonamedreturns # reports all named returns
+    #- nonamedreturns # reports all named returns
     - nosprintfhostport # checks for misuse of Sprintf to construct a host with port in a URL
-    - predeclared # finds code that shadows one of Go's predeclared identifiers
+    #- predeclared # finds code that shadows one of Go's predeclared identifiers
     - promlinter # checks Prometheus metrics naming via promlint
     - reassign # checks that package variables are not reassigned
-    - revive # fast, configurable, extensible, flexible, and beautiful linter for Go, drop-in replacement of golint
+    #- revive # fast, configurable, extensible, flexible, and beautiful linter for Go, drop-in replacement of golint
     - rowserrcheck # checks whether Err of rows is checked successfully
     - sqlclosecheck # checks that sql.Rows and sql.Stmt are closed
-    - stylecheck # is a replacement for golint
+    #- stylecheck # is a replacement for golint
     - tenv # detects using os.Setenv instead of t.Setenv since Go1.17
     - testableexamples # checks if examples are testable (have an expected output)
-    - testpackage # makes you use a separate _test package
+    #- testpackage # makes you use a separate _test package
     - tparallel # detects inappropriate usage of t.Parallel() method in your Go test codes
     - unconvert # removes unnecessary type conversions
-    - unparam # reports unused function parameters
+    #- unparam # reports unused function parameters
     - usestdlibvars # detects the possibility to use variables/constants from the Go standard library
     - wastedassign # finds wasted assignment statements
     - whitespace # detects leading and trailing whitespace
 
     ## you may want to enable
     - decorder # checks declaration order and count of types, constants, variables and functions
-    - gci # controls golang package import order and makes it always deterministic
+    #- gci # controls golang package import order and makes it always deterministic
     - goheader # checks is file header matches to pattern
     - interfacebloat # checks the number of methods inside an interface
-    - prealloc # [premature optimization, but can be used in some cases] finds slice declarations that could potentially be preallocated
-    - varnamelen # [great idea, but too many false positives] checks that the length of a variable's name matches its scope
-    - wrapcheck # checks that errors returned from external packages are wrapped
-    - containedctx # detects struct contained context.Context field
+    #- prealloc # [premature optimization, but can be used in some cases] finds slice declarations that could potentially be preallocated
+    #- varnamelen # [great idea, but too many false positives] checks that the length of a variable's name matches its scope
+    #- wrapcheck # checks that errors returned from external packages are wrapped
+    #- containedctx # detects struct contained context.Context field
     - contextcheck # [too many false positives] checks the function whether use a non-inherited context
     - dogsled # checks assignments with too many blank identifiers (e.g. x, _, _, _, := f())
-    - dupword # [useless without config] checks for duplicate words in the source code
+    #- dupword # [useless without config] checks for duplicate words in the source code
     - errchkjson # [don't see profit + I'm against of omitting errors like in the first example https://github.com/breml/errchkjson] checks types passed to the json encoding functions. Reports unsupported types and optionally reports occasions, where the check for the returned error can be omitted
-    - goerr113 # [too strict] checks the errors handling expressions
+    #- goerr113 # [too strict] checks the errors handling expressions
     - grouper # analyzes expression groups
     - importas # enforces consistent import aliases
     - maintidx # measures the maintainability index of each function
     - misspell # [useless] finds commonly misspelled English words in comments
-    - nlreturn # [too strict and mostly code is not more readable] checks for a new line before return and branch statements to increase code clarity
-    - paralleltest # [too many false positives] detects missing usage of t.Parallel() method in your Go test
+    #- nlreturn # [too strict and mostly code is not more readable] checks for a new line before return and branch statements to increase code clarity
+    #- paralleltest # [too many false positives] detects missing usage of t.Parallel() method in your Go test
     - tagliatelle # checks the struct tags
-    - thelper # detects golang test helpers without t.Helper() call and checks the consistency of test helpers
-    - wsl # [too strict and mostly code is not more readable] whitespace linter forces you to use empty lines
+    #- thelper # detects golang test helpers without t.Helper() call and checks the consistency of test helpers
+    #- wsl # [too strict and mostly code is not more readable] whitespace linter forces you to use empty lines
 
     ## disabled
     # - exhaustruct # [highly recommend to enable] checks if all structure fields are initialized

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ controller-norbac.yaml: controller-norbac.jsonnet schema-v1alpha1.yaml kube-fixe
 controller-podmonitor.yaml: controller.jsonnet controller-norbac.jsonnet schema-v1alpha1.yaml kube-fixes.libsonnet
 
 test:
-	$(GOTESTSUM) $(GO_FLAGS) $(GO_PACKAGES)
+	$(GOTESTSUM) $(GO_FLAGS) --junitfile report.xml --format testname -- "-coverprofile=coverage.out" $(GO_PACKAGES)
 
 integrationtest: kubeseal controller
 	# Assumes a k8s cluster exists, with controller already installed

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GO = go
 GOTESTSUM = gotestsum
 GOFMT = gofmt
-GOLANGCILINT=golangci-lint
+GOLANGCILINT=golangci-lint -vv
 GOSEC=gosec
 
 export GO111MODULE = on

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -24,7 +24,7 @@ const (
 )
 
 var (
-	// VERSION set from Makefile
+	// VERSION set from Makefile.
 	VERSION = buildinfo.DefaultVersion
 )
 

--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -23,7 +23,7 @@ import (
 	"github.com/bitnami-labs/sealed-secrets/pkg/kubeseal"
 	"github.com/bitnami-labs/sealed-secrets/pkg/pflagenv"
 
-	// Register Auth providers
+	// Register Auth providers.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
@@ -32,7 +32,7 @@ const (
 )
 
 var (
-	// VERSION set from Makefile
+	// VERSION set from Makefile.
 	VERSION = buildinfo.DefaultVersion
 )
 

--- a/pkg/apis/sealedsecrets/v1alpha1/register.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/register.go
@@ -8,16 +8,16 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
-// GroupName is the group name used in this package
+// GroupName is the group name used in this package.
 const GroupName = "bitnami.com"
 
 var (
-	// SchemeGroupVersion is the group version used to register these objects
+	// SchemeGroupVersion is the group version used to register these objects.
 	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1alpha1"}
 
-	// SchemeBuilder adds this group to scheme
+	// SchemeBuilder adds this group to scheme.
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
-	// AddToScheme is a global function that registers this API group & version to a scheme
+	// AddToScheme is a global function that registers this API group & version to a scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
 
@@ -25,7 +25,7 @@ func init() {
 	utilruntime.Must(SchemeBuilder.AddToScheme(scheme.Scheme))
 }
 
-// Resource takes an unqualified resource and returns a Group qualified GroupResource
+// Resource takes an unqualified resource and returns a Group qualified GroupResource.
 func Resource(resource string) schema.GroupResource {
 	return SchemeGroupVersion.WithResource(resource).GroupResource()
 }

--- a/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
@@ -31,7 +31,7 @@ const (
 )
 
 var (
-	// TODO(mkm): remove after a release
+	// TODO(mkm): remove after a release.
 	AcceptDeprecatedV1Data = false
 )
 
@@ -41,7 +41,7 @@ type SealedSecretExpansion interface {
 }
 
 // SealingScope is an enum that declares the mobility of a sealed secret by defining
-// in which scopes
+// in which scopes.
 type SealingScope int
 
 func (s *SealingScope) String() string {
@@ -73,7 +73,7 @@ func (s *SealingScope) Set(v string) error {
 	return nil
 }
 
-// Type implements the pflag.Value interface
+// Type implements the pflag.Value interface.
 func (s *SealingScope) Type() string { return "string" }
 
 // EncryptionLabel returns the label meant to be used for encrypting a sealed secret according to scope.

--- a/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_test.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/bitnami-labs/sealed-secrets/pkg/crypto"
 
-	// Install standard API types
+	// Install standard API types.
 	_ "k8s.io/client-go/kubernetes"
 )
 
@@ -399,7 +399,6 @@ func TestTemplateWithoutEncryptedData(t *testing.T) {
 }
 
 func TestSkipSetOwnerReference(t *testing.T) {
-
 	testCases := []struct {
 		sealedSecret          SealedSecret
 		skipSetOwnerReference bool
@@ -449,7 +448,6 @@ func TestSkipSetOwnerReference(t *testing.T) {
 		if tc.sealedSecret.Spec.Template.Annotations[SealedSecretSkipSetOwnerReferencesAnnotation] == "true" &&
 			len(unsealed.ObjectMeta.OwnerReferences) > 0 {
 			t.Errorf("got: owner, want: no owner")
-
 		} else if (tc.sealedSecret.Spec.Template.Annotations[SealedSecretSkipSetOwnerReferencesAnnotation] != "true") &&
 			len(unsealed.ObjectMeta.OwnerReferences) == 0 {
 			t.Errorf("got: no owner, want:  owner")

--- a/pkg/apis/sealedsecrets/v1alpha1/types.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/types.go
@@ -8,12 +8,12 @@ import (
 )
 
 const (
-	// SealedSecretName is the name used in SealedSecret CRD
+	// SealedSecretName is the name used in SealedSecret CRD.
 	SealedSecretName = "sealed-secret." + GroupName
-	// SealedSecretPlural is the collection plural used with SealedSecret API
+	// SealedSecretPlural is the collection plural used with SealedSecret API.
 	SealedSecretPlural = "sealedsecrets"
 
-	// Annotation namespace prefix
+	// Annotation namespace prefix.
 	annoNs = "sealedsecrets." + GroupName + "/"
 
 	// SealedSecretClusterWideAnnotation is the name for the annotation for
@@ -34,7 +34,7 @@ const (
 )
 
 // SecretTemplateSpec describes the structure a Secret should have
-// when created from a template
+// when created from a template.
 type SecretTemplateSpec struct {
 	// Standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
@@ -47,13 +47,13 @@ type SecretTemplateSpec struct {
 	// +optional
 	Type apiv1.SecretType `json:"type,omitempty" protobuf:"bytes,3,opt,name=type,casttype=SecretType"`
 
-	// Keys that should be templated using decrypted data
+	// Keys that should be templated using decrypted data.
 	// +optional
 	// +nullable
 	Data map[string]string `json:"data,omitempty"`
 }
 
-// SealedSecretSpec is the specification of a SealedSecret
+// SealedSecretSpec is the specification of a SealedSecret.
 type SealedSecretSpec struct {
 	// Template defines the structure of the Secret that will be
 	// created from this sealed secret.
@@ -70,14 +70,14 @@ type SealedSecretEncryptedData map[string]string
 
 func (s *SealedSecretEncryptedData) UnmarshalJSON(data []byte) error {
 	tmp := map[string]string{}
-	// drop error - likelihood of an error occurring is quite high due to the disabled schema validation, these errors
-	// would cause the controller to stop processing any SealedSecret
+	// drop error - likelihood of an error occurring is quite high due to the disabled schema validation, these errors.
+	// would cause the controller to stop processing any SealedSecret.
 	_ = json.Unmarshal(data, &tmp)
 	*s = tmp
 	return nil
 }
 
-// SealedSecretConditionType describes the type of SealedSecret condition
+// SealedSecretConditionType describes the type of SealedSecret condition.
 type SealedSecretConditionType string
 
 const (
@@ -137,7 +137,7 @@ type SealedSecret struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// SealedSecretList represents a list of SealedSecrets
+// SealedSecretList represents a list of SealedSecrets.
 type SealedSecretList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`
@@ -145,7 +145,7 @@ type SealedSecretList struct {
 	Items []SealedSecret `json:"items"`
 }
 
-// ByCreationTimestamp is used to sort a list of secrets
+// ByCreationTimestamp is used to sort a list of secrets.
 type ByCreationTimestamp []apiv1.Secret
 
 func (s ByCreationTimestamp) Len() int {

--- a/pkg/buildinfo/version.go
+++ b/pkg/buildinfo/version.go
@@ -2,10 +2,10 @@ package buildinfo
 
 import "runtime/debug"
 
-// DefaultVersion is the default version string if it's unset
+// DefaultVersion is the default version string if it's unset.
 const DefaultVersion = "UNKNOWN"
 
-// FallbackVersion initializes the automatic version detection
+// FallbackVersion initializes the automatic version detection.
 func FallbackVersion(v *string, unchanged string) {
 	if *v != unchanged {
 		return

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -57,7 +57,7 @@ const (
 )
 
 var (
-	// ErrCast happens when a K8s any type cannot be casted to the expected type
+	// ErrCast happens when a K8s any type cannot be casted to the expected type.
 	ErrCast = errors.New("cast error")
 )
 
@@ -200,7 +200,7 @@ func watchSecrets(sinformer informers.SharedInformerFactory, ssclientset ssclien
 }
 
 // HasSynced returns true once this controller has completed an
-// initial resource listing
+// initial resource listing.
 func (c *Controller) HasSynced() bool {
 	var synced bool
 	if c.sInformer == nil {
@@ -435,7 +435,7 @@ func updateSealedSecretsStatusConditions(st *ssv1alpha1.SealedSecretStatus, unse
 	}
 }
 
-// checks if the annotation equals to "true", and it's case-sensitive
+// checks if the annotation equals to "true", and it's case-sensitive.
 func isAnnotatedToBeManaged(secret *corev1.Secret) bool {
 	return secret.Annotations[ssv1alpha1.SealedSecretManagedAnnotation] == "true"
 }

--- a/pkg/controller/main.go
+++ b/pkg/controller/main.go
@@ -29,11 +29,11 @@ import (
 )
 
 var (
-	// Selector used to find existing public/private key pairs on startup
+	// Selector used to find existing public/private key pairs on startup.
 	keySelector = fields.OneTermEqualSelector(SealedSecretsKeyLabel, "active")
 )
 
-// Flags to configure the controller
+// Flags to configure the controller.
 type Flags struct {
 	KeyPrefix             string
 	KeySize               int

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -10,7 +10,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-// Define Prometheus Exporter namespace (prefix) for all metric names
+// Define Prometheus Exporter namespace (prefix) for all metric names.
 const metricNamespace string = "sealed_secrets_controller"
 
 const (
@@ -25,7 +25,7 @@ var conditionStatusToGaugeValue = map[v1.ConditionStatus]float64{
 	v1.ConditionTrue:    1,
 }
 
-// Define Prometheus metrics to expose
+// Define Prometheus metrics to expose.
 var (
 	buildInfo prometheus.Gauge
 	// TODO: rename metric, change increment logic, or accept behaviour
@@ -116,7 +116,7 @@ func UnregisterCondition(ssecret *v1alpha1.SealedSecret) {
 	}
 }
 
-// Instrument HTTP handler
+// Instrument HTTP handler.
 func Instrument(path string, h http.Handler) http.Handler {
 	return promhttp.InstrumentHandlerDuration(httpRequestDurationSeconds.MustCurryWith(prometheus.Labels{"path": path}),
 		promhttp.InstrumentHandlerCounter(httpRequestsTotal.MustCurryWith(prometheus.Labels{"path": path}), h))

--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -17,7 +17,7 @@ const (
 	sessionKeyBytes = 32
 )
 
-// ErrTooShort indicates the provided data is too short to be valid
+// ErrTooShort indicates the provided data is too short to be valid.
 var ErrTooShort = errors.New("SealedSecret data is too short")
 
 // PublicKeyFingerprint returns a fingerprint for a public key.
@@ -83,7 +83,7 @@ func HybridDecrypt(rnd io.Reader, privKeys map[string]*rsa.PrivateKey, ciphertex
 	return nil, fmt.Errorf("no key could decrypt secret")
 }
 
-// singleDecrypt performs a regular AES-GCM + RSA-OAEP decryption
+// singleDecrypt performs a regular AES-GCM + RSA-OAEP decryption.
 func singleDecrypt(rnd io.Reader, privKey *rsa.PrivateKey, ciphertext, label []byte) ([]byte, error) {
 	if len(ciphertext) < 2 {
 		return nil, ErrTooShort

--- a/pkg/kubeseal/kubeseal.go
+++ b/pkg/kubeseal/kubeseal.go
@@ -111,7 +111,7 @@ func isFilename(name string) (bool, error) {
 	return u.Scheme == "", nil
 }
 
-// getServicePortName obtains the SealedSecrets service port name
+// getServicePortName obtains the SealedSecrets service port name.
 func getServicePortName(ctx context.Context, client corev1.CoreV1Interface, namespace, serviceName string) (string, error) {
 	service, err := client.Services(namespace).Get(ctx, serviceName, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/kubeseal/kubeseal_test.go
+++ b/pkg/kubeseal/kubeseal_test.go
@@ -471,7 +471,7 @@ func mkTestSealedSecret(t *testing.T, pubKey *rsa.PublicKey, key, value string, 
 	return outbuf.Bytes()
 }
 
-// TODO(mkm): rename newTestKeyPair to newTestKeyPairs
+// TODO(mkm): rename newTestKeyPair to newTestKeyPairs.
 func newTestKeyPair(t *testing.T) (*rsa.PublicKey, map[string]*rsa.PrivateKey) {
 	privKey, _, err := crypto.GeneratePrivateKeyAndCert(2048, time.Hour, "testcn")
 	if err != nil {

--- a/pkg/multidocyaml/multidocyaml.go
+++ b/pkg/multidocyaml/multidocyaml.go
@@ -14,7 +14,7 @@ func isMultiDocumentYAML(src []byte) bool {
 	return dec.Decode(&dummy) == nil
 }
 
-// EnsureNotMultiDoc returns an error if the yaml
+// EnsureNotMultiDoc returns an error if the yaml.
 func EnsureNotMultiDoc(src []byte) error {
 	if isMultiDocumentYAML(src) {
 		return fmt.Errorf("Multistream YAML not supported yet (see https://github.com/bitnami-labs/sealed-secrets/issues/114)")


### PR DESCRIPTION
**Description of the change**

Enable full linter support for golangci-lint
 Changes have been included to comply with two syntax formaters (whispace and dots at the end of the comments)