### PR TITLE
feat: Pad output from raw encryption on tty (fixes #874)

### DIFF
--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -256,7 +256,16 @@ func runCLI(w io.Writer, cfg *config) (err error) {
 			return err
 		}
 
-		return kubeseal.EncryptSecretItem(w, flags.secretName, ns, data, flags.sealingScope, pubKey)
+		separator := ""
+		if isatty.IsTerminal(os.Stdin.Fd()) {
+			separator = "\n"
+		}
+
+		fmt.Fprint(os.Stderr, separator)
+		fmt.Fprint(os.Stderr, separator)
+		err = kubeseal.EncryptSecretItem(w, flags.secretName, ns, data, flags.sealingScope, pubKey)
+		fmt.Fprint(os.Stderr, separator)
+		return err
 	}
 
 	return kubeseal.Seal(cfg.clientConfig, flags.outputFormat, input, w, scheme.Codecs, pubKey, flags.sealingScope, flags.allowEmptyData, flags.secretName, "")


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

As requested in #874, this increases the readability when using `--raw` in combination with a tty to ensure that the output is easier to parse for a human. I _specifically_ took a minimalist approach compared to what was presented as a solution in that discussion  so as to minimize potential impact if the tty check passes inadvertently.

**Benefits**

It will be easier to grab the output when using `--raw` from a tty.

**Possible drawbacks**

There could be situations where scripts that attach a tty will depend on this output, and it will change as a result of this.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #874

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
