### PR TITLE
fix: show field name in error message when base64 decoding fails

### DIFF
--- a/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
@@ -277,7 +277,8 @@ func (s *SealedSecret) Unseal(codecs runtimeserializer.CodecFactory, privKeys ma
 		for key, value := range s.Spec.EncryptedData {
 			valueBytes, err := base64.StdEncoding.DecodeString(value)
 			if err != nil {
-				return nil, err
+				errs = append(errs, multierror.Tag(key, err))
+				continue
 			}
 			plaintext, err := crypto.HybridDecrypt(rand.Reader, privKeys, valueBytes, label)
 			if err != nil {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

unsealing errors usually show the field name that caused the error - except for base64 decoding. This change fixes that.

**Benefits**

clearer error message

**Possible drawbacks**

none

**Applicable issues**


**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
