### PR TITLE
Check ObservedGeneration and generation before to check

### DIFF
--- a/integration/controller_test.go
+++ b/integration/controller_test.go
@@ -56,6 +56,10 @@ func getStatus(ss *ssv1alpha1.SealedSecret) *ssv1alpha1.SealedSecretStatus {
 	return ss.Status
 }
 
+func getObservedGeneration(ss *ssv1alpha1.SealedSecret) int64 {
+	return ss.Status.ObservedGeneration
+}
+
 // get the first owner name assuming there is only one owner which is the sealed-secret object
 func getFirstOwnerName(s *v1.Secret) string {
 	return s.OwnerReferences[0].Name
@@ -230,6 +234,9 @@ var _ = Describe("create", func() {
 				Eventually(func() (*ssv1alpha1.SealedSecret, error) {
 					return ssc.BitnamiV1alpha1().SealedSecrets(ns).Get(context.Background(), secretName, metav1.GetOptions{})
 				}, Timeout, PollingInterval).ShouldNot(WithTransform(getStatus, BeNil()))
+				Eventually(func() (*ssv1alpha1.SealedSecret, error) {
+					return ssc.BitnamiV1alpha1().SealedSecrets(ns).Get(context.Background(), secretName, metav1.GetOptions{})
+				}, Timeout, PollingInterval).Should(WithTransform(getObservedGeneration, Equal(int64(2))))
 			})
 		})
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -412,9 +412,9 @@ func (c *Controller) updateSealedSecretStatus(ssecret *ssv1alpha1.SealedSecret, 
 		ssecret.Status = &ssv1alpha1.SealedSecretStatus{}
 	}
 
-	ssecret.Status.ObservedGeneration = ssecret.ObjectMeta.Generation
 	updatedRequired := updateSealedSecretsStatusConditions(ssecret.Status, unsealError)
-	if updatedRequired {
+	if updatedRequired || (ssecret.Status.ObservedGeneration != ssecret.ObjectMeta.Generation) {
+		ssecret.Status.ObservedGeneration = ssecret.ObjectMeta.Generation
 		_, err := c.ssclient.SealedSecrets(ssecret.GetObjectMeta().GetNamespace()).UpdateStatus(context.Background(), ssecret, metav1.UpdateOptions{})
 		return err
 	}


### PR DESCRIPTION
**Description of the change**

Take into account ObservedGeneration versus Generation in our Sealed Secrets Status

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #1354
- fixes #1355
