### PR TITLE
fix: migrate goreleaser config to version 2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 project_name: sealed-secrets
 env:
   - CGO_ENABLED=0
@@ -27,7 +28,7 @@ builds:
       - linux_arm
       - windows_amd64
 archives:
-  - builds:
+  - ids:
       - kubeseal
     name_template: "kubeseal-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
 checksum:


### PR DESCRIPTION
I noticed deprecation warnings from GoReleaser so I thought I'd fix them.

## Summary

- Add `version: 2` header to `.goreleaser.yml`
- Replace deprecated `archives.builds` with `archives.ids`

This silences the deprecation warnings when running
GoReleaser v2:

```
DEPRECATED: archives.builds should not be used anymore
only version: 2 configuration files are supported, yours is version: 0
```

No functional changes — GoReleaser v2 is the same as
v1.26.2 with deprecated options removed.

Fixes #1898

## Test plan

- [x] `goreleaser check` validates cleanly
- [x] `goreleaser release --snapshot` builds with no
      deprecation warnings