### PR TITLE
fix: panic when patching empty secret

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -359,16 +359,24 @@ func (c *Controller) unseal(ctx context.Context, key string) (unsealErr error) {
 	secret = secret.DeepCopy()
 
 	if isAnnotatedToBePatched(secret) {
+		if secret.Data == nil {
+			secret.Data = make(map[string][]byte)
+		}
+
 		for k, v := range newSecret.Data {
 			secret.Data[k] = v
 		}
 
-		for k, v := range newSecret.ObjectMeta.Annotations {
-			secret.ObjectMeta.Annotations[k] = v
+		if secret.ObjectMeta.Labels == nil {
+			secret.ObjectMeta.Labels = make(map[string]string)
 		}
 
 		for k, v := range newSecret.ObjectMeta.Labels {
 			secret.ObjectMeta.Labels[k] = v
+		}
+
+		for k, v := range newSecret.ObjectMeta.Annotations {
+			secret.ObjectMeta.Annotations[k] = v
 		}
 
 		if isAnnotatedToBeManaged(secret) {


### PR DESCRIPTION
When patching an empty secret, i.e. one with no data field, the controller will panic as it's trying to assign to a nil map. Same will happen with the labels.

- Always initialize the Data and Labels maps if they are empty
- Add a test to cover this use case

fixes: #1282

