### PR TITLE
Delete repeating warning message

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -394,7 +394,6 @@ func convertSealedSecret(obj any) (*ssv1alpha1.SealedSecret, error) {
 	}
 	if sealedSecret.APIVersion == "" || sealedSecret.Kind == "" {
 		// https://github.com/operator-framework/operator-sdk/issues/727
-		log.Errorf("WARNING: Empty API version & kind, filling it...")
 		gv := schema.GroupVersion{Group: ssv1alpha1.GroupName, Version: "v1alpha1"}
 		gvk := gv.WithKind("SealedSecret")
 		sealedSecret.APIVersion = gvk.GroupVersion().String()


### PR DESCRIPTION
**Description of the change**

This issue is still present in the SDK and the object comes with these parameters empty. We are going to continue setting up these parameters when they are empty but we will remove this warning repeated a lot of times.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #1284
