### PR TITLE
chore: update cosign version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,9 @@ jobs:
       uses: actions/checkout@v3.1.0
 
     - name: Install Cosign
-      uses: sigstore/cosign-installer@v3.0.2
+      uses: sigstore/cosign-installer@v3.4.0
+      with:
+        cosign-release: v2.2.3
 
     - name: Distroless verify
       run: |

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -65,7 +65,10 @@ jobs:
 
       # Setup Cosign
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.0.2
+        uses: sigstore/cosign-installer@v3.4.0
+        with:
+          cosign-release: v2.2.3
+
         if: env.RELEASE == 1
       - name: Write Cosign key
         if: env.RELEASE == 1


### PR DESCRIPTION
**Description of the change**
- Update `cosign-installer` action to `v3.4.0`
- Use `cosign v2.2.3` in CI

**Benefits**
The version we are using, `v2.0.1`, fails to verify the distroless images:

```
Error: getting Rekor public keys: updating local metadata and targets: error updating to TUF remote mirror: invalid key
```