### PR TITLE
helm: allow container port configuration

### DIFF
--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -145,6 +145,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `additionalVolumes`                               | Extra Volumes for the Sealed Secrets Controller Deployment                                            | `{}`                                |
 | `additionalVolumeMounts`                          | Extra volumeMounts for the Sealed Secrets Controller container                                        | `{}`                                |
 | `hostNetwork`                                     | Sealed Secrets pods' hostNetwork                                                                      | `false`                             |
+| `containerPorts.http`                             | Controller HTTP Port on the Host and Container                                                        | `8080`                              |
+| `containerPorts.metrics`                          | Metrics HTTP Port on the Host and Container                                                           | `8081`                              |
+| `hostPorts.http`                                  | Controller HTTP Port on the Host                                                                      | `""`                                |
+| `hostPorts.metrics`                               | Metrics HTTP Port on the Host                                                                         | `""`                                |
 | `dnsPolicy`                                       | Sealed Secrets pods' dnsPolicy                                                                        | `""`                                |
 
 ### Traffic Exposure Parameters
@@ -152,7 +156,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                               | Description                                                                                                                      | Value                    |
 | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
 | `service.type`                     | Sealed Secret service type                                                                                                       | `ClusterIP`              |
-| `service.loadBalancerClass`        | Sealed Secret service loadBalancerClass                                                                                          | ``                       |
+| `service.loadBalancerClass`        | Sealed Secret service loadBalancerClass                                                                                          | `""`                     |
 | `service.port`                     | Sealed Secret service HTTP port                                                                                                  | `8080`                   |
 | `service.nodePort`                 | Node port for HTTP                                                                                                               | `""`                     |
 | `service.annotations`              | Additional custom annotations for Sealed Secret service                                                                          | `{}`                     |
@@ -214,7 +218,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.dashboards.annotations`           | Annotations to be added to the Grafana dashboard ConfigMap                             | `{}`        |
 | `metrics.dashboards.namespace`             | Namespace where Grafana dashboard ConfigMap is deployed                                | `""`        |
 | `metrics.service.type`                     | Sealed Secret Metrics service type                                                     | `ClusterIP` |
-| `metrics.service.loadBalancerClass`        | Sealed Secret service Metrics loadBalancerClass                                        | ``          |
+| `metrics.service.loadBalancerClass`        | Sealed Secret Metrics service loadBalancerClass                                        | `""`        |
 | `metrics.service.port`                     | Sealed Secret service Metrics HTTP port                                                | `8081`      |
 | `metrics.service.nodePort`                 | Node port for HTTP                                                                     | `""`        |
 | `metrics.service.annotations`              | Additional custom annotations for Sealed Secret Metrics service                        | `{}`        |

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -129,6 +129,14 @@ spec:
             - --log-format
             - {{ .Values.logFormat }}
             {{- end }}
+            {{- if .Values.containerPorts.http }}
+            - --listen-addr
+            - {{ printf ":%s" (.Values.containerPorts.http | toString ) }}
+            {{- end }}
+            {{- if .Values.containerPorts.metrics }}
+            - --listen-metrics-addr
+            - {{ printf ":%s" (.Values.containerPorts.metrics | toString) }}
+            {{- end }}
           {{- end }}
           image: {{ printf "%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -146,10 +154,20 @@ spec:
                   resource: limits.memory
             {{- end }}
           ports:
-            - containerPort: 8080
-              name: http
-            - containerPort: 8081
-              name: metrics
+            - name: http
+              containerPort: {{ .Values.containerPorts.http | default "8080" }}
+              {{- if .Values.hostNetwork }}
+              hostPort: {{ .Values.containerPorts.http }}
+              {{- else if .Values.hostPorts.http }}
+              hostPort: {{ .Values.hostPorts.http }}
+              {{- end }}
+            - name: metrics
+              containerPort: {{ .Values.containerPorts.metrics | default "8081" }}
+              {{- if .Values.hostNetwork }}
+              hostPort: {{ .Values.containerPorts.metrics }}
+              {{- else if .Values.hostPorts.metrics }}
+              hostPort: {{ .Values.hostPorts.metrics }}
+              {{- end }}
           {{- if .Values.startupProbe.enabled }}
           startupProbe: {{- include "sealed-secrets.render" (dict "value" (omit .Values.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -230,9 +230,25 @@ additionalVolumes: []
 additionalVolumeMounts: []
 ## @param hostNetwork Sealed Secrets pods' hostNetwork
 hostNetwork: false
+## Sealed Secrets controller ports to open
+## If hostNetwork true: the hostPort is set identical to the containerPort
+## @param containerPorts.http Controller HTTP Port on the Host and Container
+## @param containerPorts.metrics Metrics HTTP Port on the Host and Container
+##
+containerPorts:
+  http: 8080
+  metrics: 8081
+## Sealed Secrets controller ports to be exposed as hostPort
+## If hostNetwork is false, only the ports specified here will be exposed (or not if set to an empty string)
+## @param hostPorts.http Controller HTTP Port on the Host
+## @param hostPorts.metrics Metrics HTTP Port on the Host
+##
+hostPorts:
+  http: ""
+  metrics: ""
+
 ## @param dnsPolicy Sealed Secrets pods' dnsPolicy
 dnsPolicy: ""
-
 ## @section Traffic Exposure Parameters
 
 ## Sealed Secret service parameters


### PR DESCRIPTION
**Description of the change**
The container and host ports are now configurable in the Helm chart. As per the docs, when `hostNetwork` is enabled, the host ports are set equal to the container ports.

```
$ kubectl explain po.spec.containers.ports

[...]
   hostPort	<integer>
     Number of port to expose on the host. If specified, this must be a valid
     port number, 0 < x < 65536. If HostNetwork is specified, this must match
     ContainerPort. Most containers do not need this.
[...]
```

**Benefits**
Users can configure the ports to use.

**Possible drawbacks**
- 

**Applicable issues**
- fixes #1596
