### PR TITLE
fix: explicitly specify TCP protocol for helm SSA compatibility (#692)

### DIFF
--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -181,6 +181,7 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.containerPorts.http | default "8080" }}
+              protocol: TCP
               {{- if .Values.hostNetwork }}
               hostPort: {{ .Values.containerPorts.http }}
               {{- else if .Values.hostPorts.http }}
@@ -188,6 +189,7 @@ spec:
               {{- end }}
             - name: metrics
               containerPort: {{ .Values.containerPorts.metrics | default "8081" }}
+              protocol: TCP
               {{- if .Values.hostNetwork }}
               hostPort: {{ .Values.containerPorts.metrics }}
               {{- else if .Values.hostPorts.metrics }}

--- a/helm/sealed-secrets/templates/service.yaml
+++ b/helm/sealed-secrets/templates/service.yaml
@@ -29,6 +29,7 @@ spec:
     - name: http
       port: {{ .Values.service.port }}
       targetPort: http
+      protocol: TCP
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePort)) }}
       nodePort: {{ .Values.service.nodePort }}
       {{- else if eq .Values.service.type "ClusterIP" }}
@@ -67,6 +68,7 @@ spec:
     - name: metrics
       port: {{ .Values.metrics.service.port }}
       targetPort: metrics
+      protocol: TCP
       {{- if and (or (eq .Values.metrics.service.type "NodePort") (eq .Values.metrics.service.type "LoadBalancer")) (not (empty .Values.metrics.service.nodePort)) }}
       nodePort: {{ .Values.metrics.service.nodePort }}
       {{- else if eq .Values.metrics.service.type "ClusterIP" }}


### PR DESCRIPTION
**Description of the change**
This PR adds the explicit `protocol: TCP` field to the port definitions in the Sealed Secrets Helm chart.

While TCP is the default protocol in Kubernetes, Server-Side Apply (SSA) on clusters running version 1.19 or earlier can reject manifests if the protocol is not explicitly defined. This change ensures the Helm chart is compatible with modern GitOps workflows (like ArgoCD or Flux using SSA) across all supported Kubernetes versions.

**Targeted Files:**
- `templates/deployment.yaml`: Added `protocol: TCP` to the http and metrics container ports.
- `templates/service.yaml`: Added `protocol: TCP` to the main service and metrics service port definitions.

**Benefits**
- Resolves deployment failures when using Server-Side Apply on older Kubernetes clusters (<= 1.19).
- Improves manifest explicitness and follows best practices for cross-version compatibility.

**Applicable issues**
- fixes #692

**Checklist**
- [x] I have read the CONTRIBUTING doc.
- [x] My commit is Signed-off-by using `git commit -s`.
- [ ] (If applicable) Table of Contents in `README.md` or `values.txt` has been updated via `doctoc`.
- [x] Changes are focused solely on the Helm YAML templates as requested.