### PR TITLE
fix: explicitly set resourceFieldRef.divisor

### DIFF
--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -158,12 +158,14 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.cpu
+                  divisor: "1"
             {{- end }}
             {{- if (.Values.resources.limits).memory }}
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+                  divisor: "1"
             {{- end }}
           ports:
             - name: http


### PR DESCRIPTION
**Description of the change**

In the helm chart the divisor is not set and kubernetes mutates the Deployments to "0" which is the same as "1".

**Benefits**

When deploying with ArgoCD the application will not be displayed as "OutOfSync"

**Possible drawbacks**

---
