### PR TITLE
docs: document GKE Warden and RBAC restrictions

### DIFF
--- a/docs/GKE.md
+++ b/docs/GKE.md
@@ -7,6 +7,10 @@
   - [Private GKE clusters](#private-gke-clusters)
     - [Offline sealing](#offline-sealing)
     - [Control Plane to Node firewall](#control-plane-to-node-firewall)
+- [RBAC and GKE Warden Restrictions](#rbac-and-gke-warden-restrictions)
+- [Workarounds](#workarounds)
+  - [Option 1: Disable the service-proxier (Simplest)](#option-1-disable-the-service-proxier-simplest)
+  - [Option 2: Use Google Groups for RBAC (Recommended)](#option-2-use-google-groups-for-rbac-recommended)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -104,4 +108,66 @@ gcloud compute firewall-rules create gke-to-metrics-8081 \
   --source-ranges "$CP_IPV4_CIDR" \
   --target-tags "$NETWORK_TARGET_TAG" \
   --priority 1000
+```
+# RBAC and GKE Warden Restrictions
+
+On GKE clusters running version `1.32.2-gke.1182003` or later, the **GKE
+Warden admission webhook** strictly forbids binding any `Role` or
+`ClusterRole` to the `system:authenticated` group.
+
+By default, the `sealed-secrets` Helm chart binds the `service-proxier`
+role to this group to allow `kubeseal` to communicate with the
+controller and fetch the public key.
+
+On modern GKE versions, this default configuration will cause the
+installation to fail with the following error:
+
+``` text
+admission webhook "warden-validating.common-webhooks.networking.gke.io" denied the request:
+GKE Warden rejected the request because it violates one or more constraints.
+Violations details:
+{"[denied by rbac-binding-limitation]":["Binding any Role or ClusterRole to Group \"system:authenticated\" is forbidden."]}
+```
+
+------------------------------------------------------------------------
+
+# Workarounds
+
+To successfully deploy on GKE, you must override the default
+`serviceProxier` settings in your `values.yaml`.
+
+------------------------------------------------------------------------
+
+## Option 1: Disable the service-proxier (Simplest)
+
+If you do not need the `kubeseal --fetch-cert` functionality through the
+proxier, you can disable its creation entirely:
+
+``` yaml
+rbac:
+  serviceProxier:
+    create: false
+```
+
+------------------------------------------------------------------------
+
+## Option 2: Use Google Groups for RBAC (Recommended)
+
+For a more secure setup, bind the proxier role to a specific restricted
+Google Group instead of the broad `system:authenticated` group.
+
+This requires:
+
+1.  Setting up Google Groups for RBAC in your Google Cloud organization.
+2.  Creating an "anchor" group named
+    `gke-security-groups@yourdomain.com`.
+3.  Updating your Helm values to point to your specific subgroup:
+
+``` yaml
+rbac:
+  serviceProxier:
+    subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: "your-restricted-group@yourdomain.com"
 ```


### PR DESCRIPTION
**Description of the change**
This PR addresses a critical installation blocker for modern GKE clusters (v1.32.2+). Due to the **GKE Warden** admission webhook, RBAC bindings to the `system:authenticated` group are now strictly forbidden. I have updated `docs/GKE.md` to document this restriction and provided two workarounds using existing Helm values.

**Benefits**
* **Unblocks GKE Users:** Resolves the `[denied by rbac-binding-limitation]` error during installation.
* **Security Hardening:** Encourages users to adopt the Principle of Least Privilege by using Google Groups for RBAC.

**Possible drawbacks**
None. This is a documentation-only change that does not impact controller logic or existing Helm templates.

**Applicable issues**
- fixes #1448

**Additional information**
I have followed the project's contribution guidelines:
- Commit is **DCO signed-off** (`-s`).
- Table of Contents in `GKE.md` has been updated via **doctoc**.