### PR TITLE
Release the newest Sealed Secrets version using the Bitnami container release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,11 +9,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      controller_dockerhub_image_name: docker.io/bitnami/sealed-secrets-controller
-      controller_ghcr_image_name: ghcr.io/bitnami-labs/sealed-secrets-controller
-      kubeseal_dockerhub_image_name: docker.io/bitnami/sealed-secrets-kubeseal
-      kubeseal_ghcr_image_name: ghcr.io/bitnami-labs/sealed-secrets-kubeseal
     steps:
       # Checkout and set env
       - name: Checkout
@@ -22,6 +17,10 @@ jobs:
         run: |
           source $GITHUB_WORKSPACE/versions.env
           echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       - name: Set up Go
         uses: actions/setup-go@v3.3.1
         with:
@@ -40,109 +39,10 @@ jobs:
       - name: Tests
         run: make test
 
-      # Generate K8s manifests
-      - name: K8s manifests
-        run: |
-          export PATH=~/bin:$PATH
-          RELEASE_BRANCH="${{ github.ref }}"
-          VERSION_TAG=$(echo "${RELEASE_BRANCH}" | awk -F'/' '{print $NF}')
-          echo "VERSION_TAG=$VERSION_TAG" >> $GITHUB_ENV
-          make CONTROLLER_IMAGE=${{ env.controller_dockerhub_image_name }}:${VERSION_TAG} controller.yaml controller-norbac.yaml
-
-      # Setup env for multi-arch builds
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2.0.0
-        with:
-          image: tonistiigi/binfmt:latest
-          platforms: arm64,arm
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.0.0
-
-      # Setup Cosign
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.0.2
-      - name: Write Cosign key
-        run: echo "$COSIGN_KEY" > /tmp/cosign.key
-        env:
-          COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
-
       # Tag for GoReleaser from release branch name
       - name: Tag Release
         run: |
-          git tag "${VERSION_TAG}"
-
-      # Build & Release binaries
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3.1.0
-        if: success() && startsWith(github.ref, 'refs/heads/')
-        with:
-          version: v1.10.3
-          args: release --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
-
-      # Build & Publish multi-arch image
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2.0.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: Login to GHRC
-        uses: docker/login-action@v2.0.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for Docker controller image
-        id: meta_controller
-        uses: docker/metadata-action@v4.0.1
-        with:
-          images: |
-            ${{ env.controller_dockerhub_image_name }}
-            ${{ env.controller_ghcr_image_name }}
-          tags: |
-            type=raw,value=${{ env.VERSION_TAG }}
-            type=raw,value=latest
-      - name: Build and push controller image
-        id: docker_build_controller
-        uses: docker/build-push-action@v3.2.0
-        with:
-          context: .
-          file: ./docker/controller.Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm
-          push: true
-          tags: ${{ steps.meta_controller.outputs.tags }}
-      - name: Extract metadata (tags, labels) for Docker kubeseal image
-        id: meta_kubeseal
-        uses: docker/metadata-action@v4.0.1
-        with:
-          images: |
-            ${{ env.kubeseal_dockerhub_image_name }}
-            ${{ env.kubeseal_ghcr_image_name }}
-          tags: |
-            type=raw,value=${{ env.VERSION_TAG }}
-            type=raw,value=latest
-      - name: Build and push kubeseal image
-        id: docker_build_kubeseal
-        uses: docker/build-push-action@v3.2.0
-        with:
-          context: .
-          file: ./docker/kubeseal.Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm
-          push: true
-          tags: ${{ steps.meta_kubeseal.outputs.tags }}
-      - name: Sign controller image with a key in GHCR
-        run: |
-          echo -n "$COSIGN_PASSWORD" | cosign sign --key /tmp/cosign.key --yes $TAG_CURRENT
-        env:
-          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
-          TAG_CURRENT: ${{ steps.meta_controller.outputs.tags }}
-          COSIGN_REPOSITORY: ${{ env.controller_ghcr_image_name }}/signs
-      - name: Sign kubeseal image with a key in GHCR
-        run: |
-          echo -n "$COSIGN_PASSWORD" | cosign sign --key /tmp/cosign.key --yes $TAG_CURRENT
-        env:
-          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
-          TAG_CURRENT: ${{ steps.meta_kubeseal.outputs.tags }}
-          COSIGN_REPOSITORY: ${{ env.kubeseal_ghcr_image_name }}/signs
+          RELEASE_BRANCH="${{ github.ref }}"
+          VERSION_TAG=$(echo "${RELEASE_BRANCH}" | awk -F'/' '{print $NF}')
+          git tag -a "${VERSION_TAG}" -m "Tag autogenerated ${VERSION_TAG}"
+          git push origin "${VERSION_TAG}"

