### PR TITLE
Update Linux installation process on README to have a way to dynamically get kubeseal version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,24 @@ tar -xvzf kubeseal-${KUBESEAL_VERSION:?}-linux-amd64.tar.gz kubeseal
 sudo install -m 755 kubeseal /usr/local/bin/kubeseal
 ```
 
-where `release-tag` is the [version tag](https://github.com/bitnami-labs/sealed-secrets/tags) of the kubeseal release you want to use. For example: `v0.18.0`.
+If you have `curl` and `jq` installed on your machine, you can get the version dynamically this way. This can be useful for environments used in automation and such.
+
+```
+# Fetch the latest sealed-secrets version using GitHub API
+KUBESEAL_VERSION=$(curl -s https://api.github.com/repos/bitnami-labs/sealed-secrets/tags | jq -r '.[0].name' | cut -c 2-)
+
+# Check if the version was fetched successfully
+if [ -z "$KUBESEAL_VERSION" ]; then
+    echo "Failed to fetch the latest KUBESEAL_VERSION"
+    exit 1
+fi
+
+wget "https://github.com/bitnami-labs/sealed-secrets/releases/download/v${KUBESEAL_VERSION}/kubeseal-${KUBESEAL_VERSION}-linux-amd64.tar.gz"
+tar -xvzf kubeseal-${KUBESEAL_VERSION}-linux-amd64.tar.gz kubeseal
+sudo install -m 755 kubeseal /usr/local/bin/kubeseal
+```
+
+where `KUBESEAL_VERSION` is the [version tag](https://github.com/bitnami-labs/sealed-secrets/tags) of the kubeseal release you want to use. For example: `v0.18.0`.
 
 #### Installation from source
 


### PR DESCRIPTION

**Description of the change**

Updating the README.md to show how to get the version of kubeseal dynamically instead of having to hardcode it for the Linux install script

**Benefits**

Users don't have to go to the release page to find the latest version

Install script can be used in CI/CD environments or other environments where kubeseal may be dynamically installed and this will allow the version of the latest to be automatically installed

**Possible drawbacks**

Adds extra detail to the README. I've maintained the original way to do it in the event the user using this doesn't have `jq` and `curl` installed, which is required for this method and cannot/does not want to install it.

**Applicable issues**

N/A

**Additional information**
N/A