### PR TITLE
Remove code setting name/namespace overriding secret templates

### DIFF
--- a/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
@@ -324,10 +324,6 @@ func (s *SealedSecret) Unseal(codecs runtimeserializer.CodecFactory, privKeys ma
 		return nil, fmt.Errorf("using deprecated 'data' field, use 'encryptedData' or flip the feature flag")
 	}
 
-	// Ensure these are set to what we expect
-	secret.SetNamespace(smeta.GetNamespace())
-	secret.SetName(smeta.GetName())
-
 	gvk := s.GetObjectKind().GroupVersionKind()
 	if anno, ok := s.Spec.Template.Annotations[SealedSecretSkipSetOwnerReferencesAnnotation]; !ok || anno != "true" {
 		// Refer back to owning SealedSecret


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

Currently, when specifying a template in a `SealedSecret` resource, `metadata.name` and `metadata.namespace` are ignored and the name and namespace from the source metadata is applied.

**Benefits**

<!-- What benefits will be realized by the code change? -->

Possibility to override the name and namespace of the generated `Secret` resource.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

The code that's overriding `metadata.name` and `metadata.namespace` is added before the templating functionality so I might be missing potential implications of this change. One thing that might be impactful is the fact that overriding the namespace might **enable somebody to apply a secret to a namespace they don't have access to**. If that is the case, the CRD should be updated to remove the `namespace` field from `spec.template.metadata` altogether.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #1543 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
