### PR TITLE
add commonLabels to customizable values

### DIFF
--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -78,6 +78,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `namespace`         | Namespace where to deploy the Sealed Secrets controller | `""`  |
 | `extraDeploy`       | Array of extra objects to deploy with the release       | `[]`  |
 | `commonAnnotations` | Annotations to add to all deployed resources            | `{}`  |
+| `commonLabels`      | Labels to add to all deployed resources                 | `{}`  |
 
 ### Sealed Secrets Parameters
 

--- a/helm/sealed-secrets/templates/_helpers.tpl
+++ b/helm/sealed-secrets/templates/_helpers.tpl
@@ -58,6 +58,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/version: {{ .Chart.AppVersion }}
 app.kubernetes.io/part-of: sealed-secrets
+{{- if .Values.commonLabels }}
+{{ .Values.commonLabels | toYaml }}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/helm/sealed-secrets/templates/_helpers.tpl
+++ b/helm/sealed-secrets/templates/_helpers.tpl
@@ -58,9 +58,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/version: {{ .Chart.AppVersion }}
 app.kubernetes.io/part-of: sealed-secrets
-{{- if .Values.commonLabels }}
-{{ .Values.commonLabels | toYaml }}
-{{- end -}}
 {{- end -}}
 
 {{/*

--- a/helm/sealed-secrets/templates/cluster-role-binding.yaml
+++ b/helm/sealed-secrets/templates/cluster-role-binding.yaml
@@ -7,6 +7,9 @@ metadata:
     {{- if .Values.rbac.labels }}
     {{- include "sealed-secrets.render" ( dict "value" .Values.rbac.labels "context" $) | nindent 4 }}
     {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/helm/sealed-secrets/templates/cluster-role.yaml
+++ b/helm/sealed-secrets/templates/cluster-role.yaml
@@ -7,6 +7,9 @@ metadata:
     {{- if .Values.rbac.labels }}
     {{- include "sealed-secrets.render" ( dict "value" .Values.rbac.labels "context" $) | nindent 4 }}
     {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
 rules:
   - apiGroups:
       - bitnami.com

--- a/helm/sealed-secrets/templates/configmap-dashboards.yaml
+++ b/helm/sealed-secrets/templates/configmap-dashboards.yaml
@@ -11,6 +11,9 @@ metadata:
     {{- if $.Values.metrics.dashboards.labels }}
     {{- include "sealed-secrets.render" ( dict "value" $.Values.metrics.dashboards.labels "context" $) | nindent 4 }}
     {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
   annotations:
     {{- if $.Values.metrics.dashboards.annotations }}
     {{- include "sealed-secrets.render" ( dict "value" $.Values.metrics.dashboards.annotations "context" $) | nindent 4 }}

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "sealed-secrets.fullname" . }}
   namespace: {{ include "sealed-secrets.namespace" . }}
   labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- toYaml .Values.commonAnnotations | nindent 4 }}
   {{- end }}

--- a/helm/sealed-secrets/templates/ingress.yaml
+++ b/helm/sealed-secrets/templates/ingress.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "sealed-secrets.fullname" . }}
   namespace: {{ include "sealed-secrets.namespace" . }}
   labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
   {{- if .Values.ingress.annotations }}
   annotations:
     {{- if .Values.ingress.annotations }}

--- a/helm/sealed-secrets/templates/networkpolicy.yaml
+++ b/helm/sealed-secrets/templates/networkpolicy.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "sealed-secrets.fullname" . }}
   namespace: {{ include "sealed-secrets.namespace" . }}
   labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
 spec:
   podSelector:
     matchLabels: {{- include "sealed-secrets.matchLabels" . | nindent 6 }}

--- a/helm/sealed-secrets/templates/pdb.yaml
+++ b/helm/sealed-secrets/templates/pdb.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "sealed-secrets.fullname" . }}
   namespace: {{ include "sealed-secrets.namespace" . }}
   labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- toYaml .Values.commonAnnotations | nindent 4 }}
   {{- end }}

--- a/helm/sealed-secrets/templates/psp-clusterrole.yaml
+++ b/helm/sealed-secrets/templates/psp-clusterrole.yaml
@@ -7,6 +7,9 @@ metadata:
     {{- if .Values.rbac.labels }}
     {{- include "sealed-secrets.render" ( dict "value" .Values.rbac.labels "context" $) | nindent 4 }}
     {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
 rules:
   - apiGroups: ['extensions']
     resources: ['podsecuritypolicies']

--- a/helm/sealed-secrets/templates/psp-clusterrolebinding.yaml
+++ b/helm/sealed-secrets/templates/psp-clusterrolebinding.yaml
@@ -7,6 +7,9 @@ metadata:
     {{- if .Values.rbac.labels }}
     {{- include "sealed-secrets.render" ( dict "value" .Values.rbac.labels "context" $) | nindent 4 }}
     {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/helm/sealed-secrets/templates/psp.yaml
+++ b/helm/sealed-secrets/templates/psp.yaml
@@ -4,6 +4,9 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ include "sealed-secrets.fullname" . }}
   labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
 spec:
   privileged: false
   allowPrivilegeEscalation: false

--- a/helm/sealed-secrets/templates/role-binding.yaml
+++ b/helm/sealed-secrets/templates/role-binding.yaml
@@ -8,6 +8,9 @@ metadata:
     {{- if .Values.rbac.labels }}
     {{- include "sealed-secrets.render" ( dict "value" .Values.rbac.labels "context" $) | nindent 4 }}
     {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -26,6 +29,9 @@ metadata:
   labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
     {{- if .Values.rbac.labels }}
     {{- include "sealed-secrets.render" ( dict "value" .Values.rbac.labels "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/helm/sealed-secrets/templates/role.yaml
+++ b/helm/sealed-secrets/templates/role.yaml
@@ -8,6 +8,9 @@ metadata:
     {{- if .Values.rbac.labels }}
     {{- include "sealed-secrets.render" ( dict "value" .Values.rbac.labels "context" $) | nindent 4 }}
     {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
 rules:
   - apiGroups:
       - ""
@@ -33,6 +36,9 @@ metadata:
   labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
     {{- if .Values.rbac.labels }}
     {{- include "sealed-secrets.render" ( dict "value" .Values.rbac.labels "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
 rules:
   - apiGroups:

--- a/helm/sealed-secrets/templates/service-account.yaml
+++ b/helm/sealed-secrets/templates/service-account.yaml
@@ -17,4 +17,7 @@ metadata:
     {{- if .Values.serviceAccount.labels }}
     {{- include "sealed-secrets.render" ( dict "value" .Values.serviceAccount.labels "context" $) | nindent 4 }}
     {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
 {{ end }}

--- a/helm/sealed-secrets/templates/service.yaml
+++ b/helm/sealed-secrets/templates/service.yaml
@@ -17,6 +17,9 @@ metadata:
     {{- if .Values.service.labels }}
     {{- include "sealed-secrets.render" ( dict "value" .Values.service.labels "context" $) | nindent 4 }}
     {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -47,6 +50,9 @@ metadata:
   labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
     {{- if .Values.metrics.service.labels }}
     {{- include "sealed-secrets.render" ( dict "value" .Values.metrics.service.labels "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
 spec:
   type: {{ .Values.metrics.service.type }}

--- a/helm/sealed-secrets/templates/servicemonitor.yaml
+++ b/helm/sealed-secrets/templates/servicemonitor.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- if .Values.metrics.serviceMonitor.labels }}
     {{- include "sealed-secrets.render" ( dict "value" .Values.metrics.serviceMonitor.labels "context" $) | nindent 4 }}
     {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
   {{- if .Values.metrics.serviceMonitor.annotations }}
   annotations: {{- include "sealed-secrets.render" (dict "value" .Values.metrics.serviceMonitor.annotations "context" $) | nindent 4 }}
   {{- end }}

--- a/helm/sealed-secrets/templates/tls-secret.yaml
+++ b/helm/sealed-secrets/templates/tls-secret.yaml
@@ -7,6 +7,9 @@ metadata:
   name: {{ .name }}
   namespace: {{ include "sealed-secrets.namespace" $ | quote }}
   labels: {{- include "sealed-secrets.labels" $ | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .certificate | b64enc }}
@@ -23,6 +26,9 @@ metadata:
   name: {{ printf "%s-tls" .Values.ingress.hostname }}
   namespace: {{ include "sealed-secrets.namespace" . }}
   labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
 type: kubernetes.io/tls
 data:
   tls.crt: {{ $cert.Cert | b64enc | quote }}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -21,6 +21,11 @@ extraDeploy: []
 ##
 commonAnnotations: {}
 
+## @param commonLabels [ojbect] Labels to add to all deployed resources
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+## 
+commonLabels: {}
+
 ## @section Sealed Secrets Parameters
 
 ## Sealed Secrets image


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Helm Chart only update, add new value `commonLabels` that functions the same as `commonAnnotations` by adding labels to `_helpers.tpl` in `sealed-secrets.labels` 

**Benefits**

* Ability to add custom labels to all resources for any organization compliance

**Possible drawbacks**

N/A

**Applicable issues**

- fixes #1373

**Additional information**

My current organization requires adding a custom label to all resources, thus the PR.
The changes in the PR were tested on a local Kubernetes installation with both `commonLabels: {}` and `commonLabels: {x: 'y'}`
