### PR TITLE
chore: remove note about deprecation of helm chart.

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,8 +298,6 @@ However this is confusing, so our current versioning rule is:
 There can be thus multiple revisions of the helm chart, with fixes that apply only to the helm chart without
 affecting the static YAML manifests or the controller image itself.
 
-> NOTE: The helm chart readme still contains a deprecation notice, but it no longer reflects reality and will be removed upon the next release.
-
 > NOTE: The helm chart by default installs the controller with the name `sealed-secrets`, while the `kubeseal` command line interface (CLI) tries to access the controller with the name `sealed-secrets-controller`. You can explicitly pass `--controller-name` to the CLI:
 
 ```bash


### PR DESCRIPTION
The mentioned deprecation notice in the helm chart was removed 13 months ago (+2 days ...), but the comment in the readme was forgotten.

The scope of the PR: just the main README.
Limitations: none. Just benefits,


**Description of the change**

Minor change removing a no longer relevant note.

**Benefits**

 The README file is less confusing.

**Possible drawbacks**

None.

**Applicable issues**

None.

**Additional information**

See commit 62a9eafe171ecd89474fe806d6165676fe04e4f2.
