### PR TITLE
Cooldown period for dependency updates and update K8S support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,13 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"
     directory: "/docker"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s: ["1.33.10","1.34.6","1.35.3"]
+        k8s: ["1.33.10","1.34.6","1.35.3", "1.36.0"]
     env:
       MINIKUBE_WANTUPDATENOTIFICATION: "false"
       MINIKUBE_WANTREPORTERRORPROMPT: "false"
@@ -226,7 +226,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s: ["1.33.10","1.34.6","1.35.3"]
+        k8s: ["1.33.10","1.34.6","1.35.3", "1.36.0"]
     env:
       MINIKUBE_WANTUPDATENOTIFICATION: "false"
       MINIKUBE_WANTREPORTERRORPROMPT: "false"


### PR DESCRIPTION
- Dependabot [cooldown period](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-) to prevent updating dependencies in an unstable state.

- Update the K8S support matrix with the recently released [1.36](https://kubernetes.io/releases/) version
 
