### PR TITLE
[Security] Preserve scope during Sealed Secret rotation

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -569,8 +569,10 @@ func (c *Controller) Rotate(content []byte) ([]byte, error) {
 	switch s := object.(type) {
 	case *ssv1alpha1.SealedSecret:
 		// Verify metainformation is well set up in Template ObjectMeta and ObjectMeta to avoid unconsistences with the scope during the rotate.
+		// This is going to keep the original scope.
 		if !reflect.DeepEqual(s.ObjectMeta, s.Spec.Template.ObjectMeta) {
-			return nil, fmt.Errorf("Sealed Secret invalid: metadata no longer matches the sealed secret")
+			s.ObjectMeta.DeepCopyInto(&s.Spec.Template.ObjectMeta)
+			slog.Warn("Sealed Secret metadata doesn't match. Please align your Sealed Secret metadata")
 		}
 
 		secret, err := c.attemptUnseal(s)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"encoding/json"
+
 	ssv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealedsecrets/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -382,8 +384,17 @@ func TestRotateKeepScope(t *testing.T) {
 		t.Fatalf("unexpected encoding the sealed secret: %v", err)
 	}
 
-	_, err = controller.Rotate(data)
-	if err == nil {
+	out, err := controller.Rotate(data)
+	if err != nil {
 		t.Fatalf("expected failure is not hit")
+	}
+
+	s := &ssv1alpha1.SealedSecret{}
+	if err = json.Unmarshal(out, s); err != nil {
+		t.Fatalf("error unmarshalling the rotate sealed secret")
+	}
+
+	if ssv1alpha1.SecretScope(s) != ssv1alpha1.SecretScope(ssecret) {
+		t.Fatalf("Scope from the original and the rotate sealed secret do not match")
 	}
 }


### PR DESCRIPTION
    This change avoids throwing an error during rotation and keeps the Sealed Secret’s scope
    correct by preferring the object’s metadata over the spec template metadata.