### PR TITLE
readme: mention limitation of backup with key renewal

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,7 +742,7 @@ kubectl get secret -n kube-system sealed-secrets-key -o yaml >>main.key
 
 > NOTE: This file will contain the controller's public + private keys and should be kept omg-safe!
 
-> NOTE: Sealing key renewal requires another backup. Otherwise, newly sealed secrets cannot be decrypted.
+> NOTE: After sealing key renewal you should recreate your backup. Otherwise, your backup won't be able to decrypt new sealed secrets.
 
 To restore from a backup after some disaster, just put that secrets back before starting the controller - or if the controller was already started, replace the newly-created secrets and restart the controller:
 

--- a/README.md
+++ b/README.md
@@ -742,6 +742,8 @@ kubectl get secret -n kube-system sealed-secrets-key -o yaml >>main.key
 
 > NOTE: This file will contain the controller's public + private keys and should be kept omg-safe!
 
+> NOTE: Sealing key renewal requires another backup. Otherwise, newly sealed secrets cannot be decrypted.
+
 To restore from a backup after some disaster, just put that secrets back before starting the controller - or if the controller was already started, replace the newly-created secrets and restart the controller:
 
 * For Helm deployment:


### PR DESCRIPTION
**Description of the change**

Add a note about the limitation of backing up the public / private key with key renewal.

**Benefits**

Clarity about the limitation of backing up without understanding how key renewal works.

**Possible drawbacks**

Conciseness of readme

**Applicable issues**

none

**Additional information**

Tested in minikube.

- create secret
- backup sealedsecrets.bitnami.com/sealed-secrets-key to main.key
- force renewal
- create secret2
- backup sealedsecrets.bitnami.com/sealed-secrets-key to main2.key
- delete cluster and recreate
- restore main.key and secert2 cannot decrypt.
- restore main2.key and both secrets work