--- a/.github/workflows/scheduled-release.yaml
+++ b/.github/workflows/scheduled-release.yaml
@@ -45,7 +45,7 @@ jobs:
       # Check Release
       - name: Check Release
         run: |
-          VERSION_TAG=$(git ls-remote --tags --refs --sort="v:refname" origin  | tail -n1 | sed 's/.*\///')
+          VERSION_TAG=$(git describe --tags --match "v[0-9]*" --abbrev=0 | tr -d v)
           echo "Tag looking for $VERSION_TAG"
           CHECK=$(./scripts/release-check ${{ env.controller_dockerhub_image_name }} $VERSION_TAG)
           echo "RELEASE=$CHECK" >> $GITHUB_ENV

--- a/.github/workflows/scheduled-release.yaml
+++ b/.github/workflows/scheduled-release.yaml
@@ -1,0 +1,149 @@
+name: Scheduled Release
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      controller_dockerhub_image_name: docker.io/bitnami/sealed-secrets-controller
+      controller_ghcr_image_name: ghcr.io/bitnami-labs/sealed-secrets-controller
+      kubeseal_dockerhub_image_name: docker.io/bitnami/sealed-secrets-kubeseal
+      kubeseal_ghcr_image_name: ghcr.io/bitnami-labs/sealed-secrets-kubeseal
+    steps:
+      # Checkout and set env
+      - name: Checkout
+        uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
+      - id: load-version
+        run: |
+          source $GITHUB_WORKSPACE/versions.env
+          echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
+      - name: Set up Go
+        uses: actions/setup-go@v3.3.1
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Setup kubecfg
+        run: |
+          mkdir -p ~/bin
+          curl -sLf https://github.com/kubecfg/kubecfg/releases/download/v0.26.0/kubecfg_Linux_X64 >~/bin/kubecfg
+          chmod +x ~/bin/kubecfg
+
+      - name: Install dependencies
+        run: |
+          go install gotest.tools/gotestsum@v1.8.1
+
+      # Setup env tools to copy images
+      - name: Set up regctl
+        uses: iarekylew00t/regctl-installer@v1
+        with:
+          regctl-release: v0.4.7
+
+      # Check Release
+      - name: Check Release
+        run: |
+          VERSION_TAG=$(git ls-remote --tags --refs --sort="v:refname" origin  | tail -n1 | sed 's/.*\///')
+          echo "Tag looking for $VERSION_TAG"
+          CHECK=$(./scripts/release-check ${{ env.controller_dockerhub_image_name }} $VERSION_TAG)
+          echo "RELEASE=$CHECK" >> $GITHUB_ENV
+          echo "VERSION_TAG=$VERSION_TAG" >> $GITHUB_ENV
+          echo "GORELEASER_CURRENT_TAG=$VERSION_TAG" >> $GITHUB_ENV
+
+      # Run tests
+      - name: Tests
+        if: env.RELEASE == 1
+        run: make test
+
+      # Generate K8s manifests
+      - name: K8s manifests
+        if: env.RELEASE == 1
+        run: |
+          export PATH=~/bin:$PATH
+          make CONTROLLER_IMAGE=${{ env.controller_dockerhub_image_name }}:${VERSION_TAG} controller.yaml controller-norbac.yaml
+
+      # Setup Cosign
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.0.2
+        if: env.RELEASE == 1
+      - name: Write Cosign key
+        if: env.RELEASE == 1
+        run: echo "$COSIGN_KEY" > /tmp/cosign.key
+        env:
+          COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
+
+      # Build & Release binaries
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3.1.0
+        if: success() && startsWith(github.ref, 'refs/heads/') && env.RELEASE == 1
+        with:
+          version: v1.10.3
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+
+      # Build & Publish multi-arch image
+      - name: Login to Docker Hub
+        if: env.RELEASE == 1
+        uses: docker/login-action@v2.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Login to GHRC
+        if: env.RELEASE == 1
+        uses: docker/login-action@v2.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker controller image
+        if: env.RELEASE == 1
+        id: meta_controller
+        uses: docker/metadata-action@v4.0.1
+        with:
+          images: |
+            ${{ env.controller_dockerhub_image_name }}
+            ${{ env.controller_ghcr_image_name }}
+          tags: |
+            type=raw,value=${{ env.VERSION_TAG }}
+            type=raw,value=latest
+      - name: Copy controller image
+        if: env.RELEASE == 1
+        run: |
+          regctl image copy ${{ env.controller_dockerhub_image_name }}:latest ${{ env.controller_ghcr_image_name }}:latest
+          regctl image copy ${{ env.controller_dockerhub_image_name }}:${VERSION_TAG} ${{ env.controller_ghcr_image_name }}:${VERSION_TAG}
+      - name: Extract metadata (tags, labels) for Docker kubeseal image
+        if: env.RELEASE == 1
+        id: meta_kubeseal
+        uses: docker/metadata-action@v4.0.1
+        with:
+          images: |
+            ${{ env.kubeseal_dockerhub_image_name }}
+            ${{ env.kubeseal_ghcr_image_name }}
+          tags: |
+            type=raw,value=${{ env.VERSION_TAG }}
+            type=raw,value=latest
+      - name: Copy kubeseal image
+        if: env.RELEASE == 1
+        run: |
+          regctl image copy ${{ env.kubeseal_dockerhub_image_name }}:latest ${{ env.kubeseal_ghcr_image_name }}:latest
+          regctl image copy ${{ env.kubeseal_dockerhub_image_name }}:${VERSION_TAG} ${{ env.kubeseal_ghcr_image_name }}:${VERSION_TAG}
+      - name: Sign controller image with a key in GHCR
+        if: env.RELEASE == 1
+        run: |
+          echo -n "$COSIGN_PASSWORD" | cosign sign --key /tmp/cosign.key --yes $TAG_CURRENT
+        env:
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          TAG_CURRENT: ${{ steps.meta_controller.outputs.tags }}
+          COSIGN_REPOSITORY: ${{ env.controller_ghcr_image_name }}/signs
+      - name: Sign kubeseal image with a key in GHCR
+        if: env.RELEASE == 1
+        run: |
+          echo -n "$COSIGN_PASSWORD" | cosign sign --key /tmp/cosign.key --yes $TAG_CURRENT
+        env:
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          TAG_CURRENT: ${{ steps.meta_kubeseal.outputs.tags }}
+          COSIGN_REPOSITORY: ${{ env.kubeseal_ghcr_image_name }}/signs

--- a/scripts/release-check
+++ b/scripts/release-check
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -o nounset
+
+function docker_tag_exists() {
+	docker pull $1:$2 > /dev/null
+}
+
+function find_release() {
+	curl -v --silent https://github.com/bitnami-labs/sealed-secrets/releases 2>&1 | grep $1 > /dev/null
+	echo $?
+}
+
+
+RELEASE=$(find_release $2)
+if [ $RELEASE -ne 0 ] ; then
+	if docker_tag_exists $1 $2; then
+		echo 1
+	else
+		echo 0
+	fi
+else
+	echo 0
+fi


### PR DESCRIPTION
With these changes, we are going to release the newest Sealed Secrets version using the containers generated by the Bitnami Container Release process using the tag of with our release. Then, we will generate the official release in our project.

Why this decision? Using the Bitnami Release process, the containers are tested in several environment (OpenShift, AKS, etc) running our integration tests. Like this, the project will be covered in several real environments that Sealed Secrets in running by the users.

From the user side, **you will not notice any change at all**. We are publishing the containers in the same registry and our chart and controller will use the same containers.

fixes #1393 