### PR TITLE
feature: loadbalancerclass

### DIFF
--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -14,6 +14,6 @@ maintainers:
     url: https://github.com/bitnami-labs/sealed-secrets
 name: sealed-secrets
 type: application
-version: 2.15.4
+version: 2.16.0
 sources:
   - https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/Chart.yaml
+++ b/helm/sealed-secrets/Chart.yaml
@@ -14,6 +14,6 @@ maintainers:
     url: https://github.com/bitnami-labs/sealed-secrets
 name: sealed-secrets
 type: application
-version: 2.16.0
+version: 2.15.4
 sources:
   - https://github.com/bitnami-labs/sealed-secrets

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -152,6 +152,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                               | Description                                                                                                                      | Value                    |
 | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
 | `service.type`                     | Sealed Secret service type                                                                                                       | `ClusterIP`              |
+| `service.loadBalancerClass`        | Sealed Secret service loadBalancerClass                                                                                          | ``                       |
 | `service.port`                     | Sealed Secret service HTTP port                                                                                                  | `8080`                   |
 | `service.nodePort`                 | Node port for HTTP                                                                                                               | `""`                     |
 | `service.annotations`              | Additional custom annotations for Sealed Secret service                                                                          | `{}`                     |
@@ -213,6 +214,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.dashboards.annotations`           | Annotations to be added to the Grafana dashboard ConfigMap                             | `{}`        |
 | `metrics.dashboards.namespace`             | Namespace where Grafana dashboard ConfigMap is deployed                                | `""`        |
 | `metrics.service.type`                     | Sealed Secret Metrics service type                                                     | `ClusterIP` |
+| `metrics.service.loadBalancerClass`        | Sealed Secret service Metrics loadBalancerClass                                        | ``          |
 | `metrics.service.port`                     | Sealed Secret service Metrics HTTP port                                                | `8081`      |
 | `metrics.service.nodePort`                 | Node port for HTTP                                                                     | `""`        |
 | `metrics.service.annotations`              | Additional custom annotations for Sealed Secret Metrics service                        | `{}`        |

--- a/helm/sealed-secrets/templates/service.yaml
+++ b/helm/sealed-secrets/templates/service.yaml
@@ -22,6 +22,9 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.loadBalancerClass }}
+  loadBalancerClass: {{ . }}
+  {{- end }}
   ports:
     - name: http
       port: {{ .Values.service.port }}
@@ -57,6 +60,9 @@ metadata:
     app.kubernetes.io/component: metrics
 spec:
   type: {{ .Values.metrics.service.type }}
+  {{- with .Values.metrics.service.loadBalancerClass }}
+  loadBalancerClass: {{ . }}
+  {{- end }}
   ports:
     - name: metrics
       port: {{ .Values.metrics.service.port }}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -241,6 +241,9 @@ service:
   ## @param service.type Sealed Secret service type
   ##
   type: ClusterIP
+  ## @param service.loadBalancerClass Sealed Secret service loadBalancerClass
+  ##
+  loadBalancerClass: ""
   ## @param service.port Sealed Secret service HTTP port
   ##
   port: 8080
@@ -482,6 +485,9 @@ metrics:
     ## @param metrics.service.type Sealed Secret Metrics service type
     ##
     type: ClusterIP
+    ## @param metrics.service.loadBalancerClass Sealed Secret Metrics service loadBalancerClass
+    ##
+    loadBalancerClass: ""
     ## @param metrics.service.port Sealed Secret service Metrics HTTP port
     ##
     port: 8081


### PR DESCRIPTION
**Description of the change**

This allows to specify a loadbalancerclass on the created services.
From the kubernetes docs: 

> For a Service with type set to LoadBalancer, the .spec.loadBalancerClass field enables you to use a load balancer implementation other than the cloud provider default.
> 
> By default, .spec.loadBalancerClass is not set and a LoadBalancer type of Service uses the cloud provider's default load balancer implementation if the cluster is configured with a cloud provider using the --cloud-provider component flag.
> 
> If you specify .spec.loadBalancerClass, it is assumed that a load balancer implementation that matches the specified class is watching for Services. Any default load balancer implementation (for example, the one provided by the cloud provider) will ignore Services that have this field set. spec.loadBalancerClass can be set on a Service of type LoadBalancer only. Once set, it cannot be changed. The value of spec.loadBalancerClass must be a label-style identifier, with an optional prefix such as "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users.
