### PR TITLE
Introduce KUBESEAL_VERSION for Linux installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ nix-env -iA nixpkgs.kubeseal
 The `kubeseal` client can be installed on Linux, using the below commands:
 
 ```bash
-KUBESEAL_VERSION='0.23.0'
+KUBESEAL_VERSION='' # Set this to, for example, KUBESEAL_VERSION='0.23.0'
 wget "https://github.com/bitnami-labs/sealed-secrets/releases/download/v${KUBESEAL_VERSION:?}/kubeseal-${KUBESEAL_VERSION:?}-linux-amd64.tar.gz"
 tar -xvzf kubeseal-${KUBESEAL_VERSION:?}-linux-amd64.tar.gz kubeseal
 sudo install -m 755 kubeseal /usr/local/bin/kubeseal

--- a/README.md
+++ b/README.md
@@ -379,8 +379,9 @@ nix-env -iA nixpkgs.kubeseal
 The `kubeseal` client can be installed on Linux, using the below commands:
 
 ```bash
-wget https://github.com/bitnami-labs/sealed-secrets/releases/download/<release-tag>/kubeseal-<version>-linux-amd64.tar.gz
-tar -xvzf kubeseal-<version>-linux-amd64.tar.gz kubeseal
+KUBESEAL_VERSION='0.23.0'
+wget "https://github.com/bitnami-labs/sealed-secrets/releases/download/v${KUBESEAL_VERSION:?}/kubeseal-${KUBESEAL_VERSION:?}-linux-amd64.tar.gz"
+tar -xvzf kubeseal-${KUBESEAL_VERSION:?}-linux-amd64.tar.gz kubeseal
 sudo install -m 755 kubeseal /usr/local/bin/kubeseal
 ```
 


### PR DESCRIPTION
**Description of the change**

This change introduces a variable `KUBESEAL_VERSION` in the README's example of how to install the `kubeseal` tools on Linux. 

**Benefits**

This makes it quicker and easier to just copy-paste the commands in order to install a certain version.

**Additional information**

If you are CI ninjas it might be worth considering some sort of check to make sure that `KUBESEAL_VERSION` stays up to date with the latest stable release number.

> 💡 A good way to inspect this commit is:
> 
> ```shell
> git show --color-words='.'
> ```