### PR TITLE
fix(helm): syntax fix in dashboard template

### DIFF
--- a/helm/sealed-secrets/templates/configmap-dashboards.yaml
+++ b/helm/sealed-secrets/templates/configmap-dashboards.yaml
@@ -11,8 +11,8 @@ metadata:
     {{- if $.Values.metrics.dashboards.labels }}
     {{- include "sealed-secrets.render" ( dict "value" $.Values.metrics.dashboards.labels "context" $) | nindent 4 }}
     {{- end }}
-    {{- if .Values.commonLabels }}
-    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- if $.Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" $.Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   annotations:
     {{- if $.Values.metrics.dashboards.annotations }}


### PR DESCRIPTION
**Description of the change**

Addresses https://github.com/bitnami-labs/sealed-secrets/issues/1416
Update dashboard configmap template syntax on commonLabels

**Benefits**

When dashboards are enabled helm will now render them correctly.

**Possible drawbacks**

None know.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #1416

**Additional information**

Tested with helm template.  Before fix with dashboards enabled:
```
helm template testing . --values values.yaml
Error: template: sealed-secrets/templates/configmap-dashboards.yaml:14:18: executing "sealed-secrets/templates/configmap-dashboards.yaml" at <.Values.commonLabels>: can't evaluate field Values in type []uint8

Use --debug flag to render out invalid YAML
```
With change, renders as expected.