### PR TITLE
add dedicated label to metrics service and servicemonitor

### DIFF
--- a/helm/sealed-secrets/templates/service.yaml
+++ b/helm/sealed-secrets/templates/service.yaml
@@ -54,6 +54,7 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
+    app.kubernetes.io/component: metrics
 spec:
   type: {{ .Values.metrics.service.type }}
   ports:

--- a/helm/sealed-secrets/templates/servicemonitor.yaml
+++ b/helm/sealed-secrets/templates/servicemonitor.yaml
@@ -40,5 +40,7 @@ spec:
     matchNames:
       - {{ include "sealed-secrets.namespace" . }}
   selector:
-    matchLabels: {{- include "sealed-secrets.matchLabels" . | nindent 6 }}
+    matchLabels:
+      {{- include "sealed-secrets.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: metrics
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add a dedicated label to the metrics service and servicemonitor within the helmchart template.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Only match the metrics service with the servicemonitor

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #1423 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
