### PR TITLE
fix: missing common annotations in the helm chart

### DIFF
--- a/helm/sealed-secrets/templates/cluster-role-binding.yaml
+++ b/helm/sealed-secrets/templates/cluster-role-binding.yaml
@@ -10,6 +10,10 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/helm/sealed-secrets/templates/cluster-role.yaml
+++ b/helm/sealed-secrets/templates/cluster-role.yaml
@@ -10,6 +10,10 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
 rules:
   - apiGroups:
       - bitnami.com

--- a/helm/sealed-secrets/templates/configmap-dashboards.yaml
+++ b/helm/sealed-secrets/templates/configmap-dashboards.yaml
@@ -18,6 +18,9 @@ metadata:
     {{- if $.Values.metrics.dashboards.annotations }}
     {{- include "sealed-secrets.render" ( dict "value" $.Values.metrics.dashboards.annotations "context" $) | nindent 4 }}
     {{- end }}
+    {{- if $.Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
 data:
   {{ base $path }}: |-
 {{ $.Files.Get $path | indent 4 }}

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -8,9 +8,10 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- toYaml .Values.commonAnnotations | nindent 4 }}
-  {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   replicas: 1
   {{- if .Values.revisionHistoryLimit }}

--- a/helm/sealed-secrets/templates/ingress.yaml
+++ b/helm/sealed-secrets/templates/ingress.yaml
@@ -8,12 +8,13 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
-  {{- if .Values.ingress.annotations }}
   annotations:
     {{- if .Values.ingress.annotations }}
     {{- include "sealed-secrets.render" ( dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
     {{- end }}
-  {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   {{- if and .Values.ingress.ingressClassName (eq "true" (include "sealed-secrets.supportsIngressClassname" .)) }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}

--- a/helm/sealed-secrets/templates/networkpolicy.yaml
+++ b/helm/sealed-secrets/templates/networkpolicy.yaml
@@ -8,6 +8,10 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   podSelector:
     matchLabels: {{- include "sealed-secrets.matchLabels" . | nindent 6 }}

--- a/helm/sealed-secrets/templates/pdb.yaml
+++ b/helm/sealed-secrets/templates/pdb.yaml
@@ -8,9 +8,10 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- toYaml .Values.commonAnnotations | nindent 4 }}
-  {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   {{- if regexMatch "64$" (typeOf .Values.pdb.minAvailable) }}
   minAvailable: {{ .Values.pdb.minAvailable }}

--- a/helm/sealed-secrets/templates/psp-clusterrole.yaml
+++ b/helm/sealed-secrets/templates/psp-clusterrole.yaml
@@ -10,6 +10,10 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
 rules:
   - apiGroups: ['extensions']
     resources: ['podsecuritypolicies']

--- a/helm/sealed-secrets/templates/psp-clusterrolebinding.yaml
+++ b/helm/sealed-secrets/templates/psp-clusterrolebinding.yaml
@@ -10,6 +10,10 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/helm/sealed-secrets/templates/psp.yaml
+++ b/helm/sealed-secrets/templates/psp.yaml
@@ -7,6 +7,10 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   privileged: false
   allowPrivilegeEscalation: false

--- a/helm/sealed-secrets/templates/role-binding.yaml
+++ b/helm/sealed-secrets/templates/role-binding.yaml
@@ -11,6 +11,10 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -35,6 +39,10 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -53,6 +61,10 @@ metadata:
   labels: {{- include "sealed-secrets.labels" $ | nindent 4 }}
     {{- if $.Values.rbac.labels }}
     {{- include "sealed-secrets.render" ( dict "value" $.Values.rbac.labels "context" $) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/helm/sealed-secrets/templates/role.yaml
+++ b/helm/sealed-secrets/templates/role.yaml
@@ -11,6 +11,10 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
 rules:
   - apiGroups:
       - ""

--- a/helm/sealed-secrets/templates/servicemonitor.yaml
+++ b/helm/sealed-secrets/templates/servicemonitor.yaml
@@ -15,9 +15,13 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
-  {{- if .Values.metrics.serviceMonitor.annotations }}
-  annotations: {{- include "sealed-secrets.render" (dict "value" .Values.metrics.serviceMonitor.annotations "context" $) | nindent 4 }}
-  {{- end }}
+  annotations:
+    {{- if .Values.metrics.serviceMonitor.annotations }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.metrics.serviceMonitor.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   endpoints:
     - port: metrics

--- a/helm/sealed-secrets/templates/tls-secret.yaml
+++ b/helm/sealed-secrets/templates/tls-secret.yaml
@@ -10,6 +10,10 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .certificate | b64enc }}
@@ -28,6 +32,10 @@ metadata:
   labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
 type: kubernetes.io/tls
 data:


### PR DESCRIPTION
**Description of the change**

Add common annotations to all resources in the helm chart as per the [documentation](https://github.com/bitnami-labs/sealed-secrets/blob/main/helm/sealed-secrets/values.yaml#L19):
`## @param commonAnnotations [object] Annotations to add to all deployed resources`

**Benefits**

Add common annotations to all resources in the helm chart as per the documentation

**Applicable issues**

- fixes #1372 

