### PR TITLE
Adding keyttl and keycutofftime options to helm chart

### DIFF
--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -95,6 +95,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `updateStatus`                                    | Specifies whether the Sealed Secrets controller should update the status subresource                  | `true`                              |
 | `skipRecreate`                                    | Specifies whether the Sealed Secrets controller should skip recreating removed secrets                | `false`                             |
 | `keyrenewperiod`                                  | Specifies key renewal period. Default 30 days                                                         | `""`                                |
+| `keyttl`                                          | Specifies generated certificate validity duration. Default 10 years                                   | `""`                                |
+| `keycutofftime`                                   | Specifies a date at which the controller must generate a new key. Useful in early renewal scenarios.  | `""`                                |
 | `rateLimit`                                       | Number of allowed sustained request per second for verify endpoint                                    | `""`                                |
 | `rateLimitBurst`                                  | Number of requests allowed to exceed the rate limit per second for verify endpoint                    | `""`                                |
 | `additionalNamespaces`                            | List of namespaces used to manage the Sealed Secrets                                                  | `[]`                                |

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -82,6 +82,14 @@ spec:
             - --key-renew-period
             - {{ .Values.keyrenewperiod | quote }}
             {{- end }}
+            {{- if .Values.keyttl }}
+            - --key-ttl
+            - {{ .Values.keyttl | quote }}
+            {{- end }}
+            {{- if .Values.keycutofftime }}
+            - --key-cutoff-time
+            - {{ .Values.keycutofftime | quote }}
+            {{- end }}
             {{- if .Values.rateLimit }}
             - --rate-limit
             - {{ .Values.rateLimit | quote }}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -77,6 +77,17 @@ skipRecreate: false
 ## To disable use "0", with quotes!
 ##
 keyrenewperiod: ""
+## @param keyttl Specifies the certificate validity duration. Default 10 years.
+## e.g for one year
+## keyttl: "8760h00m00s"
+##
+keyttl: ""
+## @param keycutofftime Specifies a date at which the controller should generate a new certificate. Useful in early key renewal scenarios.
+## Takes a date formated according to RFC1123. Can be obtained with the 'date -R' command on a unix system.
+## e.g 
+## keycutofftime: "Mon, 14 Oct 2024 21:45:30 +0200"
+##
+keycutofftime: ""
 ## @param rateLimit Number of allowed sustained request per second for verify endpoint
 ##
 rateLimit: ""


### PR DESCRIPTION
**Description of the change**

Hi, this change adds the two following controller flags as options in the helm chart :

- --key-ttl
- --key-cutoff-time

**Benefits**

It allows specifying those options without having to override the default args list defined by the helm chart.
Thus simplifying the early key renewal procedure when Sealed Secrets is deployed through ArgoCD for example.

**Possible drawbacks**

No drawback identified.

**Applicable issues**

Did not find an opened issue mentioning this.

**Additional information**

N/A
