### PR TITLE
Add metrics port to allow ingress traffic in the netpols

### DIFF
--- a/helm/sealed-secrets/templates/networkpolicy.yaml
+++ b/helm/sealed-secrets/templates/networkpolicy.yaml
@@ -14,6 +14,7 @@ spec:
   ingress:
     - ports:
       - port: {{ .Values.service.port }}
+      - port: {{ .Values.metrics.service.port }}
   {{- if .Values.networkPolicy.egress.enabled }}
   egress:
     - to:


### PR DESCRIPTION
**Description of the change**

Include metrics port to allow ingress traffics when the network policies are enabled.

**Benefits**

Allow metrics traffic

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #1469