### PR TITLE
fix(helm): role binding annotations

### DIFF
--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -14,6 +14,6 @@ maintainers:
     url: https://github.com/bitnami-labs/sealed-secrets
 name: sealed-secrets
 type: application
-version: 2.15.1
+version: 2.15.2
 sources:
   - https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/templates/role-binding.yaml
+++ b/helm/sealed-secrets/templates/role-binding.yaml
@@ -63,8 +63,8 @@ metadata:
     {{- include "sealed-secrets.render" ( dict "value" $.Values.rbac.labels "context" $) | nindent 4 }}
     {{- end }}
   annotations:
-    {{- if .Values.commonAnnotations }}
-    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- if $.Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
**Description of the change**
Use the right context for `commonAnnotations` in namespaced role bindings.

**Benefits**
Fix a bug preventing namespaced role bindings to be created.

**Applicable issues**
- fixes #1493

