### PR TITLE
fix: Bring back private keys logging

### DIFF
--- a/docs/bring-your-own-certificates.md
+++ b/docs/bring-your-own-certificates.md
@@ -44,8 +44,8 @@ kubectl -n "$NAMESPACE" logs -l name=sealed-secrets-controller
 controller version: v0.12.1+dirty
 2020/06/09 14:30:45 Starting sealed-secrets controller version: v0.12.1+dirty
 2020/06/09 14:30:45 Searching for existing private keys
-2020/06/09 14:30:45 ----- sealed-secrets-key5rxd9
-2020/06/09 14:30:45 ----- mycustomkeys
+2020/06/09 14:30:45 registered private key secretname=sealed-secrets-key5rxd9
+2020/06/09 14:30:45 registered private key secretname=mycustomkeys
 2020/06/09 14:30:45 HTTP server serving on :8080
 ```
 

--- a/pkg/controller/main.go
+++ b/pkg/controller/main.go
@@ -90,6 +90,7 @@ func initKeyRegistry(ctx context.Context, client kubernetes.Interface, r io.Read
 		if err := keyRegistry.registerNewKey(secret.Name, key, certs[0], certs[0].NotBefore); err != nil {
 			return nil, err
 		}
+		slog.Info("registered private key", "secretname", secret.Name)
 	}
 	return keyRegistry, nil
 }


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

- Fixes missing log entries in the doc
https://github.com/bitnami-labs/sealed-secrets/blob/main/docs/bring-your-own-certificates.md#see-the-new-certificates-private-keys-in-the-controller-logs

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes https://github.com/bitnami-labs/sealed-secrets/commit/40c279fb9320f32aa91d04fa1572c5cf7e933cdf#r139767674

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
