### PR TITLE
[helm] Set `GOMAXPROCS` and `GOMEMLIMIT` environment variables

### DIFF
--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -106,7 +106,7 @@ spec:
             {{- end }}
             - --privatekey-annotations
             - {{ trimSuffix "," $privatekeyAnnotations | quote }}
-            {{- end }}            
+            {{- end }}
             {{- if $.Values.privateKeyLabels }}
             {{- $privateKeyLabels := ""}}
             {{- range $k, $v := $.Values.privateKeyLabels }}
@@ -181,13 +181,13 @@ spec:
           {{- end }}
           volumeMounts:
             {{- if .Values.additionalVolumeMounts }}
-              {{- toYaml .Values.additionalVolumeMounts | nindent 12 }} 
+              {{- toYaml .Values.additionalVolumeMounts | nindent 12 }}
             {{- end }}
             - mountPath: /tmp
               name: tmp
-      volumes: 
+      volumes:
       {{- if .Values.additionalVolumes }}
-        {{- toYaml .Values.additionalVolumes | nindent 8 }} 
+        {{- toYaml .Values.additionalVolumes | nindent 8 }}
       {{- end }}
         - name: tmp
           emptyDir: {}

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -132,6 +132,19 @@ spec:
           {{- end }}
           image: {{ printf "%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            {{- if (.Values.resources.limits).cpu }}
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            {{- end }}
+            {{- if (.Values.resources.limits).memory }}
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            {{- end }}
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Set `GOMAXPROCS` and `GOMEMLIMIT` environment variables based on container resources.

Inspired by https://github.com/traefik/traefik-helm-chart/pull/1029.

**Benefits**

This should reduce potential CPU throttling and OOMKills on containers.

**Possible drawbacks**

This creates an empty `env` key for those not setting resource values. This is only a little ugly, but should not be harmful. Alternatively, we could add some conditional wrapper around the whole `env` block to only make it appear if a value is set, but that will be more complicated if additional env would be added in the future.

**Applicable issues**

N/A

**Additional information**

The [`resourceFieldRef`](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/#downwardapi-resourceFieldRef) is a very specific Kubernetes directive that is created specifically for passing resource-related values, which rounds up the CPU value to the nearest whole number (e.g. 250m to 1) and passes the memory as a numeric value; so `64Mi` would result in the environment variable being set to `67108864`. This by design makes it completely compatible with Go's API.

An example is documented within Kubernetes documentation itself: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#use-container-fields-as-values-for-environment-variables.
