### PR TITLE
[helm] Check for ServiceMonitor apiVersion capabilities

### DIFF
--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -14,6 +14,6 @@ maintainers:
     url: https://github.com/bitnami-labs/sealed-secrets
 name: sealed-secrets
 type: application
-version: 2.14.2
+version: 2.14.3
 sources:
   - https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/templates/servicemonitor.yaml
+++ b/helm/sealed-secrets/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.metrics.serviceMonitor.enabled }}
+{{- if (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor") .Values.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/helm/sealed-secrets/templates/servicemonitor.yaml
+++ b/helm/sealed-secrets/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor") .Values.metrics.serviceMonitor.enabled }}
+{{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor") .Values.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
**Description of the change**

In an Kubernetes as a Service Environment the values.yaml for the sealed-secrets are predefined.
This means also that the Monitoring is enabled by default.
Enabling the ServiceMonitor and not have the kube-prometheus-stack in place leads to issues installing this chart.
The kube-prometheus-stack releates on some pre defined secrets thats why the sealed-secrets deployment is needed before the kube-prometheus-stack.
Also enabling and disabling this leads to some commits in an gitops approach way.
Thats why i would like to have this capabilities check in place. 

**Benefits**

The ServiceMonitor is not applyed unless the approappropriate crd is installed.

**Possible drawbacks**

helm template will not render the ServiceMonitor object if it does not know about this api capabilities or the --validate flag is not provided.
