### PR TITLE
Implement structured logging

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -52,6 +52,8 @@ func bindControllerFlags(f *controller.Flags, fs *flag.FlagSet) {
 	fs.BoolVar(&f.SkipRecreate, "skip-recreate", false, "if true the controller will skip listening for managed secret changes to recreate them. This helps on limited permission environments.")
 
 	fs.BoolVar(&f.LogInfoToStdout, "log-info-stdout", false, "if true the controller will log info to stdout.")
+	fs.StringVar(&f.LogLevel, "log-level", "INFO", "Log level (DEBUG|INFO|WARN|ERROR).")
+	fs.StringVar(&f.LogLevel, "log-format", "text", "Log format (text|json).")
 
 	fs.DurationVar(&f.KeyRenewPeriod, "rotate-period", defaultKeyRenewPeriod, "")
 	_ = fs.MarkDeprecated("rotate-period", "please use key-renew-period instead")

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -102,8 +102,8 @@ func mainE(w io.Writer, fs *flag.FlagSet, gofs *goflag.FlagSet, args []string) e
 
 	ssv1alpha1.AcceptDeprecatedV1Data = flags.AcceptV1Data
 
-	slog.Info("controller version", "version", VERSION)
 	if printVersion {
+		fmt.Fprintf(w, "controller version: %s\n", VERSION)
 		return nil
 	}
 

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -101,6 +101,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `privateKeyAnnotations`                           | Map of annotations to be set on the sealing keypairs                                                  | `{}`                                |
 | `privateKeyLabels`                                | Map of labels to be set on the sealing keypairs                                                       | `{}`                                |
 | `logInfoStdout`                                   | Specifies whether the Sealed Secrets controller will log info to stdout                               | `false`                             |
+| `logLevel`                                   | Specifies log level of controller (DEBUG,INFO,WARN,ERROR)                               | `""`                             |
+| `logFormat`                                   | Specifies log format (text,json)                               | `""`                             |
 | `command`                                         | Override default container command                                                                    | `[]`                                |
 | `args`                                            | Override default container args                                                                       | `[]`                                |
 | `livenessProbe.enabled`                           | Enable livenessProbe on Sealed Secret containers                                                      | `true`                              |

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -101,7 +101,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `privateKeyAnnotations`                           | Map of annotations to be set on the sealing keypairs                                                  | `{}`                                |
 | `privateKeyLabels`                                | Map of labels to be set on the sealing keypairs                                                       | `{}`                                |
 | `logInfoStdout`                                   | Specifies whether the Sealed Secrets controller will log info to stdout                               | `false`                             |
-| `logLevel`                                   | Specifies log level of controller (DEBUG,INFO,WARN,ERROR)                               | `""`                             |
+| `logLevel`                                   | Specifies log level of controller (INFO,ERROR)                               | `""`                             |
 | `logFormat`                                   | Specifies log format (text,json)                               | `""`                             |
 | `command`                                         | Override default container command                                                                    | `[]`                                |
 | `args`                                            | Override default container args                                                                       | `[]`                                |

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -120,6 +120,14 @@ spec:
             {{- if .Values.logInfoStdout }}
             - --log-info-stdout
             {{- end }}
+            {{- if .Values.logLevel }}
+            - --log-level
+            - {{ .Values.logLevel }}
+            {{- end }}
+            {{- if .Values.logFormat }}
+            - --log-level
+            - {{ .Values.logFormat }}
+            {{- end }}
           {{- end }}
           image: {{ printf "%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -125,7 +125,7 @@ spec:
             - {{ .Values.logLevel }}
             {{- end }}
             {{- if .Values.logFormat }}
-            - --log-level
+            - --log-format
             - {{ .Values.logFormat }}
             {{- end }}
           {{- end }}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -94,6 +94,12 @@ privateKeyLabels: {}
 ## @param logInfoStdout Specifies whether the Sealed Secrets controller will log info to stdout
 ##
 logInfoStdout: false
+## @param logLevel Specifies log level of controller (DEBUG,INFO,WARN,ERROR)
+##
+logLevel: ""
+## @param logFormat Specifies log format (text,json)
+##
+logFormat: ""
 ## @param command Override default container command
 ##
 command: []

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -94,7 +94,7 @@ privateKeyLabels: {}
 ## @param logInfoStdout Specifies whether the Sealed Secrets controller will log info to stdout
 ##
 logInfoStdout: false
-## @param logLevel Specifies log level of controller (DEBUG,INFO,WARN,ERROR)
+## @param logLevel Specifies log level of controller (INFO,ERROR)
 ##
 logLevel: ""
 ## @param logFormat Specifies log format (text,json)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -287,7 +287,7 @@ func (c *Controller) unseal(ctx context.Context, key string) (unsealErr error) {
 	unsealRequestsTotal.Inc()
 	obj, exists, err := c.ssInformer.GetIndexer().GetByKey(key)
 	if err != nil {
-		slog.Error("Error fetching object  from store", "key", key, "error", err)
+		slog.Error("Error fetching object from store", "key", key, "error", err)
 		unsealErrorsTotal.WithLabelValues("fetch", "").Inc()
 		return err
 	}

--- a/pkg/controller/keyregistry.go
+++ b/pkg/controller/keyregistry.go
@@ -6,11 +6,11 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
 	"github.com/bitnami-labs/sealed-secrets/pkg/crypto"
-	"github.com/bitnami-labs/sealed-secrets/pkg/log"
 	"k8s.io/client-go/kubernetes"
 	certUtil "k8s.io/client-go/util/cert"
 )
@@ -61,8 +61,8 @@ func (kr *KeyRegistry) generateKey(ctx context.Context, validFor time.Duration, 
 	if err := kr.registerNewKey(generatedName, key, cert, time.Now()); err != nil {
 		return "", err
 	}
-	log.Infof("New key written to %s/%s\n", kr.namespace, generatedName)
-	log.Infof("Certificate is \n%s\n", pem.EncodeToMemory(&pem.Block{Type: certUtil.CertificateBlockType, Bytes: cert.Raw}))
+	slog.Info("New key written", "namespace", kr.namespace, "name", generatedName)
+	slog.Info("Certificate generated", "certificate", pem.EncodeToMemory(&pem.Block{Type: certUtil.CertificateBlockType, Bytes: cert.Raw}))
 	return generatedName, nil
 }
 

--- a/pkg/controller/main.go
+++ b/pkg/controller/main.go
@@ -26,7 +26,6 @@ import (
 	"github.com/bitnami-labs/sealed-secrets/pkg/client/clientset/versioned"
 	sealedsecrets "github.com/bitnami-labs/sealed-secrets/pkg/client/clientset/versioned"
 	ssinformers "github.com/bitnami-labs/sealed-secrets/pkg/client/informers/externalversions"
-	"github.com/bitnami-labs/sealed-secrets/pkg/log"
 )
 
 var (
@@ -125,7 +124,7 @@ func initKeyRenewal(ctx context.Context, registry *KeyRegistry, period, validFor
 	// wrapper function to log error thrown by generateKey function
 	keyGenFunc := func() {
 		if _, err := registry.generateKey(ctx, validFor, cn, privateKeyAnnotations, privateKeyLabels); err != nil {
-			slog.Error("Failed to generate new key : %v\n", err)
+			slog.Error("Failed to generate new key", "error", err)
 		}
 	}
 	if period == 0 {
@@ -144,18 +143,6 @@ func initKeyRenewal(ctx context.Context, registry *KeyRegistry, period, validFor
 
 func Main(f *Flags, version string) error {
 	registerMetrics(version)
-
-	// Set logging
-	logLevel := slog.Level(0)
-	(&logLevel).UnmarshalText([]byte(f.LogLevel))
-	opts := &slog.HandlerOptions{
-		Level: logLevel,
-	}
-	if f.LogInfoToStdout {
-		slog.SetDefault(slog.New(log.New(os.Stdout, os.Stderr, f.LogFormat, opts)))
-	} else {
-		slog.SetDefault(slog.New(log.New(os.Stderr, os.Stderr, f.LogFormat, opts)))
-	}
 
 	config, err := rest.InClusterConfig()
 	if err != nil {
@@ -244,7 +231,7 @@ func Main(f *Flags, version string) error {
 				}
 				ctlr.oldGCBehavior = f.OldGCBehavior
 				ctlr.updateStatus = f.UpdateStatus
-				slog.Info("Starting informer for namespace", "namespace", ns)
+				slog.Info("Starting informer", "namespace", ns)
 				go ctlr.Run(stop)
 			}
 		}

--- a/pkg/controller/server.go
+++ b/pkg/controller/server.go
@@ -72,14 +72,14 @@ func httpserver(cp certProvider, sc secretChecker, sr secretRotator, burst int, 
 	mux.Handle("/v1/rotate", Instrument("/v1/rotate", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		content, err := io.ReadAll(r.Body)
 		if err != nil {
-			slog.Error("Error handling /v1/rotate request: %v", err)
+			slog.Error("Error handling /v1/rotate request", "error", err)
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 
 		newSecret, err := sr(content)
 		if err != nil {
-			slog.Error("Error rotating secret: %v", err)
+			slog.Error("Error rotating secret", "error", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
@@ -92,7 +92,7 @@ func httpserver(cp certProvider, sc secretChecker, sr secretRotator, burst int, 
 	mux.Handle("/v1/cert.pem", Instrument("/v1/cert.pem", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		certs, err := cp()
 		if err != nil {
-			slog.Error("cannot get certificates: %v", err)
+			slog.Error("cannot get certificates", "error", err)
 			http.Error(w, "cannot get certificate", http.StatusInternalServerError)
 			return
 		}
@@ -114,7 +114,7 @@ func httpserver(cp certProvider, sc secretChecker, sr secretRotator, burst int, 
 	slog.Info("HTTP server serving", "addr", server.Addr)
 	go func() {
 		err := server.ListenAndServe()
-		slog.Error("HTTP server exiting: %v", err)
+		slog.Error("HTTP server exiting", "error", err)
 	}()
 	return &server
 }
@@ -134,7 +134,7 @@ func httpserverMetrics() *http.Server {
 	slog.Info("HTTP metrics server serving", "addr", server.Addr)
 	go func() {
 		err := server.ListenAndServe()
-		slog.Error("HTTP metrics server exiting: %v", err)
+		slog.Error("HTTP metrics server exiting", "error", err)
 	}()
 	return &server
 }

--- a/pkg/controller/server.go
+++ b/pkg/controller/server.go
@@ -49,14 +49,14 @@ func httpserver(cp certProvider, sc secretChecker, sr secretRotator, burst int, 
 	mux.Handle("/v1/verify", Instrument("/v1/verify", httpRateLimiter.RateLimit(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		content, err := io.ReadAll(r.Body)
 		if err != nil {
-			slog.Error("Error handling /v1/verify request: %v", err)
+			slog.Error("Error handling /v1/verify request", "error", err)
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 
 		valid, err := sc(content)
 		if err != nil {
-			slog.Error("Error validating secret: %v", err)
+			slog.Error("Error validating secret", "error", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}


### PR DESCRIPTION
**Description of the change**

Change controller logging to use `log/slog`.

**Benefits**

1. Allow structured logging.
2. Allow changing logging format between text and JSON.
3. Allow changing logging level.

**Possible drawbacks**

N/A

**Applicable issues**

- fixes #1285 

**Additional information**

* I took the liberty of removing log at line 91 in pkg/controller/main.go as it only served as a separator
* To implement the functionality of `--log-info-to-stdout`, I had to implement a custom handler that would hand logs down to one of two slog.Loggers in place of the package in `pkg/log` that handled this previously
