### PR TITLE
Update install instructions for consistent HTTP request package

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ The `kubeseal` client can be installed on Linux, using the below commands:
 
 ```bash
 KUBESEAL_VERSION='' # Set this to, for example, KUBESEAL_VERSION='0.23.0'
-wget "https://github.com/bitnami-labs/sealed-secrets/releases/download/v${KUBESEAL_VERSION:?}/kubeseal-${KUBESEAL_VERSION:?}-linux-amd64.tar.gz"
+curl -OL "https://github.com/bitnami-labs/sealed-secrets/releases/download/v${KUBESEAL_VERSION:?}/kubeseal-${KUBESEAL_VERSION:?}-linux-amd64.tar.gz"
 tar -xvzf kubeseal-${KUBESEAL_VERSION:?}-linux-amd64.tar.gz kubeseal
 sudo install -m 755 kubeseal /usr/local/bin/kubeseal
 ```
@@ -403,7 +403,7 @@ if [ -z "$KUBESEAL_VERSION" ]; then
     exit 1
 fi
 
-wget "https://github.com/bitnami-labs/sealed-secrets/releases/download/v${KUBESEAL_VERSION}/kubeseal-${KUBESEAL_VERSION}-linux-amd64.tar.gz"
+curl -OL "https://github.com/bitnami-labs/sealed-secrets/releases/download/v${KUBESEAL_VERSION}/kubeseal-${KUBESEAL_VERSION}-linux-amd64.tar.gz"
 tar -xvzf kubeseal-${KUBESEAL_VERSION}-linux-amd64.tar.gz kubeseal
 sudo install -m 755 kubeseal /usr/local/bin/kubeseal
 ```


### PR DESCRIPTION
**Description of the change**

The kubeseal install command instructions for linux contained both wget and curl commands. This change just uses curl.

**Benefits**

Reduce the dependencies need to run a one bash block install of kubeseal.

**Possible drawbacks**

The user has wget installed but not curl, now both commands (version get, and tar download) will fail. 

**Additional information**

I ran into an issue where I copy and pasted the linux install commands for kubeseal that contained the curl and jq to automatically pull the version number, but I didn't have wget installed.