### PR TITLE
Increase unseal retry limit

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	maxRetries = 5
+	maxRetries = 15
 
 	// SuccessUnsealed is used as part of the Event 'reason' when
 	// a SealedSecret is unsealed successfully.


### PR DESCRIPTION
**Description of the change**
Increase the number of maximum unseal retries to 15.

The original first 5 retries happen in just 200ms, which is not enough time for some scenarios, such as the one described in #1599.
 Increasing this number will ensure the exponential backoff takes off.

Here's an excerpt from the logs that shows the time at which each retry happens (starting at 1, since 0 shows the first attempt which is not a retry):

```
$ kubectl logs -n kube-system deploy/sealed-secrets-controller | grep Updating | nl -v 0
     0	time=2024-09-29T11:49:35.764Z level=INFO msg=Updating key=default/my-secret
     1	time=2024-09-29T11:49:35.777Z level=INFO msg=Updating key=default/my-secret
     2	time=2024-09-29T11:49:35.794Z level=INFO msg=Updating key=default/my-secret
     3	time=2024-09-29T11:49:35.822Z level=INFO msg=Updating key=default/my-secret
     4	time=2024-09-29T11:49:35.867Z level=INFO msg=Updating key=default/my-secret
     5	time=2024-09-29T11:49:35.955Z level=INFO msg=Updating key=default/my-secret
     6	time=2024-09-29T11:49:36.123Z level=INFO msg=Updating key=default/my-secret
     7	time=2024-09-29T11:49:36.451Z level=INFO msg=Updating key=default/my-secret
     8	time=2024-09-29T11:49:37.098Z level=INFO msg=Updating key=default/my-secret
     9	time=2024-09-29T11:49:38.389Z level=INFO msg=Updating key=default/my-secret
    10	time=2024-09-29T11:49:40.957Z level=INFO msg=Updating key=default/my-secret
    11	time=2024-09-29T11:49:46.088Z level=INFO msg=Updating key=default/my-secret
    12	time=2024-09-29T11:49:56.338Z level=INFO msg=Updating key=default/my-secret
    13	time=2024-09-29T11:50:16.823Z level=INFO msg=Updating key=default/my-secret
    14	time=2024-09-29T11:50:57.793Z level=INFO msg=Updating key=default/my-secret
    15	time=2024-09-29T11:52:19.723Z level=INFO msg=Updating key=default/my-secret
    16	time=2024-09-29T11:55:03.572Z level=INFO msg=Updating key=default/my-secret
```

**Benefits**
The controller takes longer to give up on a Sealed Secret.

**Possible drawbacks**
There will be more retries when the unseal error is legit, but that shouldn't cause any issues because of the exponential backoff.

**Applicable issues**
- fixes #1599 
