### PR TITLE
fix: send INFO logs to stdout by default

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -55,7 +55,7 @@ func bindControllerFlags(f *controller.Flags, fs *flag.FlagSet) {
 
 	fs.BoolVar(&f.SkipRecreate, "skip-recreate", false, "if true the controller will skip listening for managed secret changes to recreate them. This helps on limited permission environments.")
 
-	fs.BoolVar(&f.LogInfoToStdout, "log-info-stdout", false, "if true the controller will log info to stdout.")
+	fs.BoolVar(&f.LogInfoToStdout, "log-info-stdout", true, "if true the controller will log info to stdout and error/warn to stderr.")
 	fs.StringVar(&f.LogLevel, "log-level", "INFO", "Log level (INFO|ERROR).")
 	fs.StringVar(&f.LogFormat, "log-format", "text", "Log format (text|json).")
 


### PR DESCRIPTION
## Summary

Changes the default value of `--log-info-stdout` from `false` to `true` so that INFO-level logs are written to stdout and WARN/ERROR logs to stderr, following standard Unix conventions.

The `MultiStreamHandler` and `--log-info-stdout` flag already exist in the codebase but the flag defaults to `false`, causing all log levels to go to stderr. This confuses log aggregation tools (e.g., Datadog) that classify stderr output as errors.

Users who need the old behavior can set `--log-info-stdout=false`.

Fixes #396

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all tests green)
- [ ] Deploy controller and verify INFO logs appear on stdout, ERROR/WARN on stderr