### PR TITLE
chore: increase vib timeout

### DIFF
--- a/.github/workflows/helm-vib.yaml
+++ b/.github/workflows/helm-vib.yaml
@@ -42,5 +42,6 @@ jobs:
       - uses: vmware-labs/vmware-image-builder-action@v0.6.0
         with:
           pipeline: ${{ matrix.target-pipeline }}
+          max-pipeline-duration: 7200
         env:
           TARGET_PLATFORM: ${{ matrix.target-platform-id }}


### PR DESCRIPTION
**Description of the change**
Increase the timeout for VIB pipelines to 7200 seconds (2 hours) from the default 90 minutes as OpenShift sometimes takes more than 90 minutes to run.
