### PR TITLE
fix: remove trailing dashes for multidoc yaml the pragmatic way

### DIFF
--- a/pkg/kubeseal/kubeseal.go
+++ b/pkg/kubeseal/kubeseal.go
@@ -389,6 +389,7 @@ func resourceOutput(out io.Writer, outputFormat string, codecs runtimeserializer
 		contentType = runtime.ContentTypeJSON
 	case "yaml":
 		contentType = runtime.ContentTypeYAML
+		fmt.Fprint(out, "---\n")
 	default:
 		return fmt.Errorf("unsupported output format: %s", outputFormat)
 	}
@@ -402,11 +403,8 @@ func resourceOutput(out io.Writer, outputFormat string, codecs runtimeserializer
 	}
 	_, _ = out.Write(buf)
 
-	switch contentType {
-	case runtime.ContentTypeJSON:
+	if contentType == runtime.ContentTypeJSON {
 		fmt.Fprint(out, "\n")
-	case runtime.ContentTypeYAML:
-		fmt.Fprint(out, "---\n")
 	}
 	return nil
 }

--- a/pkg/kubeseal/kubeseal_test.go
+++ b/pkg/kubeseal/kubeseal_test.go
@@ -220,7 +220,7 @@ func TestSealWithMultiDocSecrets(t *testing.T) {
 				t.Fatalf("Error writing to buffer: %v", err)
 			}
 
-			t.Logf("input is: %s", inbuf.String())
+			t.Logf("input is:\n%s", inbuf.String())
 
 			outbuf := bytes.Buffer{}
 			if err := Seal(clientConfig, outputFormat, &inbuf, &outbuf, scheme.Codecs, key, ssv1alpha1.NamespaceWideScope, false, "", ""); err != nil {
@@ -228,7 +228,17 @@ func TestSealWithMultiDocSecrets(t *testing.T) {
 			}
 
 			outBytes := outbuf.Bytes()
-			t.Logf("output is %s", outBytes)
+			t.Logf("output is:\n%s", outBytes)
+
+			if tc.asYaml {
+				if !strings.HasPrefix(string(outBytes), "---") {
+					t.Errorf("YAML output should start with ---")
+				}
+
+				if strings.HasSuffix(string(outBytes), "---\n") {
+					t.Errorf("YAML output should not end with ---")
+				}
+			}
 
 			decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(outBytes), 4096)
 			var gotSecrets []*ssv1alpha1.SealedSecret


### PR DESCRIPTION
Fixes #1330 #1296

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

While introducing multi document support for JSON and YAML, we introduced trailing dashes for YAMLs, which violates the YAML specification. This change will add `---` before every YAML document

**Benefits**

YAML specification is met, linters will be happy.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #1330 #1296 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
