### PR TITLE
Fix metrics endpoints

### DIFF
--- a/helm/sealed-secrets/templates/_helpers.tpl
+++ b/helm/sealed-secrets/templates/_helpers.tpl
@@ -60,25 +60,11 @@ app.kubernetes.io/version: {{ .Chart.AppVersion }}
 app.kubernetes.io/part-of: sealed-secrets
 {{- end -}}
 
-{{- define "sealed-secrets.metrics-labels" -}}
-app.kubernetes.io/name: {{ include "sealed-secrets.name" . }}-metrics
-helm.sh/chart: {{ include "sealed-secrets.chart" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/version: {{ .Chart.AppVersion }}
-app.kubernetes.io/part-of: sealed-secrets
-{{- end -}}
-
 {{/*
 Labels to use on deploy.spec.selector.matchLabels and svc.spec.selector
 */}}
 {{- define "sealed-secrets.matchLabels" -}}
 app.kubernetes.io/name: {{ include "sealed-secrets.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end -}}
-
-{{- define "sealed-secrets.metrics-matchLabels" -}}
-app.kubernetes.io/name: {{ include "sealed-secrets.name" . }}-metrics
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 

--- a/helm/sealed-secrets/templates/_helpers.tpl
+++ b/helm/sealed-secrets/templates/_helpers.tpl
@@ -60,11 +60,25 @@ app.kubernetes.io/version: {{ .Chart.AppVersion }}
 app.kubernetes.io/part-of: sealed-secrets
 {{- end -}}
 
+{{- define "sealed-secrets.metrics-labels" -}}
+app.kubernetes.io/name: {{ include "sealed-secrets.name" . }}-metrics
+helm.sh/chart: {{ include "sealed-secrets.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/part-of: sealed-secrets
+{{- end -}}
+
 {{/*
 Labels to use on deploy.spec.selector.matchLabels and svc.spec.selector
 */}}
 {{- define "sealed-secrets.matchLabels" -}}
 app.kubernetes.io/name: {{ include "sealed-secrets.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "sealed-secrets.metrics-matchLabels" -}}
+app.kubernetes.io/name: {{ include "sealed-secrets.name" . }}-metrics
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 

--- a/helm/sealed-secrets/templates/service.yaml
+++ b/helm/sealed-secrets/templates/service.yaml
@@ -29,6 +29,7 @@ spec:
       nodePort: null
       {{- end }}
   selector: {{- include "sealed-secrets.matchLabels" . | nindent 4 }}
+{{- if .Values.metrics.serviceMonitor.enabled }}
 ---
 apiVersion: v1
 kind: Service
@@ -44,20 +45,21 @@ metadata:
     {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
-  labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+  labels: {{- include "sealed-secrets.metrics-labels" . | nindent 4 }}
     {{- if .Values.metrics.service.labels }}
     {{- include "sealed-secrets.render" ( dict "value" .Values.metrics.service.labels "context" $) | nindent 4 }}
     {{- end }}
 spec:
   type: {{ .Values.metrics.service.type }}
   ports:
-    - name: http
+    - name: metrics
       port: {{ .Values.metrics.service.port }}
-      targetPort: http
+      targetPort: metrics
       {{- if and (or (eq .Values.metrics.service.type "NodePort") (eq .Values.metrics.service.type "LoadBalancer")) (not (empty .Values.metrics.service.nodePort)) }}
       nodePort: {{ .Values.metrics.service.nodePort }}
       {{- else if eq .Values.metrics.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
   selector: {{- include "sealed-secrets.matchLabels" . | nindent 4 }}
+{{- end -}}
 {{- end }}

--- a/helm/sealed-secrets/templates/service.yaml
+++ b/helm/sealed-secrets/templates/service.yaml
@@ -29,7 +29,6 @@ spec:
       nodePort: null
       {{- end }}
   selector: {{- include "sealed-secrets.matchLabels" . | nindent 4 }}
-{{- if .Values.metrics.serviceMonitor.enabled }}
 ---
 apiVersion: v1
 kind: Service
@@ -45,7 +44,7 @@ metadata:
     {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
-  labels: {{- include "sealed-secrets.metrics-labels" . | nindent 4 }}
+  labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
     {{- if .Values.metrics.service.labels }}
     {{- include "sealed-secrets.render" ( dict "value" .Values.metrics.service.labels "context" $) | nindent 4 }}
     {{- end }}
@@ -61,5 +60,4 @@ spec:
       nodePort: null
       {{- end }}
   selector: {{- include "sealed-secrets.matchLabels" . | nindent 4 }}
-{{- end -}}
 {{- end }}

--- a/helm/sealed-secrets/templates/servicemonitor.yaml
+++ b/helm/sealed-secrets/templates/servicemonitor.yaml
@@ -17,7 +17,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-    - port: http
+    - port: metrics
       {{- if .Values.metrics.serviceMonitor.honorLabels }}
       honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}
       {{- end }}
@@ -37,5 +37,5 @@ spec:
     matchNames:
       - {{ include "sealed-secrets.namespace" . }}
   selector:
-    matchLabels: {{- include "sealed-secrets.matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "sealed-secrets.metrics-matchLabels" . | nindent 6 }}
 {{- end }}

--- a/helm/sealed-secrets/templates/servicemonitor.yaml
+++ b/helm/sealed-secrets/templates/servicemonitor.yaml
@@ -37,5 +37,5 @@ spec:
     matchNames:
       - {{ include "sealed-secrets.namespace" . }}
   selector:
-    matchLabels: {{- include "sealed-secrets.metrics-matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "sealed-secrets.matchLabels" . | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
**Description of the change**

Adapt helm chart to support #1369:

- set metrics service port and targetPort consistent with deployment metrics port
- set metrics servicemonitor port consistent with metrics service port

**Benefits**

ServiceMonitor is no longer broken.

**Possible drawbacks**

None.

**Applicable issues**

- fixes #1402

**Additional information**

Tested succesfully with quay.io/prometheus-operator/prometheus-operator:v0.70.0.
