### PR TITLE
Support fetching certificate URL via proxy environment variables

### DIFF
--- a/pkg/kubeseal/kubeseal.go
+++ b/pkg/kubeseal/kubeseal.go
@@ -122,7 +122,7 @@ func openCertURI(uri string) (io.ReadCloser, error) {
 	// than using the file:// scheme below because there is no point in complicating our lives
 	// and escape the filename properly.
 
-	t := &http.Transport{}
+	t := &http.Transport{Proxy: http.ProxyFromEnvironment}
 	// #nosec: G111 -- we want to allow all files to be opened
 	t.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
 	c := &http.Client{Transport: t}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This change allows users to specify company private URL for certificate URL which requires their proxy to fetch.

**Benefits**

In our company, since the certificate URL requires our proxy, we always use something like `kubeseal --cert <(curl -sSf "https://example.com/our-cert-file.cert")` (we set `https_proxy` environment variable), or sometimes `wget "https://example.com/our-cert-file.cert" && kubeseal --cert "our-cert-file.cert"`. It would be very useful if we can directly specify the private URL to `--cert`.

**Possible drawbacks**

I don't think there're any drawbacks.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- No issues.

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
