### PR TITLE
fix: explicit service account tokens

### DIFF
--- a/helm/sealed-secrets/templates/_helpers.tpl
+++ b/helm/sealed-secrets/templates/_helpers.tpl
@@ -48,6 +48,15 @@ Create the name of the service account to use
 {{- end -}}
 {{- end -}}
 
+
+{{/*
+Create the name of the service account token to use
+*/}}
+{{- define "sealed-secrets.serviceAccountTokenName" -}}
+    {{- $serviceAccountName := include "sealed-secrets.serviceAccountName" . -}}
+    {{- printf "%s-token" $serviceAccountName | default .Values.serviceAccount.tokenName -}}
+{{- end -}}
+
 {{/*
 Kubernetes standard labels
 */}}

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -50,7 +50,9 @@ spec:
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "sealed-secrets.serviceAccountName" . }}
+      {{ if .Values.serviceAccount.create }}
       automountServiceAccountToken: false
+      {{- end }}
       {{- if .Values.hostNetwork }}
       hostNetwork: true
       {{- end }}

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -50,6 +50,7 @@ spec:
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "sealed-secrets.serviceAccountName" . }}
+      automountServiceAccountToken: false
       {{- if .Values.hostNetwork }}
       hostNetwork: true
       {{- end }}
@@ -158,10 +159,15 @@ spec:
             {{- end }}
             - mountPath: /tmp
               name: tmp
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: service-account-token
       volumes: 
       {{- if .Values.additionalVolumes }}
         {{- toYaml .Values.additionalVolumes | nindent 8 }} 
       {{- end }}
         - name: tmp
           emptyDir: {}
+        - name: service-account-token
+          secret:
+            secretName: {{ include "sealed-secrets.serviceAccountTokenName" . }}
 {{- end }}

--- a/helm/sealed-secrets/templates/service-account.yaml
+++ b/helm/sealed-secrets/templates/service-account.yaml
@@ -17,4 +17,13 @@ metadata:
     {{- if .Values.serviceAccount.labels }}
     {{- include "sealed-secrets.render" ( dict "value" .Values.serviceAccount.labels "context" $) | nindent 4 }}
     {{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "sealed-secrets.serviceAccountTokenName" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "kubernetes.io/service-account.name": {{ include "sealed-secrets.serviceAccountName" . }}
+type: kubernetes.io/service-account-token
 {{ end }}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -81,10 +81,10 @@ rateLimitBurst: ""
 ##
 additionalNamespaces: []
 ## @param privateKeyAnnotations Map of annotations to be set on the sealing keypairs
-## 
+##
 privateKeyAnnotations: {}
 ## @param privateKeyLabels Map of labels to be set on the sealing keypairs
-## 
+##
 privateKeyLabels: {}
 ## @param logInfoStdout Specifies whether the Sealed Secrets controller will log info to stdout
 ##
@@ -369,6 +369,8 @@ serviceAccount:
   ## If not set and create is true, a name is generated using the sealed-secrets.fullname template
   ##
   name: ""
+  tokenName: ""
+
 ## RBAC configuration
 ##
 rbac:


### PR DESCRIPTION
### Issue:
While working on a Civo/K3s cluster, we encountered issues related to the sealed-secrets controller failing to initialize properly. Although we're not sure if this issue is cluster-specific, it aligns with changes made to the TokenRequest API in Kubernetes 1.24 concerning short-lived tokens.

### Solution:
The Helm chart has been updated to explicitly specify a service account token. This is done by manually creating a Secret containing the API access token for the service account and mounting it to the Pod via a projected volume.

### Why This Change Was Necessary:
The change aims to proactively handle Kubernetes 1.24's move to short-lived tokens, especially as it affects service accounts on Civo/K3s clusters. Explicitly specifying the service account token seems to solve the issue and may be beneficial for others facing similar problems.

### Disclaimer:
This issue was encountered on a Civo/K3s cluster. We are not entirely sure if the problem is unique to this specific setup, but the fix works in our case and hopefully can help others.

### Testing:
1. Deploy the updated Helm chart on a Civo/K3s Kubernetes 1.24+ cluster.
2. Verify that the sealed-secrets controller initializes without errors.
3. Examine logs to confirm that issues related to service account tokens are resolved.

### Failure Case:
The failure case generally manifests as [errors in logs](https://stackoverflow.com/questions/69038012/mountvolume-setup-failed-for-volume-kube-api-access-fcz9j-object-default) regarding missing `kube-root-ca` ConfigMap when relying on the default service account token.

### Checklist:
- [x] Helm Chart updated
- [x] Test cases updated
- [x] Documentation updated to include this change

### Caveat
Turning it on for everyone seemed technically simplest, but do we need a more sophisticated way to enable/disable token creation?
