### PR TITLE
Set up LastTransitionTime in case that it is empty

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -447,7 +447,9 @@ func updateSealedSecretsStatusConditions(st *ssv1alpha1.SealedSecretStatus, unse
 
 	// Status has changed, update the transition time and signal that an update is required
 	if cond.Status != status {
-		cond.LastTransitionTime = cond.LastUpdateTime
+		if !cond.LastUpdateTime.IsZero() {
+			cond.LastTransitionTime = cond.LastUpdateTime
+		}
 		cond.Status = status
 		cond.LastUpdateTime = metav1.Now()
 		updateRequired = true

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -449,6 +449,8 @@ func updateSealedSecretsStatusConditions(st *ssv1alpha1.SealedSecretStatus, unse
 	if cond.Status != status {
 		if !cond.LastUpdateTime.IsZero() {
 			cond.LastTransitionTime = cond.LastUpdateTime
+		} else {
+			cond.LastTransitionTime = metav1.Now()
 		}
 		cond.Status = status
 		cond.LastUpdateTime = metav1.Now()

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -165,15 +165,25 @@ func TestEmptyStatusSendsUpdate(t *testing.T) {
 }
 
 func TestStatusUpdateSendsUpdate(t *testing.T) {
-	updateRequired := updateSealedSecretsStatusConditions(&ssv1alpha1.SealedSecretStatus{
+	status := &ssv1alpha1.SealedSecretStatus{
 		Conditions: []ssv1alpha1.SealedSecretCondition{{
-			Status: "False",
-			Type:   ssv1alpha1.SealedSecretSynced,
+			Status:         "False",
+			Type:           ssv1alpha1.SealedSecretSynced,
+			LastUpdateTime: metav1.Now(),
 		}},
-	}, nil)
+	}
+	updateRequired := updateSealedSecretsStatusConditions(status, nil)
 
 	if !updateRequired {
 		t.Fatalf("expected status update, but no update was send")
+	}
+
+	if status.Conditions[0].LastTransitionTime.IsZero() {
+		t.Fatalf("expected LastTransitionTime is not empty")
+	}
+
+	if status.Conditions[0].LastUpdateTime.IsZero() {
+		t.Fatalf("expected LastUpdateTime is not empty")
 	}
 }
 


### PR DESCRIPTION
**Description of the change**

Set up LastTransitionTime in case that it is empty to avoid crashes setting up the Status:

```
Error updating SealedSecret namespace/mock-secret status: 
SealedSecret.bitnami.com "rnamespace/mock-secret" is invalid: 
status.conditions[0].lastTransitionTime: Invalid value: "null": 
status.conditions[0].lastTransitionTime in body must be of type string: "null"
```

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #1354
