### PR TITLE
feat: support immutable secrets (#574)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ In particular, the annotations and labels of a `SealedSecret` resource are not t
 
 To capture this distinction, the `SealedSecret` object has a `template` section which encodes all the fields you want the controller to put in the unsealed `Secret`.
 
-This includes metadata such as labels or annotations, but also things like the `type` of the secret.
+This includes metadata such as labels or annotations, but also things like `type` and `immutable` fields of the secret.
 
 ```yaml
 apiVersion: bitnami.com/v1alpha1
@@ -131,6 +131,7 @@ spec:
     .dockerconfigjson: AgBy3i4OJSWK+PiTySYZZA9rO43cGDEq.....
   template:
     type: kubernetes.io/dockerconfigjson
+    immutable: true
     # this is an example of labels and annotations that will be added to the output secret
     metadata:
       labels:
@@ -158,6 +159,7 @@ metadata:
     name: mysecret
     uid: 5caff6a0-c9ac-11e9-881e-42010aac003e
 type: kubernetes.io/dockerconfigjson
+immutable: true
 data:
   .dockerconfigjson: ewogICJjcmVk...
 ```

--- a/helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
+++ b/helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
@@ -91,6 +91,10 @@ spec:
                     description: Used to facilitate programmatic handling of secret
                       data.
                     type: string
+                  immutable:
+                    description: 'Immutable, if set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+                      If not set to true, the field can be modified at any time. Defaulted to nil.'
+                    type: boolean
                 type: object
             required:
             - encryptedData

--- a/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
@@ -208,7 +208,8 @@ func NewSealedSecret(codecs runtimeserializer.CodecFactory, pubKey *rsa.PublicKe
 		Spec: SealedSecretSpec{
 			Template: SecretTemplateSpec{
 				// ObjectMeta copied below
-				Type: secret.Type,
+				Type:      secret.Type,
+				Immutable: secret.Immutable,
 			},
 			EncryptedData: map[string]string{},
 		},
@@ -266,6 +267,7 @@ func (s *SealedSecret) Unseal(codecs runtimeserializer.CodecFactory, privKeys ma
 	if s.Spec.Data == nil {
 		s.Spec.Template.ObjectMeta.DeepCopyInto(&secret.ObjectMeta)
 		secret.Type = s.Spec.Template.Type
+		secret.Immutable = s.Spec.Template.Immutable
 
 		secret.Data = map[string][]byte{}
 		data := map[string]string{}

--- a/pkg/apis/sealedsecrets/v1alpha1/types.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/types.go
@@ -51,6 +51,13 @@ type SecretTemplateSpec struct {
 	// +optional
 	Type apiv1.SecretType `json:"type,omitempty" protobuf:"bytes,3,opt,name=type,casttype=SecretType"`
 
+	// Immutable, if set to true, ensures that data stored in the Secret cannot
+	// be updated (only object metadata can be modified).
+	// If not set to true, the field can be modified at any time.
+	// Defaulted to nil.
+	// +optional
+	Immutable *bool `json:"immutable,omitempty" protobuf:"varint,5,opt,name=immutable"`
+
 	// Keys that should be templated using decrypted data.
 	// +optional
 	// +nullable

--- a/schema-v1alpha1.yaml
+++ b/schema-v1alpha1.yaml
@@ -55,6 +55,9 @@ openAPIV3Schema:
             type:
               description: Used to facilitate programmatic handling of secret data.
               type: string
+            immutable:
+              description: 'Immutable, if set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil.'
+              type: boolean
           type: object
       required:
         - encryptedData


### PR DESCRIPTION
**Description of the change**

This adds support to seal and unseal immutable secrets via `spec.template.immutable`. I have also updated a related integration test and did some additional manual testing.

<details>
  <summary>Additional manual testing details</summary>

Test 1: Use kubeseal to seal an immutable secret
Result: produced a SealedSecret with `spec.template.immutable: true`

```bash
$ kubeseal <<EOF > sealed.json
apiVersion: v1
kind: Secret
metadata:
  name: test
immutable: true
data:
  foo: deadbeef
EOF

$ cat sealed.json
{
  "kind": "SealedSecret",
  "apiVersion": "bitnami.com/v1alpha1",
  "metadata": {
    "name": "test",
    "namespace": "default",
    "creationTimestamp": null
  },
  "spec": {
    "template": {
      "metadata": {
        "name": "test",
        "namespace": "default",
        "creationTimestamp": null
      },
      "immutable": true
    },
    "encryptedData": {
      "foo": "AgAUYqFKbJ4sKRxs3+Gq24OxYeHDeo2U37wM7hFFQLSDg1cm2A6JVDREm/WAnLRUCzEpqwdlwVJ6HKpGndeepe597zlw+OT16uL4pzOth0dKce8KpM3M5V0dZYOLZ+Apq8LvVJ4l4GV/yaNlLhUV2msgzBzl+mvCo9ge10KVNN70tr0HkYA7m1L51J7py7GTcccp5ytXvIWI2i2xWZ73NlteMGYDnVYwOC7GGA6YL17LNMNpIZoDlfYqcQl0HgGCgwX2VYTlA+WJ9rftfBsvAcwkA8/SSu69r0cYX2BZcG2EI1RlP2mn86Ki4VuqbYPLV1a4e0WfCSchlmHsVUEL/doC43bV7qPcqA60/+kg9hZHTopNYmr8kpIh4Cto4caPOgbT+85+rSsADJT2D7506jxkU4eEEn3AN64Pi8LjcKU8JCHBXsMNlzQ/fKmS1ciJqFD17eihx2IVRMFgBKTgfZsAcBBF6KnPu+J6WDqBvwzoV68cIx/3DYJZUG/tXnx3RZdhxDoYS0bghyA8w+9+6yYimnxqqaAAVQGf/npGm5+eHb+b/Sk6ZD3mpZ4C+eNRsDRCzVh8rcc1yXByuXMSIyw4+3f7opD+MVf4ab/OyOBtHX4/zPku6wQuwdDJO26skj6NJU0zANz2VUg4+ctIwIoIFLn8F0b1PDsBhX2ntShX42ZLqwP41CMs4o67gdAtD3yCy7RtUgM="
    }
  }
}
```

Test 2: Create a SealedSecret resource with `spec.template.immutable: true`
Result: the secret is unsealed correctly

```bash
$ kubectl apply -f sealed.json
sealedsecret.bitnami.com/test configured

$ kubectl get secret test -o yaml
apiVersion: v1
data:
  foo: deadbeef
immutable: true
kind: Secret
metadata:
  creationTimestamp: "2023-11-28T03:47:27Z"
  name: test
  namespace: default
  ownerReferences:
  - apiVersion: bitnami.com/v1alpha1
    controller: true
    kind: SealedSecret
    name: test
    uid: 0e09c7ed-5a29-40f9-9ea1-ee8e5236951c
  resourceVersion: "42712"
  uid: 10ef189b-7ca5-4777-906f-fde6842c558b
type: Opaque
```
</details>

**Benefits**

Users can opt-in to create immutable secrets. The new field is optional and the default behavior is not changed.

The benefits of immutable secrets are discussed in the official Kubernetes documentation. https://kubernetes.io/docs/concepts/configuration/secret/#secret-immutable

**Possible drawbacks**

None.

**Applicable issues**

- Fixes #574

**Additional information**

Requires a release of both Sealed Secrets and the Helm chart