### PR TITLE
fix(chart): create servicemonitor only if apiVersion is available

### DIFF
--- a/helm/sealed-secrets/templates/servicemonitor.yaml
+++ b/helm/sealed-secrets/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.metrics.serviceMonitor.enabled }}
+{{- if and .Values.metrics.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This will prevent the chart from failing to install if ServiceMonitor is enabled but the Prometheus Operator is not installed in the cluster. Tiny change adding a check for `monitoring.coreos.com/v1` API capability.

**Benefits**

<!-- What benefits will be realized by the code change? -->

Installation of Helm chart will silently ignore missing Prometheus Operator / ServiceMonitor CRD even if enabled in values file.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

None known.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) 
- fixes #
-->

None

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

None