### PR TITLE
Added SHA256 digest support to the helm deployment template 

### DIFF
--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -150,7 +150,11 @@ spec:
             - {{ .Values.maxRetries | quote }}
             {{- end }}
           {{- end }}
+          {{- if .Values.image.digest }}
+          image: {{ printf "%s/%s@sha256:%s" .Values.image.registry .Values.image.repository .Values.image.digest }}
+          {{- else }}
           image: {{ printf "%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.tag }}
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             {{- if (.Values.resources.limits).cpu }}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -33,6 +33,7 @@ commonLabels: {}
 ## @param image.registry Sealed Secrets image registry
 ## @param image.repository Sealed Secrets image repository
 ## @param image.tag Sealed Secrets image tag (immutable tags are recommended)
+## @param image.digest Sealed Secrets image SHA256 Digest value 
 ## @param image.pullPolicy Sealed Secrets image pull policy
 ## @param image.pullSecrets [array]  Sealed Secrets image pull secrets
 ##
@@ -40,6 +41,7 @@ image:
   registry: docker.io
   repository: bitnami/sealed-secrets-controller
   tag: 0.27.2
+  #digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**Description of the change**

Add SHA256 digest support to the deployment template and add the "digest" parameter to values.yaml 

**Benefits**

It is easy to pull images with specific SHA digest values when the need arises. 

**Possible drawbacks**

We used it in our production environment for a while and haven't seen any drawbacks yet. 



**Additional information**

The deployment template update to support the SHA digest helped us explicitly specify the SHA digest for particular architecture-based images when facing issues in the cluster that are irrelevant to sealed secrets and image pull. Having the SHA digest support helped us not have a roadblock to deploying and using sealed secrets smoothly. So, I am sharing the update we did and used with the community. 
