### PR TITLE
Offline sealedsecret validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,7 +298,7 @@ jobs:
 
     - name: Testing environment setup
       run: |
-        helm install sealed-secrets -n kube-system --set fullnameOverride=sealed-secrets-controller --set image.registry=$controller_registry --set image.repository=$controller_repository --set image.tag=$controller_tag --set image.pullPolicy=Never helm/sealed-secrets
+        helm install sealed-secrets -n kube-system --set enableOfflineValidation=true --set fullnameOverride=sealed-secrets-controller --set image.registry=$controller_registry --set image.repository=$controller_repository --set image.tag=$controller_tag --set image.pullPolicy=Never helm/sealed-secrets
         kubectl rollout status deployment/sealed-secrets-controller -n kube-system -w --timeout=1m || kubectl -n kube-system describe pod -lapp.kubernetes.io/name=sealed-secrets
 
     - name: Integration tests

--- a/README.md
+++ b/README.md
@@ -551,6 +551,8 @@ metadata:
 
 ### Validate a Sealed Secret
 
+#### Online validation
+
 If you want to validate an existing sealed secret, `kubeseal` has the flag `--validate` to help you.
 
 Giving a file named `sealed-secrets.yaml` containing the following sealed secret:
@@ -578,6 +580,12 @@ In case of an invalid sealed secret, `kubeseal` will show:
 $ cat sealed-secrets.yaml | kubeseal --validate
 error: unable to decrypt sealed secret
 ```
+
+#### Offline validation
+
+If you need to validate sealed secret values but cannot access the cluster, you can use the `--add-offline-validation-data` flag when sealing secrets, this will add extra validation data to your sealedsecret values.
+
+You can then validate those values without cluster access using `kubeseal --validate-offline`
 
 ## Secret Rotation
 

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -56,6 +56,10 @@ func bindControllerFlags(f *controller.Flags, fs *flag.FlagSet) {
 	fs.StringVar(&f.LogLevel, "log-level", "INFO", "Log level (INFO|ERROR).")
 	fs.StringVar(&f.LogFormat, "log-format", "text", "Log format (text|json).")
 
+	fs.StringVar(&f.UUIDConfigMapName, "uuid-configmap-name", "sealed-secrets-controller-id", "ConfigMap name for storing controller UUID.")
+	fs.StringVar(&f.UUIDConfigMapAnnotations, "uuid-configmap-annotations", "", "Comma-separated list of additional annotations to be put on controller UUID configmap.")
+	fs.StringVar(&f.UUIDConfigMapLabels, "uuid-configmap-labels", "", "Comma-separated list of additional labels to be put on controller UUID configmap.")
+
 	fs.DurationVar(&f.KeyRenewPeriod, "rotate-period", defaultKeyRenewPeriod, "")
 	_ = fs.MarkDeprecated("rotate-period", "please use key-renew-period instead")
 }

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -49,6 +49,7 @@ func bindControllerFlags(f *controller.Flags, fs *flag.FlagSet) {
 	fs.BoolVar(&f.OldGCBehavior, "old-gc-behavior", false, "Revert to old GC behavior where the controller deletes secrets instead of delegating that to k8s itself.")
 
 	fs.BoolVar(&f.UpdateStatus, "update-status", true, "beta: if true, the controller will update the status sub-resource whenever it processes a sealed secret")
+	fs.BoolVar(&f.AddOfflineValidationData, "add-offline-validation-data", false, "beta: if true, the controller will add validation data needed for offline validation whenever it encrypts a sealedsecret.")
 
 	fs.BoolVar(&f.SkipRecreate, "skip-recreate", false, "if true the controller will skip listening for managed secret changes to recreate them. This helps on limited permission environments.")
 

--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -230,9 +230,13 @@ func runCLI(w io.Writer, cfg *config) (err error) {
 
 	var controllerUUID string
 	if flags.addOfflineValidationData {
-		controllerUUID, err = kubeseal.ReadControllerUUID(cfg.ctx, cfg.clientConfig, flags.controllerNs, flags.uuidConfigmapName)
-		if err != nil {
-			return err
+		if flags.controllerUUID == "" {
+			controllerUUID, err = kubeseal.ReadControllerUUID(cfg.ctx, cfg.clientConfig, flags.controllerNs, flags.uuidConfigmapName)
+			if err != nil {
+				return err
+			}
+		} else {
+			controllerUUID = flags.controllerUUID
 		}
 	}
 

--- a/controller-norbac.jsonnet
+++ b/controller-norbac.jsonnet
@@ -66,6 +66,7 @@ local namespace = 'kube-system';
               image: $.controllerImage,
               imagePullPolicy: $.imagePullPolicy,
               command: ['controller'],
+              args: ['--add-offline-validation-data'],
               readinessProbe: {
                 httpGet: { path: '/healthz', port: 'http' },
               },

--- a/controller.jsonnet
+++ b/controller.jsonnet
@@ -46,6 +46,12 @@ controller {
         // Can't limit create by resource name as keys are produced on the fly
         verbs: ['create', 'list'],
       },
+      {
+        apiGroups: [''],
+        resources: ['configmaps'],
+        // Can't limit create by resource name as keys are produced on the fly
+        verbs: ['create', 'list'],
+      },
     ],
   },
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.21.5
 require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/renameio v0.1.0
+	github.com/google/uuid v1.5.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mkmik/multierror v0.4.0
 	github.com/onsi/ginkgo/v2 v2.15.0
@@ -43,7 +44,6 @@ require (
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
-	github.com/google/uuid v1.5.0 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -100,6 +100,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `additionalNamespaces`                            | List of namespaces used to manage the Sealed Secrets                                                  | `[]`                                |
 | `privateKeyAnnotations`                           | Map of annotations to be set on the sealing keypairs                                                  | `{}`                                |
 | `privateKeyLabels`                                | Map of labels to be set on the sealing keypairs                                                       | `{}`                                |
+| `uuidConfigMapAnnotations`                        | Map of annotations to be set on the configmap storing controller UUID                                 | `{}`                                |
+| `uuidConfigMapLabels`                             | Map of labels to be set on the configmap storing controller UUID                                      | `{}`                                |
+| `enableOfflineValidation`                         | Feature flag for offline validation feature                                                           | `false`                             |
+| `uuidConfigmapName`                               | The name of the configmap to contain the controller UUID                                              | `sealed-secrets-controller-id`      |
 | `logInfoStdout`                                   | Specifies whether the Sealed Secrets controller will log info to stdout                               | `false`                             |
 | `logLevel`                                   | Specifies log level of controller (INFO,ERROR)                               | `""`                             |
 | `logFormat`                                   | Specifies log format (text,json)                               | `""`                             |

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -117,6 +117,32 @@ spec:
             - --privatekey-labels
             - {{ trimSuffix "," $privateKeyLabels | quote }}
             {{- end }}
+            {{- if $.Values.uuidConfigMapName }}
+            - --uuid-configmap-name
+            - {{ .Values.uuidConfigMapName | quote }}
+            {{- end }}
+            {{- if $.Values.uuidConfigMapAnnotations }}
+            {{- $uuidConfigmapAnnotations := ""}}
+            {{- range $k, $v := $.Values.uuidConfigMapAnnotations }}
+              {{- if not (and $v (kindIs "string" $v)) }}
+                {{ fail "Annotation values have to be strings"}}
+              {{- end }}
+              {{- $uuidConfigmapAnnotations = printf "%s=%s,%s" $k $v $uuidConfigmapAnnotations}}
+            {{- end }}
+            - --uuid-configmap-annotations
+            - {{ trimSuffix "," $uuidConfigmapAnnotations | quote }}
+            {{- end }}            
+            {{- if $.Values.uuidConfigMapLabels }}
+            {{- $uuidConfigMapLabels := ""}}
+            {{- range $k, $v := $.Values.uuidConfigMapLabels }}
+              {{- if not (and $v (kindIs "string" $v)) }}
+                {{ fail "Label values have to be strings"}}
+              {{- end }}
+              {{- $uuidConfigMapLabels = printf "%s=%s,%s" $k $v $uuidConfigMapLabels}}
+            {{- end }}
+            - --uuid-configmap-labels
+            - {{ trimSuffix "," $uuidConfigMapLabels | quote }}
+            {{- end }}
             {{- if .Values.logInfoStdout }}
             - --log-info-stdout
             {{- end }}

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -154,6 +154,9 @@ spec:
             - --log-format
             - {{ .Values.logFormat }}
             {{- end }}
+            {{- if .Values.enableOfflineValidation }}
+            - --add-offline-validation-data
+            {{- end }}
           {{- end }}
           image: {{ printf "%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/helm/sealed-secrets/templates/role.yaml
+++ b/helm/sealed-secrets/templates/role.yaml
@@ -20,6 +20,7 @@ rules:
       - secrets
     verbs:
       - get
+  {{- if .Values.enableOfflineValidation }}
   - apiGroups:
       - ""
     resourceNames:
@@ -28,11 +29,14 @@ rules:
       - configmaps
     verbs:
       - get
+  {{- end }}
   - apiGroups:
       - ""
     resources:
       - secrets
+  {{- if .Values.enableOfflineValidation }}
       - configmaps
+  {{- end }}
     verbs:
       - create
       - list

--- a/helm/sealed-secrets/templates/role.yaml
+++ b/helm/sealed-secrets/templates/role.yaml
@@ -22,8 +22,17 @@ rules:
       - get
   - apiGroups:
       - ""
+    resourceNames:
+      - {{ .Values.uuidConfigMapName }}
+    resources:
+      - configmaps
+    verbs:
+      - get
+  - apiGroups:
+      - ""
     resources:
       - secrets
+      - configmaps
     verbs:
       - create
       - list

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -62,6 +62,9 @@ createController: true
 ## @param secretName The name of an existing TLS secret containing the key used to encrypt secrets
 ##
 secretName: "sealed-secrets-key"
+## @param uuidConfigmapName The name of the configmap to contain the controller UUID
+##
+uuidConfigMapName: "sealed-secrets-controller-id"
 ## @param updateStatus Specifies whether the Sealed Secrets controller should update the status subresource
 ##
 updateStatus: true
@@ -91,6 +94,12 @@ privateKeyAnnotations: {}
 ## @param privateKeyLabels Map of labels to be set on the sealing keypairs
 ## 
 privateKeyLabels: {}
+## @param uuidConfigMapAnnotations Map of annotations to be set on the configmap storing controller UUID
+## 
+uuidConfigMapAnnotations: {}
+## @param uuidConfigMapLabels Map of labels to be set on the configmap storing controller UUID
+## 
+uuidConfigMapLabels: {}
 ## @param logInfoStdout Specifies whether the Sealed Secrets controller will log info to stdout
 ##
 logInfoStdout: false

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -100,6 +100,9 @@ uuidConfigMapAnnotations: {}
 ## @param uuidConfigMapLabels Map of labels to be set on the configmap storing controller UUID
 ## 
 uuidConfigMapLabels: {}
+## @param enableOfflineValidation Feature flag for offline validation feature
+## 
+enableOfflineValidation: false
 ## @param logInfoStdout Specifies whether the Sealed Secrets controller will log info to stdout
 ##
 logInfoStdout: false

--- a/integration/controller_test.go
+++ b/integration/controller_test.go
@@ -176,7 +176,7 @@ var _ = Describe("create", func() {
 		pubKey = certs[0].PublicKey.(*rsa.PublicKey)
 
 		fmt.Fprintf(GinkgoWriter, "Sealing Secret %#v\n", s)
-		ss, err = ssv1alpha1.NewSealedSecret(scheme.Codecs, pubKey, s)
+		ss, err = ssv1alpha1.NewSealedSecret(scheme.Codecs, pubKey, s, "", false)
 		Expect(err).NotTo(HaveOccurred())
 	})
 	AfterEach(func() {
@@ -229,7 +229,7 @@ var _ = Describe("create", func() {
 
 				// update
 				s.Data["foo"] = []byte("baz")
-				ss, err = ssv1alpha1.NewSealedSecret(scheme.Codecs, pubKey, s)
+				ss, err = ssv1alpha1.NewSealedSecret(scheme.Codecs, pubKey, s, "", false)
 				Expect(err).NotTo(HaveOccurred())
 				ss.ResourceVersion = resVer
 
@@ -547,7 +547,7 @@ var _ = Describe("create", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			fmt.Fprintf(GinkgoWriter, "Resealing with wrong key\n")
-			ss, err = ssv1alpha1.NewSealedSecret(scheme.Codecs, &wrongKey.PublicKey, s)
+			ss, err = ssv1alpha1.NewSealedSecret(scheme.Codecs, &wrongKey.PublicKey, s, "", false)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -644,7 +644,7 @@ var _ = Describe("create", func() {
 
 			// update
 			s.Data["foo"] = []byte("baz")
-			ss, err = ssv1alpha1.NewSealedSecret(scheme.Codecs, pubKey, s)
+			ss, err = ssv1alpha1.NewSealedSecret(scheme.Codecs, pubKey, s, "", false)
 			Expect(err).NotTo(HaveOccurred())
 			ss.ResourceVersion = resVer
 
@@ -735,7 +735,7 @@ var _ = Describe("create", func() {
 				}
 
 				fmt.Fprintf(GinkgoWriter, "Re-sealing secret %#v\n", s)
-				ss, err = ssv1alpha1.NewSealedSecret(scheme.Codecs, pubKey, s)
+				ss, err = ssv1alpha1.NewSealedSecret(scheme.Codecs, pubKey, s, "", false)
 				Expect(err).NotTo(HaveOccurred())
 			})
 			BeforeEach(func() {
@@ -767,7 +767,7 @@ var _ = Describe("create", func() {
 				}
 
 				fmt.Fprintf(GinkgoWriter, "Re-sealing secret %#v\n", s)
-				ss, err = ssv1alpha1.NewSealedSecret(scheme.Codecs, pubKey, s)
+				ss, err = ssv1alpha1.NewSealedSecret(scheme.Codecs, pubKey, s, "", false)
 				ss.Namespace = ns2
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -797,7 +797,7 @@ var _ = Describe("create", func() {
 				}
 
 				fmt.Fprintf(GinkgoWriter, "Re-sealing secret %#v\n", s)
-				ss, err = ssv1alpha1.NewSealedSecret(scheme.Codecs, pubKey, s)
+				ss, err = ssv1alpha1.NewSealedSecret(scheme.Codecs, pubKey, s, "", false)
 				Expect(err).NotTo(HaveOccurred())
 			})
 			BeforeEach(func() {
@@ -826,7 +826,7 @@ var _ = Describe("create", func() {
 				}
 
 				fmt.Fprintf(GinkgoWriter, "Re-sealing secret %#v\n", s)
-				ss, err = ssv1alpha1.NewSealedSecret(scheme.Codecs, pubKey, s)
+				ss, err = ssv1alpha1.NewSealedSecret(scheme.Codecs, pubKey, s, "", false)
 				ss.Namespace = ns2
 				Expect(err).NotTo(HaveOccurred())
 			})

--- a/integration/kubeseal_test.go
+++ b/integration/kubeseal_test.go
@@ -124,6 +124,17 @@ var _ = Describe("kubeseal", func() {
 			args = append(args, "--add-offline-validation-data")
 		})
 
+		AfterEach(func() {
+			// Remove --add-offline-validation-data from args
+			var newArgs []string
+			for _, v := range args {
+				if v != "--add-offline-validation-data" {
+					newArgs = append(newArgs, v)
+				}
+			}
+			args = newArgs
+		})
+
 		It("should create secret as usual", func() {
 			s, err := ss.Unseal(scheme.Codecs, privKeys)
 			Expect(err).NotTo(HaveOccurred())

--- a/integration/kubeseal_test.go
+++ b/integration/kubeseal_test.go
@@ -117,6 +117,24 @@ var _ = Describe("kubeseal", func() {
 		})
 	})
 
+	Context("With --add-offline-validation-data", func() {
+		const testNs = "offlinevalns"
+		BeforeEach(func() {
+			input.Namespace = testNs
+			args = append(args, "--add-offline-validation-data")
+		})
+
+		It("should create secret as usual", func() {
+			s, err := ss.Unseal(scheme.Codecs, privKeys)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(s.Data).To(HaveKeyWithValue("foo", []byte("bar")))
+		})
+
+		It("should contain validation data", func() {
+			Expect(ss.Spec.EncryptedData["foo"]).To(ContainSubstring(";"))
+		})
+	})
+
 	Context("No input namespace", func() {
 		const testNs = "nons"
 

--- a/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_test.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_test.go
@@ -493,7 +493,7 @@ func TestSealMetadataPreservation(t *testing.T) {
 			},
 		}
 
-		ssecret, err := NewSealedSecret(codecs, &key.PublicKey, &secret)
+		ssecret, err := NewSealedSecret(codecs, &key.PublicKey, &secret, "", false)
 		if err != nil {
 			t.Fatalf("NewSealedSecret returned error: %v", err)
 		}
@@ -572,7 +572,7 @@ func TestRejectBothEncryptedDataAndDeprecatedV1Data(t *testing.T) {
 	}))
 }
 
-func sealSecret(t *testing.T, secret *v1.Secret, newSealedSecret func(serializer.CodecFactory, *rsa.PublicKey, *v1.Secret) (*SealedSecret, error)) (*SealedSecret, serializer.CodecFactory, map[string]*rsa.PrivateKey) {
+func sealSecret(t *testing.T, secret *v1.Secret, newSealedSecret func(serializer.CodecFactory, *rsa.PublicKey, *v1.Secret, string, bool) (*SealedSecret, error)) (*SealedSecret, serializer.CodecFactory, map[string]*rsa.PrivateKey) {
 	scheme := runtime.NewScheme()
 	codecs := serializer.NewCodecFactory(scheme)
 
@@ -581,7 +581,7 @@ func sealSecret(t *testing.T, secret *v1.Secret, newSealedSecret func(serializer
 
 	key, keys := generateTestKey(t, testRand(), 2048)
 
-	sealedSecret, err := newSealedSecret(codecs, &key.PublicKey, secret)
+	sealedSecret, err := newSealedSecret(codecs, &key.PublicKey, secret, "", false)
 	if err != nil {
 		t.Fatalf("NewSealedSecret returned error: %v", err)
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -71,13 +71,14 @@ type Controller struct {
 	ssclient    ssv1alpha1client.SealedSecretsGetter
 	recorder    record.EventRecorder
 	keyRegistry *KeyRegistry
+	uuid        string
 
 	oldGCBehavior bool // feature flag to revert to old behavior where we delete the secrets instead of relying on owners reference.
 	updateStatus  bool // feature flag that enables updating the status subresource.
 }
 
 // NewController returns the main sealed-secrets controller loop.
-func NewController(clientset kubernetes.Interface, ssclientset ssclientset.Interface, ssinformer ssinformer.SharedInformerFactory, sinformer informers.SharedInformerFactory, keyRegistry *KeyRegistry) (*Controller, error) {
+func NewController(clientset kubernetes.Interface, ssclientset ssclientset.Interface, ssinformer ssinformer.SharedInformerFactory, sinformer informers.SharedInformerFactory, keyRegistry *KeyRegistry, uuid string) (*Controller, error) {
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 
 	utilruntime.Must(ssscheme.AddToScheme(scheme.Scheme))
@@ -110,6 +111,7 @@ func NewController(clientset kubernetes.Interface, ssclientset ssclientset.Inter
 		ssclient:    ssclientset.BitnamiV1alpha1(),
 		recorder:    recorder,
 		keyRegistry: keyRegistry,
+		uuid:        uuid,
 	}, nil
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -73,8 +73,9 @@ type Controller struct {
 	keyRegistry *KeyRegistry
 	uuid        string
 
-	oldGCBehavior bool // feature flag to revert to old behavior where we delete the secrets instead of relying on owners reference.
-	updateStatus  bool // feature flag that enables updating the status subresource.
+	addOfflineValidationData bool // feature flag that enables adding offline validation data to sealed secret entries.
+	oldGCBehavior            bool // feature flag to revert to old behavior where we delete the secrets instead of relying on owners reference.
+	updateStatus             bool // feature flag that enables updating the status subresource.
 }
 
 // NewController returns the main sealed-secrets controller loop.
@@ -530,7 +531,7 @@ func (c *Controller) Rotate(content []byte) ([]byte, error) {
 			return nil, fmt.Errorf("error decrypting secret. %v", err)
 		}
 		latestPrivKey := c.keyRegistry.latestPrivateKey()
-		resealedSecret, err := ssv1alpha1.NewSealedSecret(scheme.Codecs, &latestPrivKey.PublicKey, secret)
+		resealedSecret, err := ssv1alpha1.NewSealedSecret(scheme.Codecs, &latestPrivKey.PublicKey, secret, c.uuid, c.addOfflineValidationData)
 		if err != nil {
 			return nil, fmt.Errorf("error creating new sealed secret. %v", err)
 		}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -125,7 +125,7 @@ func TestDefaultConfigDoesNotSkipRecreate(t *testing.T) {
 	ssc := ssfake.NewSimpleClientset()
 	keyRegistry := testKeyRegister(t, context.Background(), clientset, ns)
 
-	got, err := prepareController(clientset, ns, tweakopts, &Flags{SkipRecreate: false}, ssc, keyRegistry)
+	got, err := prepareController(clientset, ns, tweakopts, &Flags{SkipRecreate: false}, ssc, keyRegistry, "")
 	if err != nil {
 		t.Fatalf("err %v want %v", got, nil)
 	}
@@ -144,7 +144,7 @@ func TestSkipRecreateConfigDoesSkipIt(t *testing.T) {
 	ssc := ssfake.NewSimpleClientset()
 	keyRegistry := testKeyRegister(t, context.Background(), clientset, ns)
 
-	got, err := prepareController(clientset, ns, tweakopts, &Flags{SkipRecreate: true}, ssc, keyRegistry)
+	got, err := prepareController(clientset, ns, tweakopts, &Flags{SkipRecreate: true}, ssc, keyRegistry, "")
 	if err != nil {
 		t.Fatalf("err %v want %v", got, nil)
 	}

--- a/pkg/controller/main.go
+++ b/pkg/controller/main.go
@@ -55,6 +55,7 @@ type Flags struct {
 	RateLimitBurst           int
 	OldGCBehavior            bool
 	UpdateStatus             bool
+	AddOfflineValidationData bool
 	SkipRecreate             bool
 	LogInfoToStdout          bool
 	LogLevel                 string
@@ -306,6 +307,7 @@ func Main(f *Flags, version string) error {
 	}
 	controller.oldGCBehavior = f.OldGCBehavior
 	controller.updateStatus = f.UpdateStatus
+	controller.addOfflineValidationData = f.AddOfflineValidationData
 
 	stop := make(chan struct{})
 	defer close(stop)

--- a/pkg/kubeseal/kubeseal.go
+++ b/pkg/kubeseal/kubeseal.go
@@ -313,7 +313,6 @@ func ValidateSealedSecretOffline(in io.Reader, controllerUUID string) error {
 			if validationData["uuid"] != controllerUUID {
 				return fmt.Errorf("validation error: controller uuid doesn't match in sealedsecret %s field %s", secret.GetName(), k)
 			}
-
 		}
 	}
 

--- a/pkg/kubeseal/kubeseal.go
+++ b/pkg/kubeseal/kubeseal.go
@@ -287,7 +287,7 @@ func ValidateSealedSecretOffline(in io.Reader, controllerUUID string) error {
 	for _, secret := range secrets {
 		for k, v := range secret.Spec.EncryptedData {
 			if !strings.Contains(v, ";") {
-				// For backward compatability, skip secret values that don't include validation separator
+				// For backward compatibility, skip secret values that don't include validation separator
 				fmt.Printf("Skipping field %s in sealedsecret %s: no offline validation data.", k, secret.GetName())
 				continue
 			}

--- a/pkg/kubeseal/kubeseal_test.go
+++ b/pkg/kubeseal/kubeseal_test.go
@@ -223,7 +223,7 @@ func TestSealWithMultiDocSecrets(t *testing.T) {
 			t.Logf("input is:\n%s", inbuf.String())
 
 			outbuf := bytes.Buffer{}
-			if err := Seal(clientConfig, outputFormat, &inbuf, &outbuf, scheme.Codecs, key, ssv1alpha1.NamespaceWideScope, false, "", ""); err != nil {
+			if err := Seal(clientConfig, outputFormat, &inbuf, &outbuf, scheme.Codecs, key, ssv1alpha1.NamespaceWideScope, false, false, "", "", ""); err != nil {
 				t.Fatalf("seal() returned error: %v", err)
 			}
 
@@ -447,7 +447,7 @@ func TestSeal(t *testing.T) {
 			t.Logf("input is: %s", inbuf.String())
 
 			outbuf := bytes.Buffer{}
-			if err := Seal(clientConfig, outputFormat, &inbuf, &outbuf, scheme.Codecs, key, tc.scope, false, "", ""); err != nil {
+			if err := Seal(clientConfig, outputFormat, &inbuf, &outbuf, scheme.Codecs, key, tc.scope, false, false, "", "", ""); err != nil {
 				t.Fatalf("seal() returned error: %v", err)
 			}
 
@@ -557,7 +557,7 @@ func mkTestSealedSecret(t *testing.T, pubKey *rsa.PublicKey, key, value string, 
 	outputFormat := "json"
 	inbuf := bytes.NewBuffer(mkTestSecret(t, key, value, opts...))
 	var outbuf bytes.Buffer
-	if err := Seal(clientConfig, outputFormat, inbuf, &outbuf, scheme.Codecs, pubKey, ssv1alpha1.DefaultScope, false, "", ""); err != nil {
+	if err := Seal(clientConfig, outputFormat, inbuf, &outbuf, scheme.Codecs, pubKey, ssv1alpha1.DefaultScope, false, false, "", "", ""); err != nil {
 		t.Fatalf("seal() returned error: %v", err)
 	}
 
@@ -702,7 +702,7 @@ func TestMergeInto(t *testing.T) {
 		f.Close()
 
 		buf := bytes.NewBuffer(newSecret)
-		if err := SealMergingInto(clientConfig, outputFormat, buf, f.Name(), scheme.Codecs, pubKey, ssv1alpha1.DefaultScope, false); err != nil {
+		if err := SealMergingInto(clientConfig, outputFormat, buf, f.Name(), scheme.Codecs, pubKey, ssv1alpha1.DefaultScope, false, false, ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -850,7 +850,7 @@ func sealTestItem(certFilename, secretNS, secretName, secretValue string, scope 
 		return "", err
 	}
 
-	if err := EncryptSecretItem(&buf, secretName, secretNS, []byte(secretValue), scope, pubKey); err != nil {
+	if err := EncryptSecretItem(&buf, secretName, secretNS, []byte(secretValue), scope, pubKey, false, ""); err != nil {
 		return "", err
 	}
 	return buf.String(), nil


### PR DESCRIPTION
**Description of the change**

1. Add a unique controller UUID that is generated on controller startup and saved in a configmap.
1. Add the ability to validate sealedsecrets offline through adding validation data preceding each sealedsecret in the form of `<base64ValidationDataJson>;<base64ActualSecret>`.
1. Add `kubeseal --validate-offline`

The JSON contains:
* Scope
* Secret Namespace
* Secret Name
* Controller UUID

**Benefits**

The ability to validate sealed secret values through offline CI.

**Possible drawbacks**

None that come to mind.

**Applicable issues**

- fixes #1444 

**Additional information**

* All changes tested on a local minikube installation.

