### PR TITLE
[Security] Throw an error in case of inconsistencies in the Sealed Secrets

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -568,6 +568,11 @@ func (c *Controller) Rotate(content []byte) ([]byte, error) {
 
 	switch s := object.(type) {
 	case *ssv1alpha1.SealedSecret:
+		// Verify metainformation is well set up in Template ObjectMeta and ObjectMeta to avoid unconsistences with the scope during the rotate.
+		if !reflect.DeepEqual(s.ObjectMeta, s.Spec.Template.ObjectMeta) {
+			return nil, fmt.Errorf("Sealed Secret invalid: metadata no longer matches the sealed secret")
+		}
+
 		secret, err := c.attemptUnseal(s)
 		if err != nil {
 			return nil, fmt.Errorf("error decrypting secret. %v", err)


### PR DESCRIPTION
    The goal is to verify that the metadata in the Sealed Secrets matches.
    If you modify a Sealed Secret by changing it to cluster-wide or namespace-only (by including it in the spec
    template metadata), the Sealed Secret's scope can be modified.

    This patch avoid it.