### PR TITLE
Redirect external site to the GitHub Repository

### DIFF
--- a/site/content/contributors/alemorcuq.md
+++ b/site/content/contributors/alemorcuq.md
@@ -1,7 +1,0 @@
----
-first_name: Alvaro
-last_name: Neira
-image: /img/team/alvneiayu.png
-github_handle: alvneiayu
----
-Maintainer

--- a/site/content/contributors/alvneiayu.md
+++ b/site/content/contributors/alvneiayu.md
@@ -1,7 +1,7 @@
 ---
-first_name: Alejandro
-last_name: Moreno
-image: /img/team/alemorcuq.png
-github_handle: alemorcuq
+first_name: Alvaro
+last_name: Neira
+image: /img/team/alvneiayu.png
+github_handle: alvneiayu
 ---
 Maintainer

--- a/site/themes/template/layouts/_default/baseof.html
+++ b/site/themes/template/layouts/_default/baseof.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode | default "en-us" }}">
 <head>
+	<meta http-equiv="refresh" content="0; url=https://github.com/bitnami-labs/sealed-secrets/" />
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
**Description of the change**

Sealed Secrets implemented an external documentation site a few years ago. This documentation site is currently outdated and does not offer a complete vision of the Sealed Secrets features and use cases. This PR redirects users to the GitHub repository where the latest documentation will be available 

**Benefits**

The team can concentrate efforts into developing new features and fixing bugs rather than maintaining a documentation site that is redundant. 

