### PR TITLE
ci: bump K8s integration matrix to latest 1.33/1.34/1.35 patches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s: ["1.32.12","1.33.8","1.34.4","1.35.1"]
+        k8s: ["1.33.10","1.34.6","1.35.3"]
     env:
       MINIKUBE_WANTUPDATENOTIFICATION: "false"
       MINIKUBE_WANTREPORTERRORPROMPT: "false"
@@ -223,7 +223,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s: ["1.32.12","1.33.8","1.34.4","1.35.1"]
+        k8s: ["1.33.10","1.34.6","1.35.3"]
     env:
       MINIKUBE_WANTUPDATENOTIFICATION: "false"
       MINIKUBE_WANTREPORTERRORPROMPT: "false"


### PR DESCRIPTION
Align integration jobs with currently supported Kubernetes minor lines and latest patch releases per https://kubernetes.io/releases/ (1.33.10, 1.34.6, 1.35.3). Drop 1.32.x from the matrix now that 1.32 is end-of-life.

