### PR TITLE
Fix issue where sealed secrets status is not updated if sealed secret…

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -423,7 +423,8 @@ func (c *Controller) updateSealedSecretStatus(ssecret *ssv1alpha1.SealedSecret, 
 	return nil
 }
 
-func updateSealedSecretsStatusConditions(st *ssv1alpha1.SealedSecretStatus, unsealError error) (updateRequired bool) {
+func updateSealedSecretsStatusConditions(st *ssv1alpha1.SealedSecretStatus, unsealError error) bool {
+	var updateRequired bool
 	cond := func() *ssv1alpha1.SealedSecretCondition {
 		for i := range st.Conditions {
 			if st.Conditions[i].Type == ssv1alpha1.SealedSecretSynced {
@@ -453,7 +454,7 @@ func updateSealedSecretsStatusConditions(st *ssv1alpha1.SealedSecretStatus, unse
 		updateRequired = true
 	}
 
-	return
+	return updateRequired
 }
 
 func isAnnotatedToBeManaged(secret *corev1.Secret) bool {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -414,13 +414,16 @@ func (c *Controller) updateSealedSecretStatus(ssecret *ssv1alpha1.SealedSecret, 
 	}
 
 	ssecret.Status.ObservedGeneration = ssecret.ObjectMeta.Generation
-	updateSealedSecretsStatusConditions(ssecret.Status, unsealError)
+	updatedRequired := updateSealedSecretsStatusConditions(ssecret.Status, unsealError)
+	if updatedRequired {
+		_, err := c.ssclient.SealedSecrets(ssecret.GetObjectMeta().GetNamespace()).UpdateStatus(context.Background(), ssecret, metav1.UpdateOptions{})
+		return err
+	}
 
-	_, err := c.ssclient.SealedSecrets(ssecret.GetObjectMeta().GetNamespace()).UpdateStatus(context.Background(), ssecret, metav1.UpdateOptions{})
-	return err
+	return nil
 }
 
-func updateSealedSecretsStatusConditions(st *ssv1alpha1.SealedSecretStatus, unsealError error) {
+func updateSealedSecretsStatusConditions(st *ssv1alpha1.SealedSecretStatus, unsealError error) (updateRequired bool) {
 	cond := func() *ssv1alpha1.SealedSecretCondition {
 		for i := range st.Conditions {
 			if st.Conditions[i].Type == ssv1alpha1.SealedSecretSynced {
@@ -441,11 +444,16 @@ func updateSealedSecretsStatusConditions(st *ssv1alpha1.SealedSecretStatus, unse
 		status = corev1.ConditionFalse
 		cond.Message = unsealError.Error()
 	}
-	cond.LastUpdateTime = metav1.Now()
+
+	// Status has changed, update the transition time and signal that an update is required
 	if cond.Status != status {
 		cond.LastTransitionTime = cond.LastUpdateTime
 		cond.Status = status
+		cond.LastUpdateTime = metav1.Now()
+		updateRequired = true
 	}
+
+	return
 }
 
 func isAnnotatedToBeManaged(secret *corev1.Secret) bool {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -413,12 +413,6 @@ func (c *Controller) updateSealedSecretStatus(ssecret *ssv1alpha1.SealedSecret, 
 		ssecret.Status = &ssv1alpha1.SealedSecretStatus{}
 	}
 
-	// No need to update the status if we already have observed it from the
-	// current generation of the resource.
-	if ssecret.Status.ObservedGeneration == ssecret.ObjectMeta.Generation {
-		return nil
-	}
-
 	ssecret.Status.ObservedGeneration = ssecret.ObjectMeta.Generation
 	updateSealedSecretsStatusConditions(ssecret.Status, unsealError)
 


### PR DESCRIPTION

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Removes a check used to prevent unnecessary updates of the sealed secrets status.

**Benefits**

The check is used to prevent unnecessary updates on the sealed secrets status. 

However, in some cases, the sealed secret might not be updated to successfully generate the secret.
For example, if a secret is managed by a different controller, the generation from a sealedSecret would fail; if the controller is removed later, the secret would be unsealed successfully.
In this case, the check prevents a successful update leading to issues when the secret is successfully unsealed (and the successful unseal is reported), but the secret status is not updated since the generation/observedGeneration steps were not updated.

This is also an issue when using management tools such as ArgoCD, since the status would always report an error, while the secret is successfully unsealed.

**Possible drawbacks**

May increase updates of sealed secrets status if not necessary.

**Applicable issues**

- fixes #853 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
