### PR TITLE
feat: multidoc support for yaml and json

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,6 +716,10 @@ Developing guidelines can be found [in the Developer Guide](docs/developer/READM
 
 ## FAQ
 
+### Can I encrypt multiple secrets at once, in one YAML / JSON file?
+
+Yes, you can! Drop as many secrets as you like in one file. Make sure to separate them via `---` for YAML and as extra, single objects in JSON.
+
 ### Will you still be able to decrypt if you no longer have access to your cluster?
 
 No, the private keys are only stored in the Secret managed by the controller (unless you have some other backup of your k8s objects). There are no backdoors - without that private key used to encrypt a given SealedSecrets, you can't decrypt it. If you can't get to the Secrets with the encryption keys, and you also can't get to the decrypted versions of your Secrets live in the cluster, then you will need to regenerate new passwords for everything, seal them again with a new sealing key, etc.

--- a/pkg/kubeseal/kubeseal.go
+++ b/pkg/kubeseal/kubeseal.go
@@ -10,13 +10,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/util/yaml"
 	"net/http"
 	"net/url"
 	"os"
 	"reflect"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/yaml"
 
 	ssv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealedsecrets/v1alpha1"
 	"github.com/bitnami-labs/sealed-secrets/pkg/crypto"

--- a/pkg/kubeseal/kubeseal.go
+++ b/pkg/kubeseal/kubeseal.go
@@ -304,7 +304,10 @@ func ValidateSealedSecret(ctx context.Context, clientConfig ClientConfig, contro
 	}
 
 	for _, secret := range secrets {
-		content, _ := json.Marshal(secret)
+		content, err := json.Marshal(secret)
+		if err != nil {
+			return fmt.Errorf("error while marshalling sealed secret: %w", err)
+		}
 		req.Body(content)
 		res := req.Do(ctx)
 		if err := res.Error(); err != nil {

--- a/pkg/kubeseal/kubeseal.go
+++ b/pkg/kubeseal/kubeseal.go
@@ -192,6 +192,9 @@ func readMultiSecrets(r io.Reader) ([]*v1.Secret, error) {
 		secrets = append(secrets, &sec)
 	}
 
+	if len(secrets) == 0 {
+		return nil, fmt.Errorf("no secrets found")
+	}
 	return secrets, nil
 }
 

--- a/pkg/kubeseal/kubeseal_test.go
+++ b/pkg/kubeseal/kubeseal_test.go
@@ -603,7 +603,7 @@ func TestUnseal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	secret, err := readMultiSecrets(&buf)
+	secret, err := readSecrets(&buf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -664,7 +664,7 @@ func TestUnsealList(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	secret, err := readMultiSecrets(&buf)
+	secret, err := readSecrets(&buf)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kubeseal/kubeseal_test.go
+++ b/pkg/kubeseal/kubeseal_test.go
@@ -9,8 +9,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	yaml2 "k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/utils/strings/slices"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -20,6 +18,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/utils/strings/slices"
 
 	flag "github.com/spf13/pflag"
 
@@ -207,7 +208,6 @@ func TestSealWithMultiDocSecrets(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			s1 := mkTestSecret(t, "foo", "1", withSecretName("s1"), asYAML(tc.asYaml))
 			s2 := mkTestSecret(t, "bar", "2", withSecretName("s2"), asYAML(tc.asYaml))
 			multiDocYaml := fmt.Sprintf("%s%s%s", s1, tc.inputSeparator, s2)
@@ -230,7 +230,7 @@ func TestSealWithMultiDocSecrets(t *testing.T) {
 			outBytes := outbuf.Bytes()
 			t.Logf("output is %s", outBytes)
 
-			decoder := yaml2.NewYAMLOrJSONDecoder(bytes.NewReader(outBytes), 4096)
+			decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(outBytes), 4096)
 			var gotSecrets []*ssv1alpha1.SealedSecret
 			for {
 				s := ssv1alpha1.SealedSecret{}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add Support for Multidoc YAML and JSON, as stated in #114 

**Benefits**

Users can have and manage multiple secrets in one file and encrypt those secrets in one run

**Possible drawbacks**

* This change does not apply to `--merge-into`
  * To use this with mutlidoc, we would need to specify a target secret. On the other hand, users can easily put their to-be-merged secret in a separate file 

* `Kind: List` resources are not considered / supported

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #114 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
I want to get your opinion on this approach and see if I am on the right track here. 
