### PR TITLE
Make controllers kubeclient QPS & Burst configurable.

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -63,6 +63,9 @@ func bindControllerFlags(f *controller.Flags, fs *flag.FlagSet) {
 	_ = fs.MarkDeprecated("rotate-period", "please use key-renew-period instead")
 
 	fs.IntVar(&f.MaxRetries, "max-unseal-retries", 5, "Max unseal retries.")
+
+	fs.Float32Var(&f.KubeClientQPS, "kubeclient-qps", 5, "Kubeclient QPS (negative value disables ratelimiting)")
+	fs.IntVar(&f.KubeClientBurst, "kubeclient-burst", 10, "Kubeclient Burst")
 }
 
 func bindFlags(f *controller.Flags, fs *flag.FlagSet, gofs *goflag.FlagSet) {

--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -107,6 +107,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `logFormat`                                       | Specifies log format (text,json)                                                                                   | `""`                                |
 | `maxRetries`                                      | Number of maximum retries                                                                                          | `""`                                |
 | `watchForSecrets`                                 | Specifies whether the Sealed Secrets controller will watch for new secrets                                         | `false`                             |
+| `kubeClientQPS`                                   | Kubeclient QPS (negative value disables ratelimiting)                                                              | `""`                                |
+| `kubeClientBurst`                                 | Kubeclient Burst                                                                                                   | `""`                                |
 | `command`                                         | Override default container command                                                                                 | `[]`                                |
 | `args`                                            | Override default container args                                                                                    | `[]`                                |
 | `livenessProbe.enabled`                           | Enable livenessProbe on Sealed Secret containers                                                                   | `true`                              |
@@ -184,25 +186,22 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Other Parameters
 
-| Name                           | Description                                                                                              | Value                                                                               |
-| ------------------------------ | -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `serviceAccount.annotations`   | Annotations for Sealed Secret service account                                                            | `{}`                                                                                |
-| `serviceAccount.create`        | Specifies whether a ServiceAccount should be created                                                     | `true`                                                                              |
-| `serviceAccount.labels`        | Extra labels to be added to the ServiceAccount                                                           | `{}`                                                                                |
-| `serviceAccount.name`          | The name of the ServiceAccount to use.                                                                   | `""`                                                                                |
-| `rbac.create`                  | Specifies whether RBAC resources should be created                                                       | `true`                                                                              |
-| `rbac.clusterRole`             | Specifies whether the Cluster Role resource should be created                                            | `true`                                                                              |
-| `rbac.clusterRoleName`         | Specifies the name for the Cluster Role resource                                                         | `secrets-unsealer`                                                                  |
-| `rbac.namespacedRoles`         | Specifies whether the namespaced Roles should be created (in each of the specified additionalNamespaces) | `false`                                                                             |
-| `rbac.namespacedRolesName`     | Specifies the name for the namespaced Role resource                                                      | `secrets-unsealer`                                                                  |
-| `rbac.labels`                  | Extra labels to be added to RBAC resources                                                               | `{}`                                                                                |
-| `rbac.pspEnabled`              | PodSecurityPolicy                                                                                        | `false`                                                                             |
-| `rbac.serviceProxier.create`   | Specifies whether to create the "proxier" role, to allow external users to access the SealedSecret API   | `true`                                                                              |
-| `rbac.serviceProxier.bind`     | Specifies whether to create a RoleBinding for the "proxier" role                                         | `true`                                                                              |
-| `rbac.serviceProxier.subjects` | Specifies the RBAC subjects to grant the "proxier" role to, in the created RoleBinding                   | `- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: system:authenticated
-` |
+| Name                           | Description                                                                                              | Value                                                                                    |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `serviceAccount.annotations`   | Annotations for Sealed Secret service account                                                            | `{}`                                                                                     |
+| `serviceAccount.create`        | Specifies whether a ServiceAccount should be created                                                     | `true`                                                                                   |
+| `serviceAccount.labels`        | Extra labels to be added to the ServiceAccount                                                           | `{}`                                                                                     |
+| `serviceAccount.name`          | The name of the ServiceAccount to use.                                                                   | `""`                                                                                     |
+| `rbac.create`                  | Specifies whether RBAC resources should be created                                                       | `true`                                                                                   |
+| `rbac.clusterRole`             | Specifies whether the Cluster Role resource should be created                                            | `true`                                                                                   |
+| `rbac.clusterRoleName`         | Specifies the name for the Cluster Role resource                                                         | `secrets-unsealer`                                                                       |
+| `rbac.namespacedRoles`         | Specifies whether the namespaced Roles should be created (in each of the specified additionalNamespaces) | `false`                                                                                  |
+| `rbac.namespacedRolesName`     | Specifies the name for the namespaced Role resource                                                      | `secrets-unsealer`                                                                       |
+| `rbac.labels`                  | Extra labels to be added to RBAC resources                                                               | `{}`                                                                                     |
+| `rbac.pspEnabled`              | PodSecurityPolicy                                                                                        | `false`                                                                                  |
+| `rbac.serviceProxier.create`   | Specifies whether to create the "proxier" role, to allow external users to access the SealedSecret API   | `true`                                                                                   |
+| `rbac.serviceProxier.bind`     | Specifies whether to create a RoleBinding for the "proxier" role                                         | `true`                                                                                   |
+| `rbac.serviceProxier.subjects` | Specifies the RBAC subjects to grant the "proxier" role to, in the created RoleBinding                   | <pre><code>- apiGroup: rbac.authorization.k8s.io<br>  kind: Group<br>  name: system:authenticated</code></pre> |
 
 ### Metrics parameters
 

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -152,6 +152,14 @@ spec:
             {{- if .Values.watchForSecrets }}
             - --watch-for-secrets
             {{- end }}
+            {{- if .Values.kubeClientQPS }}
+            - --kubeclient-qps
+            - {{ .Values.kubeClientQPS | quote }}
+            {{- end }}
+            {{- if .Values.kubeClientBurst }}
+            - --kubeclient-burst
+            - {{ .Values.kubeClientBurst | quote }}
+            {{- end }}
           {{- end }}
           image: {{ printf "%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -118,6 +118,12 @@ maxRetries: ""
 ## @param watchForSecrets Specifies whether the Sealed Secrets controller will watch for new secrets
 ##
 watchForSecrets: false
+## @param kubeClientQPS Kubeclient QPS (negative value disables ratelimiting)
+##
+kubeClientQPS: ""
+## @param kubeClientBurst Kubeclient Burst
+##
+kubeClientBurst: ""
 ## @param command Override default container command
 ##
 command: []

--- a/pkg/controller/main.go
+++ b/pkg/controller/main.go
@@ -60,6 +60,8 @@ type Flags struct {
 	PrivateKeyLabels      string
 	MaxRetries            int
 	WatchForSecrets       bool
+	KubeClientQPS         float32
+	KubeClientBurst       int
 }
 
 func initKeyPrefix(keyPrefix string) (string, error) {
@@ -209,6 +211,9 @@ func Main(f *Flags, version string) error {
 	if err != nil {
 		return err
 	}
+
+	config.QPS = f.KubeClientQPS
+	config.Burst = f.KubeClientBurst
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {


### PR DESCRIPTION
**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

The kubeclients QPS & Burst configuration was exposed by introducing additional CLI parameters. As well as exposing those parameters in the helm chart. 

**Benefits**

When running SealedSecrets controller reconcilation speed at startup will be increased, because more requests can be made. Therefore new Secrets while reconcile should be decrypted faster when having thousand of Secrets in the cluster.

**Applicable issues**

- fixes #1833 
