### PR TITLE
Bump various GitHub action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v6.0.2
       - id: load-versions
         run: |
           source $GITHUB_WORKSPACE/versions.env
@@ -48,7 +48,7 @@ jobs:
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3.1.0
+      uses: actions/checkout@v6.0.2
 
     - name: Install dependencies
       run: |
@@ -79,7 +79,7 @@ jobs:
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3.1.0
+      uses: actions/checkout@v6.0.2
 
     - name: Install dependencies
       run: |
@@ -104,7 +104,7 @@ jobs:
         echo "CONTROLLER_IMAGE=$controller_registry/$controller_repository:$controller_tag" >> $GITHUB_ENV
 
     - name: Check out code
-      uses: actions/checkout@v3.1.0
+      uses: actions/checkout@v6.0.2
 
     - name: Install Cosign
       uses: sigstore/cosign-installer@v3.4.0
@@ -138,13 +138,13 @@ jobs:
         docker save $CONTROLLER_IMAGE -o /tmp/controller-image.tar
 
     - name: Upload manifest artifact
-      uses: actions/upload-artifact@v4.4.0
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: controller-manifest
         path: controller.yaml
 
     - name: Upload container image artifact
-      uses: actions/upload-artifact@v4.4.0
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: controller-image
         path: /tmp/controller-image.tar
@@ -176,7 +176,7 @@ jobs:
         go install github.com/onsi/ginkgo/ginkgo@v1.16.4
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3.1.0
+      uses: actions/checkout@v6.0.2
 
     - uses: medyagh/setup-minikube@v0.0.19
       with:
@@ -194,12 +194,12 @@ jobs:
         kubectl cluster-info
 
     - name: Download manifest artifact
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7.0.0
       with:
         name: controller-manifest
 
     - name: Download container image artifact
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7.0.0
       with:
         name: controller-image
 
@@ -244,7 +244,7 @@ jobs:
         go install github.com/onsi/ginkgo/ginkgo@v1.16.4
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3.1.0
+      uses: actions/checkout@v6.0.2
 
     - uses: medyagh/setup-minikube@v0.0.19
       with:
@@ -267,7 +267,7 @@ jobs:
         kubectl cluster-info
 
     - name: Download container image artifact
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7.0.0
       with:
         name: controller-image
 

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/helm-vib-lint.yaml
+++ b/.github/workflows/helm-vib-lint.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Lint chart
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v6.0.2
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}

--- a/.github/workflows/helm-vib.yaml
+++ b/.github/workflows/helm-vib.yaml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
     name: Verify chart (${{ matrix.name }})
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       # Checkout and set env
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
       - id: load-version

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v6.0.0
+      - uses: actions/stale@v10.1.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This Issue has been automatically marked as "stale" because it has not had recent activity (for 15 days). It will be closed if no further activity occurs. Thanks for the feedback.'


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Working on #1874 I encountered some issues with the setup-go action not working with latest Go download.
Given there are more outdated action references, this PR bumps them to latest to prevent further issues.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
There might be relevant breaking changes; I've not checked this thoroughly.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
