### PR TITLE
Modify LastUpdateTime when the Sealed Secrets is being updated

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -467,15 +467,11 @@ func updateSealedSecretsStatusConditions(st *ssv1alpha1.SealedSecretStatus, unse
 		cond.Message = unsealError.Error()
 	}
 
+	cond.LastUpdateTime = metav1.Now()
 	// Status has changed, update the transition time and signal that an update is required
 	if cond.Status != status {
-		if !cond.LastUpdateTime.IsZero() {
-			cond.LastTransitionTime = cond.LastUpdateTime
-		} else {
-			cond.LastTransitionTime = metav1.Now()
-		}
+		cond.LastTransitionTime = cond.LastUpdateTime
 		cond.Status = status
-		cond.LastUpdateTime = metav1.Now()
 		updateRequired = true
 	}
 


### PR DESCRIPTION
**Description of the change**

This PR modify the way that we are setting up the LastUpdateTime. We are going to modify the LastUpdateTime always that we are updating the Sealed Secrets and the LastTransitionTime only when the status has changed.

Integration tests included.

**Benefits**

LastUpdateTime is working properly

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #1470

