### PR TITLE
Improve examples with a more legible kubeseal command

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,8 +441,7 @@ The Sealed Secrets controller ensures compatibility with different versions of K
 echo -n bar | kubectl create secret generic mysecret --dry-run=client --from-file=foo=/dev/stdin -o json >mysecret.json
 
 # This is the important bit:
-# (note default format is json!)
-kubeseal <mysecret.json >mysealedsecret.json
+kubeseal -f mysecret.json -w mysealedsecret.json
 
 # At this point mysealedsecret.json is safe to upload to Github,
 # post on Twitter, etc.

--- a/site/content/docs/latest/tutorials/getting-started.md
+++ b/site/content/docs/latest/tutorials/getting-started.md
@@ -134,8 +134,7 @@ $(go env GOPATH)/bin/kubeseal
 echo -n bar | kubectl create secret generic mysecret --dry-run=client --from-file=foo=/dev/stdin -o json >mysecret.json
 
 # This is the important bit:
-# (note default format is json!)
-kubeseal <mysecret.json >mysealedsecret.json
+kubeseal -f mysecret.json -w mysealedsecret.json
 
 # At this point mysealedsecret.json is safe to upload to Github,
 # post on Twitter, etc.


### PR DESCRIPTION
**Description of the change**

Kubeseal can generate encrypted secrets in several ways, the one presented in the documentation did not use the latest features of the CLI. 

