### PR TITLE
Expose plaintext template.data values in template rendering context

### DIFF
--- a/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
@@ -324,7 +324,12 @@ func (s *SealedSecret) Unseal(codecs runtimeserializer.CodecFactory, privKeys ma
 			if err != nil {
 				errs = append(errs, multierror.Tag(key, err))
 			}
-			secret.Data[key] = plaintext.Bytes()
+			// Do not overwrite a key that was already populated from
+			// encryptedData; encrypted values take precedence in the
+			// output Secret as well as in the template rendering context.
+			if _, fromEncrypted := s.Spec.EncryptedData[key]; !fromEncrypted {
+				secret.Data[key] = plaintext.Bytes()
+			}
 		}
 
 		if errs != nil {

--- a/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
@@ -298,6 +298,20 @@ func (s *SealedSecret) Unseal(codecs runtimeserializer.CodecFactory, privKeys ma
 			data[key] = string(plaintext)
 		}
 
+		// Expose raw plaintext values from spec.template.data in the
+		// template rendering context, so that templates defined in
+		// spec.template.data can reference sibling plaintext keys as
+		// {{ .key }} variables (e.g. {{ .username }} alongside an
+		// encrypted password). Encrypted values take precedence on key
+		// collision so adding a plaintext key can never silently shadow
+		// a real secret value.
+		// See https://github.com/bitnami-labs/sealed-secrets/issues/1607
+		for key, value := range s.Spec.Template.Data {
+			if _, exists := data[key]; !exists {
+				data[key] = value
+			}
+		}
+
 		for key, value := range s.Spec.Template.Data {
 			var plaintext bytes.Buffer
 

--- a/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_test.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_test.go
@@ -391,6 +391,105 @@ func TestSealRoundTripTemplateData(t *testing.T) {
 	}
 }
 
+// TestTemplateDataPlaintextReference verifies that plaintext keys defined
+// in spec.template.data can be referenced from sibling templates as
+// {{ .key }} variables. Regression test for
+// https://github.com/bitnami-labs/sealed-secrets/issues/1607
+func TestTemplateDataPlaintextReference(t *testing.T) {
+	sealed := SealedSecret{
+		Spec: SealedSecretSpec{
+			Template: SecretTemplateSpec{
+				Data: map[string]string{
+					"username":     "myUsername",
+					"settings.xml": `<server><username>{{ .username }}</username></server>`,
+				},
+			},
+		},
+	}
+
+	unsealed, err := sealed.Unseal(serializer.CodecFactory{}, nil)
+	if err != nil {
+		t.Fatalf("Unseal returned error: %v", err)
+	}
+
+	if got, want := string(unsealed.Data["username"]), "myUsername"; got != want {
+		t.Errorf("username: got %q, want %q", got, want)
+	}
+	if got, want := string(unsealed.Data["settings.xml"]),
+		`<server><username>myUsername</username></server>`; got != want {
+		t.Errorf("settings.xml: got %q, want %q", got, want)
+	}
+}
+
+// TestTemplateDataMixedEncryptedAndPlaintext verifies that templates in
+// spec.template.data can reference both encryptedData keys and sibling
+// plaintext keys defined in spec.template.data in the same template.
+// Regression test for
+// https://github.com/bitnami-labs/sealed-secrets/issues/1607
+func TestTemplateDataMixedEncryptedAndPlaintext(t *testing.T) {
+	secret := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myname",
+			Namespace: "myns",
+		},
+		Data: map[string][]byte{
+			"password": []byte("hunter2"),
+		},
+	}
+
+	ssecret, codecs, keys := sealSecret(t, &secret, NewSealedSecret)
+
+	ssecret.Spec.Template.Data = map[string]string{
+		"username": "myUsername",
+		"settings.xml": `<server>` +
+			`<username>{{ .username }}</username>` +
+			`<password>{{ .password }}</password>` +
+			`</server>`,
+	}
+
+	unsealed, err := ssecret.Unseal(codecs, keys)
+	if err != nil {
+		t.Fatalf("Unseal returned error: %v", err)
+	}
+
+	if got, want := string(unsealed.Data["settings.xml"]),
+		`<server><username>myUsername</username><password>hunter2</password></server>`; got != want {
+		t.Errorf("settings.xml: got %q, want %q", got, want)
+	}
+}
+
+// TestTemplateDataEncryptedTakesPrecedenceOverPlaintext verifies that when
+// the same key exists in both encryptedData and template.data, the
+// decrypted value from encryptedData wins. This guards against accidentally
+// shadowing a real secret with a plaintext placeholder.
+func TestTemplateDataEncryptedTakesPrecedenceOverPlaintext(t *testing.T) {
+	secret := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myname",
+			Namespace: "myns",
+		},
+		Data: map[string][]byte{
+			"shared": []byte("from-encrypted"),
+		},
+	}
+
+	ssecret, codecs, keys := sealSecret(t, &secret, NewSealedSecret)
+
+	ssecret.Spec.Template.Data = map[string]string{
+		"shared":  "from-plaintext-should-be-ignored",
+		"out.txt": `{{ .shared }}`,
+	}
+
+	unsealed, err := ssecret.Unseal(codecs, keys)
+	if err != nil {
+		t.Fatalf("Unseal returned error: %v", err)
+	}
+
+	if got, want := string(unsealed.Data["out.txt"]), "from-encrypted"; got != want {
+		t.Errorf("out.txt: got %q, want %q", got, want)
+	}
+}
+
 func TestTemplateWithoutEncryptedData(t *testing.T) {
 	sealed := SealedSecret{
 		Spec: SealedSecretSpec{

--- a/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_test.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_test.go
@@ -488,6 +488,11 @@ func TestTemplateDataEncryptedTakesPrecedenceOverPlaintext(t *testing.T) {
 	if got, want := string(unsealed.Data["out.txt"]), "from-encrypted"; got != want {
 		t.Errorf("out.txt: got %q, want %q", got, want)
 	}
+	// The output Secret's "shared" key must retain the decrypted value,
+	// not be overwritten by the plaintext template.data entry.
+	if got, want := string(unsealed.Data["shared"]), "from-encrypted"; got != want {
+		t.Errorf("shared key in output Secret: got %q, want %q (plaintext template.data must not overwrite encrypted value)", got, want)
+	}
 }
 
 func TestTemplateWithoutEncryptedData(t *testing.T) {


### PR DESCRIPTION
## Summary

When a `SealedSecret` defines plaintext keys alongside encrypted keys inside `spec.template.data`, sibling templates in the same map could not reference those plaintext keys as `{{ .key }}` variables — the controller rendered `<no value>` instead of the configured plaintext value.

This PR fixes that by pre-populating the template execution context with the raw plaintext values from `spec.template.data` before rendering, so templates can reference them just like decrypted `encryptedData` keys.

Closes #1607

## Reproducer (matches the issue)

```yaml
apiVersion: bitnami.com/v1alpha1
kind: SealedSecret
metadata:
  name: mySecret
spec:
  encryptedData:
    password: <ciphertext>
  template:
    data:
      username: "myUsername"
      settings.xml: |-
        <server>
          <username>{{ .username }}</username>
          <password>{{ .password }}</password>
        </server>
```

**Before this PR**, the rendered `settings.xml` is:

```xml
<server>
  <username><no value></username>
  <password>plaintext password</password>
</server>
```

**After this PR**, it is:

```xml
<server>
  <username>myUsername</username>
  <password>plaintext password</password>
</server>
```

## Root cause

In `pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go`, `Unseal()` builds a `data` map that is used as the `text/template` execution context. That map was being populated **only** from decrypted entries of `spec.encryptedData`. The subsequent loop that renders each `spec.template.data` entry then ran with a context that did not contain any of the sibling plaintext values, so `{{ .username }}` resolved to a missing field and Go's `text/template` package emitted the literal string `<no value>`.

## Fix

Add a small additional loop **before** the rendering loop that copies each `spec.template.data` entry into the context as a raw string, but only if the key does not already exist in the context. This means:

- Plaintext keys defined in `spec.template.data` are now visible to all sibling templates as `{{ .key }}` variables.
- **Encrypted values always take precedence on key collision**, so adding a plaintext key with the same name as an encrypted key can never silently shadow a real secret value. This is covered by a regression test.
- Existing behavior for encrypted-only templating (e.g. the existing `TestSealRoundTripTemplateData`) is unchanged.

## Tests

Three new tests in `pkg/apis/sealedsecrets/v1alpha1/sealedsecret_test.go`:

1. **`TestTemplateDataPlaintextReference`** — pure plaintext `template.data` with cross-key references. Reproduces the exact symptom in the issue.
2. **`TestTemplateDataMixedEncryptedAndPlaintext`** — mixed encrypted + plaintext `template.data`, with a template that references both at once.
3. **`TestTemplateDataEncryptedTakesPrecedenceOverPlaintext`** — guards the precedence rule so future refactors cannot accidentally let a plaintext key shadow a decrypted one.

I followed TDD: tests 1 and 2 reproduce the bug and **fail on `main` with the exact `<no value>` output** users were seeing. Test 3 already passes on `main` and exists as a forward-looking guard.

## Verification performed locally

- `go test ./pkg/apis/sealedsecrets/v1alpha1/...` — all 11 tests in the package pass (3 new + 8 pre-existing)
- `go test ./pkg/...` — every package green (`controller`, `crypto`, `kubeseal`, `multidocyaml`, `pflagenv`, `flagenv`)
- `go vet ./pkg/apis/sealedsecrets/v1alpha1/...` — clean
- `gofmt -l` on touched files — clean
- Commit is signed off (DCO)

## Test plan for reviewers

- [x] CI green
- [x] Apply the reproducer YAML above against a cluster running this build and confirm the rendered `Secret`'s `settings.xml` contains both `myUsername` and the decrypted password.