### PR TITLE
Show error if there's no secret to encode

### DIFF
--- a/integration/kubeseal_test.go
+++ b/integration/kubeseal_test.go
@@ -189,6 +189,21 @@ var _ = Describe("kubeseal", func() {
 	})
 })
 
+var _ = Describe("kubeseal (with invalid input)", func() {
+	var input io.Reader
+	var output *bytes.Buffer
+	var args []string
+
+	BeforeEach(func() {
+		output = &bytes.Buffer{}
+	})
+
+	It("should throw an error", func() {
+		err := runKubeseal(args, input, output)
+		Expect(err).To(HaveOccurred())
+	})
+})
+
 var _ = Describe("kubeseal --fetch-cert", func() {
 	var c corev1.CoreV1Interface
 	var input io.Reader

--- a/pkg/kubeseal/kubeseal.go
+++ b/pkg/kubeseal/kubeseal.go
@@ -189,6 +189,7 @@ func readSecrets(r io.Reader) ([]*v1.Secret, error) {
 			return nil, err
 		}
 	}
+
 	return secrets, nil
 }
 
@@ -224,6 +225,10 @@ func Seal(clientConfig ClientConfig, outputFormat string, in io.Reader, out io.W
 	secrets, err := readSecrets(in)
 	if err != nil {
 		return err
+	}
+
+	if len(secrets) == 0 {
+		return fmt.Errorf("no secrets found. Ensure the input is valid and UTF-8 encoded")
 	}
 
 	for _, secret := range secrets {


### PR DESCRIPTION
**Description of the change**
Kubeseal will throw an error when trying to seal no secrets. This will happen when the file is empty or invalid, and the error suggests the user to check the file encoding as this seems to be a common issue especially in some versions of Windows #1410 #1560 

**Benefits**
Give feedback to the user to help debugging a common issue

**Possible drawbacks**
Kubeseal will now throw an error where it previously just silently succeeded with no output

**Applicable issues**
- fixes #1410
- fixes #1560
