### PR TITLE
feat: allow changing the default revisionHistoryLimit

### DIFF
--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -88,6 +88,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.tag`                                       | Sealed Secrets image tag (immutable tags are recommended)                              | `v0.23.0`                           |
 | `image.pullPolicy`                                | Sealed Secrets image pull policy                                                       | `IfNotPresent`                      |
 | `image.pullSecrets`                               | Sealed Secrets image pull secrets                                                      | `[]`                                |
+| `revisionHistoryLimit`                            | Number of old history to retain to allow rollback. Default 10                          | `""`                                |
 | `createController`                                | Specifies whether the Sealed Secrets controller should be created                      | `true`                              |
 | `secretName`                                      | The name of an existing TLS secret containing the key used to encrypt secrets          | `sealed-secrets-key`                |
 | `updateStatus`                                    | Specifies whether the Sealed Secrets controller should update the status subresource   | `true`                              |

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -10,6 +10,9 @@ metadata:
   {{- end }}
 spec:
   replicas: 1
+  {{- if .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels: {{- include "sealed-secrets.matchLabels" . | nindent 6 }}
   template:

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -12,9 +12,6 @@ fullnameOverride: ""
 ## @param namespace Namespace where to deploy the Sealed Secrets controller
 ##
 namespace: ""
-## @param revisionHistoryLimit Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
-## e.g:
-## revisionHistoryLimit: 1
 
 ## @param extraDeploy [array] Array of extra objects to deploy with the release
 ##
@@ -51,6 +48,9 @@ image:
   ##   - myRegistryKeySecretName
   ##
   pullSecrets: []
+## @param revisionHistoryLimit Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
+## e.g:
+revisionHistoryLimit: ""
 ## @param createController Specifies whether the Sealed Secrets controller should be created
 ##
 createController: true

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -12,6 +12,10 @@ fullnameOverride: ""
 ## @param namespace Namespace where to deploy the Sealed Secrets controller
 ##
 namespace: ""
+## @param revisionHistoryLimit Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
+## e.g:
+## revisionHistoryLimit: 1
+
 ## @param extraDeploy [array] Array of extra objects to deploy with the release
 ##
 extraDeploy: []


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

The deployment has been adapted to allow the user changing the default revisionHistoryLimit.

**Benefits**

You may want to clean up old replicasets so that these don't appear in metrics, OPA violations, ArgoCD UI and so on.
Therefore you want to overwrite the Kubernetes default revision history limit.


**Possible drawbacks**

<!-- Describe any known limitations with your change -->
N/A

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
N/A