### PR TITLE
Add kseal to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -851,6 +851,7 @@ Click [here](http://slack.k8s.io) to sign up to the Kubernetes Slack org.
 
 ### Related projects
 
+- `kseal` A Kubeseal Companion: [https://github.com/eznix86/kseal](https://github.com/eznix86/kseal)
 - `kubeseal-convert`: [https://github.com/EladLeev/kubeseal-convert](https://github.com/EladLeev/kubeseal-convert)
 - Visual Studio Code extension: [https://marketplace.visualstudio.com/items?itemName=codecontemplator.kubeseal](https://marketplace.visualstudio.com/items?itemName=codecontemplator.kubeseal)
 - WebSeal: generates secrets in the browser: [https://socialgouv.github.io/webseal](https://socialgouv.github.io/webseal)


### PR DESCRIPTION
**Description of the change**

Adds [**kseal**](https://github.com/eznix86/kseal) in the README, a companion CLI that simplifies working with Bitnami Sealed Secrets. This wraps underlying `kubeseal` operations to make day-to-day tasks more ergonomic. 

**Benefits**

* Provides an alternative for viewing, exporting, encrypting Secrets and decrypting SealedSecrets
* Support multiple manifests in a single file.
 
Example
```
# app.yaml
kind: ConfigMap
---
kind: Secret <--- will only encrypt this part and keep the order if `--in-place` is specified. Same for decrypting with SealedSecrets.
---
kind: Deployment
```

**Possible drawbacks**

**Applicable issues**

**Additional information**

Example usage from *kseal*:

```bash
### Common Usage

# Generate a config file 
kseal init 
# .kseal-config.yaml
# version: 0.33.1 <---- which version of kubeseal to use for this project by default picks the last one.
# controller_name: sealed-secrets
# controller_namespace: sealed-secrets
# unsealed_dir: .unsealed <--- useful for export.


# View a decrypted secret from a SealedSecret manifest (requires cluster access)
kseal cat sealed.yaml

# Export decrypted secrets
kseal export sealed.yaml

# use files yaml to grab the manifests
kseal export --all

# use ownerReferences to get the secrets.
kseal export --all --from-cluster

# Encrypt a plaintext Secret (use kubeseal behind the scene)
kseal encrypt secret.yaml -o sealed.yaml
kseal encrypt secret.yaml --in-place
```

```bash
### Offline Decryption

# One-time: export private keys while cluster access is available
kseal export-keys

# Decrypt without cluster access (use kubeseal behind the scene)
kseal decrypt sealed.yaml
kseal decrypt-all --in-place
```

```bash
### Version Management

kseal version update # latest
kseal version set 0.33.1 # set global unless specified in the config
kseal version list # view all version of kubeseal installed
```
