### PR TITLE
feat: write help message to stdout

### DIFF
--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -55,6 +55,7 @@ type cliFlags struct {
 	reEncrypt      bool
 	unseal         bool
 	privKeys       []string
+	help           bool
 }
 
 type config struct {
@@ -102,6 +103,9 @@ func bindFlags(f *cliFlags, fs *flag.FlagSet) {
 
 	fs.BoolVar(&f.unseal, "recovery-unseal", false, "Decrypt a sealed secrets file obtained from stdin, using the private key passed with --recovery-private-key. Intended to be used in disaster recovery mode.")
 	fs.StringSliceVar(&f.privKeys, "recovery-private-key", nil, "Private key filename used by the --recovery-unseal command. Multiple files accepted either via comma separated list or by repetition of the flag. Either PEM encoded private keys or a backup of a json/yaml encoded k8s sealed-secret controller secret (and v1.List) are accepted. ")
+	fs.BoolVar(&f.help, "help", false, "Print this help message")
+
+	fs.SetOutput(os.Stdout)
 }
 
 func bindClientFlags(fs *flag.FlagSet, gofs *goflag.FlagSet, overrides *clientcmd.ConfigOverrides) {
@@ -124,6 +128,13 @@ func initUsualKubectlFlags(overrides *clientcmd.ConfigOverrides, fs *flag.FlagSe
 
 func runCLI(w io.Writer, cfg *config) (err error) {
 	flags := cfg.flags
+
+	if flags.help {
+		fmt.Fprintf(os.Stdout, "Usage of %s:\n", os.Args[0])
+		flag.PrintDefaults()
+		return nil
+	}
+
 	if len(flags.fromFile) != 0 && !flags.raw {
 		return fmt.Errorf("--from-file requires --raw")
 	}


### PR DESCRIPTION
Fixes #1359

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Writes output of `--help` / `-h` to Stdout instead of Stderr

**Benefits**

Follows GNU standards for CLIs where `--help` `--version` are supposed to be printed to Stdout

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #1359

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
