### PR TITLE
[helm] add rbac.proxier config

### DIFF
--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -79,6 +79,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `extraDeploy`       | Array of extra objects to deploy with the release       | `[]`  |
 | `commonAnnotations` | Annotations to add to all deployed resources            | `{}`  |
 | `commonLabels`      | Labels to add to all deployed resources                 | `{}`  |
+| `rbac.proxier`      | Configure who is able to access the SealedSecrets service. This may have security implications so the options should be reviewed carefully. | See [Other Parameters](#other-parameters) |
 
 ### Sealed Secrets Parameters
 
@@ -190,7 +191,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `rbac.pspEnabled`            | PodSecurityPolicy                                                                                        | `false`            |
 | `rbac.proxier.create`        | Specifies whether to create the "proxier" role, to allow access the SealedSecret API                     | `true`             |
 | `rbac.proxier.bind`          | Specifies whether to create a RoleBinding for the "proxier" role                                         | `true`             |
-| `rbac.proxier.subjects`      | Specifies the Subjects to grant the "proxier" role to, in the created RoleBinding                        | `[{"apiGroup": "rbac.authorization.k8s.io", "kind": "Group", "name": "system:authenticated"}]` |
+| `rbac.proxier.subjects`      | Specifies the Subjects to grant the "proxier" role to, in the created RoleBinding. Using this chart's default value that grants access to the `system:authenticated` group is [discouraged in GKE][gkebp] | `[{"apiGroup": "rbac.authorization.k8s.io", "kind": "Group", "name": "system:authenticated"}]` |
+
+[gkebp]: https://cloud.google.com/kubernetes-engine/docs/best-practices/rbac#default-roles-groups
 
 ### Metrics parameters
 

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -191,7 +191,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `rbac.pspEnabled`            | PodSecurityPolicy                                                                                        | `false`            |
 | `rbac.serviceProxier.create` | Specifies whether to create the "service proxier" role, to allow access to the SealedSecret API          | `true`             |
 | `rbac.serviceProxier.bind`   | Specifies whether to create a RoleBinding for the "service proxier" role                                 | `true`             |
-| `rbac.serviceProxier.subjects` | Specifies the Subjects to grant the "service proxier" role to, in the created RoleBinding. Using this chart's default value that grants access to the `system:authenticated` group is [discouraged in GKE][gkebp] | `[{"apiGroup": "rbac.authorization.k8s.io", "kind": "Group", "name": "system:authenticated"}]` |
+| `rbac.serviceProxier.subjects` | Specifies the Subjects to grant the "service proxier" role to, in the created RoleBinding. Using this chart's default value that grants access to the `system:authenticated` group is [discouraged in GKE][gkebp] | `"[{"apiGroup": "rbac.authorization.k8s.io", "kind": "Group", "name": "system:authenticated"}]"` |
 
 [gkebp]: https://cloud.google.com/kubernetes-engine/docs/best-practices/rbac#default-roles-groups
 

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -79,7 +79,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `extraDeploy`       | Array of extra objects to deploy with the release       | `[]`  |
 | `commonAnnotations` | Annotations to add to all deployed resources            | `{}`  |
 | `commonLabels`      | Labels to add to all deployed resources                 | `{}`  |
-| `rbac.proxier`      | Configure who is able to access the SealedSecrets service. This may have security implications so the options should be reviewed carefully. | See [Other Parameters](#other-parameters) |
+| `rbac.serviceProxier`      | Configure who is able to access the SealedSecrets service. This may have security implications so the options should be reviewed carefully. | See [Other Parameters](#other-parameters) |
 
 ### Sealed Secrets Parameters
 
@@ -189,9 +189,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `rbac.namespacedRolesName`   | Specifies the name for the namesapced Role resource                                                      | `secrets-unsealer` |
 | `rbac.labels`                | Extra labels to be added to RBAC resources                                                               | `{}`               |
 | `rbac.pspEnabled`            | PodSecurityPolicy                                                                                        | `false`            |
-| `rbac.proxier.create`        | Specifies whether to create the "proxier" role, to allow access the SealedSecret API                     | `true`             |
-| `rbac.proxier.bind`          | Specifies whether to create a RoleBinding for the "proxier" role                                         | `true`             |
-| `rbac.proxier.subjects`      | Specifies the Subjects to grant the "proxier" role to, in the created RoleBinding. Using this chart's default value that grants access to the `system:authenticated` group is [discouraged in GKE][gkebp] | `[{"apiGroup": "rbac.authorization.k8s.io", "kind": "Group", "name": "system:authenticated"}]` |
+| `rbac.serviceProxier.create` | Specifies whether to create the "service proxier" role, to allow access to the SealedSecret API          | `true`             |
+| `rbac.serviceProxier.bind`   | Specifies whether to create a RoleBinding for the "service proxier" role                                 | `true`             |
+| `rbac.serviceProxier.subjects` | Specifies the Subjects to grant the "service proxier" role to, in the created RoleBinding. Using this chart's default value that grants access to the `system:authenticated` group is [discouraged in GKE][gkebp] | `[{"apiGroup": "rbac.authorization.k8s.io", "kind": "Group", "name": "system:authenticated"}]` |
 
 [gkebp]: https://cloud.google.com/kubernetes-engine/docs/best-practices/rbac#default-roles-groups
 

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -188,6 +188,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `rbac.namespacedRolesName`   | Specifies the name for the namesapced Role resource                                                      | `secrets-unsealer` |
 | `rbac.labels`                | Extra labels to be added to RBAC resources                                                               | `{}`               |
 | `rbac.pspEnabled`            | PodSecurityPolicy                                                                                        | `false`            |
+| `rbac.proxier.create`        | Specifies whether to create the "proxier" role, to allow access the SealedSecret API                     | `true`             |
+| `rbac.proxier.bind`          | Specifies whether to create a RoleBinding for the "proxier" role                                         | `true`             |
+| `rbac.proxier.subjects`      | Specifies the Subjects to grant the "proxier" role to, in the created RoleBinding                        | `[{"apiGroup": "rbac.authorization.k8s.io", "kind": "Group", "name": "system:authenticated"}]` |
 
 ### Metrics parameters
 

--- a/helm/sealed-secrets/templates/role-binding.yaml
+++ b/helm/sealed-secrets/templates/role-binding.yaml
@@ -40,14 +40,7 @@ roleRef:
   kind: Role
   name: {{ printf "%s-service-proxier" (include "sealed-secrets.fullname" .) }}
 subjects:
-  {{- range .Values.rbac.serviceProxier.subjects }}
-  - apiGroup: {{ .apiGroup | default "rbac.authorization.k8s.io" | quote }}
-    kind: {{ quote .kind }}
-    name: {{ quote .name }}
-    {{- with .namespace }}
-    namespace: {{ quote . }}
-    {{- end }}
-  {{- end }}
+  {{- include "sealed-secrets.render" (dict "value" .Values.rbac.serviceProxier.subjects "context" $) | nindent 2 }}
 ---
 {{ end }}
 {{ if and (and .Values.rbac.create .Values.rbac.namespacedRoles) (not $.Values.rbac.clusterRole) }}

--- a/helm/sealed-secrets/templates/role-binding.yaml
+++ b/helm/sealed-secrets/templates/role-binding.yaml
@@ -41,9 +41,9 @@ roleRef:
   name: {{ printf "%s-service-proxier" (include "sealed-secrets.fullname" .) }}
 subjects:
   {{- range .Values.rbac.proxier.subjects }}
-  - apiGroup: {{- .apiGroup | default "rbac.authorization.k8s.io" | quote }}
-    kind: {{- quote .kind }}
-    name: {{- quote .name }}
+  - apiGroup: {{ .apiGroup | default "rbac.authorization.k8s.io" | quote }}
+    kind: {{ quote .kind }}
+    name: {{ quote .name }}
     {{- with .namespace }}
     namespace: {{ quote . }}
     {{- end }}

--- a/helm/sealed-secrets/templates/role-binding.yaml
+++ b/helm/sealed-secrets/templates/role-binding.yaml
@@ -22,7 +22,7 @@ subjects:
     namespace: {{ include "sealed-secrets.namespace" . }}
 ---
 {{ end }}
-{{ if and (and .Values.rbac.create .Values.rbac.proxier.create) .Values.rbac.proxier.bind }}
+{{ if and (and .Values.rbac.create .Values.rbac.serviceProxier.create) .Values.rbac.serviceProxier.bind }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -40,7 +40,7 @@ roleRef:
   kind: Role
   name: {{ printf "%s-service-proxier" (include "sealed-secrets.fullname" .) }}
 subjects:
-  {{- range .Values.rbac.proxier.subjects }}
+  {{- range .Values.rbac.serviceProxier.subjects }}
   - apiGroup: {{ .apiGroup | default "rbac.authorization.k8s.io" | quote }}
     kind: {{ quote .kind }}
     name: {{ quote .name }}

--- a/helm/sealed-secrets/templates/role-binding.yaml
+++ b/helm/sealed-secrets/templates/role-binding.yaml
@@ -21,6 +21,8 @@ subjects:
     name: {{ include "sealed-secrets.serviceAccountName" . }}
     namespace: {{ include "sealed-secrets.namespace" . }}
 ---
+{{ end }}
+{{ if and (and .Values.rbac.create .Values.rbac.proxier.create) .Values.rbac.proxier.bind }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -38,11 +40,16 @@ roleRef:
   kind: Role
   name: {{ printf "%s-service-proxier" (include "sealed-secrets.fullname" .) }}
 subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: system:authenticated
-{{ end }}
+  {{- range .Values.rbac.proxier.subjects }}
+  - apiGroup: {{- .apiGroup | default "rbac.authorization.k8s.io" | quote }}
+    kind: {{- quote .kind }}
+    name: {{- quote .name }}
+    {{- with .namespace }}
+    namespace: {{ quote . }}
+    {{- end }}
+  {{- end }}
 ---
+{{ end }}
 {{ if and (and .Values.rbac.create .Values.rbac.namespacedRoles) (not $.Values.rbac.clusterRole) }}
   {{- range $additionalNamespace := $.Values.additionalNamespaces }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/sealed-secrets/templates/role.yaml
+++ b/helm/sealed-secrets/templates/role.yaml
@@ -28,6 +28,8 @@ rules:
       - create
       - list
 ---
+{{- end }}
+{{- if and .Values.rbac.create .Values.rbac.proxier.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -60,8 +62,8 @@ rules:
     verbs:
       - create
       - get
-{{ end }}
 ---
+{{- end }}
 {{ if and (and .Values.rbac.create .Values.rbac.namespacedRoles) (not $.Values.rbac.clusterRole) }}
   {{- range $additionalNamespace := $.Values.additionalNamespaces }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/sealed-secrets/templates/role.yaml
+++ b/helm/sealed-secrets/templates/role.yaml
@@ -29,7 +29,7 @@ rules:
       - list
 ---
 {{- end }}
-{{- if and .Values.rbac.create .Values.rbac.proxier.create }}
+{{- if and .Values.rbac.create .Values.rbac.serviceProxier.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -406,7 +406,7 @@ rbac:
   pspEnabled: false
   ## "Proxier" RBAC Role configuration
   ##
-  proxier:
+  serviceProxier:
     ## @param create Specifies whether to create the "proxier" role, to allow external users to access the SealedSecret API
     ##
     create: true

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -416,7 +416,7 @@ rbac:
     ## @param subjects Specifies the RBAC subjects to grant the "proxier" role to, in the created RoleBinding
     ## It is best to change this to something narrower, as the default binding gives `system:authenticated` access, which is very broad
     ##
-    subjects:
+    subjects: |
       - apiGroup: rbac.authorization.k8s.io
         kind: Group
         name: system:authenticated

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -404,6 +404,22 @@ rbac:
   ## @param rbac.pspEnabled PodSecurityPolicy
   ##
   pspEnabled: false
+  ## "Proxier" RBAC Role configuration
+  ##
+  proxier:
+    ## @param create Specifies whether to create the "proxier" role, to allow external users to access the SealedSecret API
+    ##
+    create: true
+    ## @param bind Specifies whether to create a RoleBinding for the "proxier" role
+    ##
+    bind: true
+    ## @param subjects Specifies the RBAC subjects to grant the "proxier" role to, in the created RoleBinding
+    ## It is best to change this to something narrower, as the default binding gives `system:authenticated` access, which is very broad
+    ##
+    subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:authenticated
 
 ## @section Metrics parameters
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add options to the Helm chart to configure the `proxier` Role, and its RoleBinding.

**Benefits**

This allows the user to override the default RoleBinding that grants `system:authenticated` the `proxier` role. `system:authenticated` is not a very safe option in a lot of clusters, so it's important to expose this option.

**Possible drawbacks**

This was written to preserve existing behavior by default, so as to not break compatibility. This isn't ideal as the existing behavior is insecure on GKE (and possibly other contexts as well), but since it doesn't directly expose anything damaging (but rather is a defense-in-depth measure), it's probably OK to just highlight the importance of changing this in the documentation.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- partially addresses #1448

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
