### PR TITLE
Add --metrics-omit-secret-labels to skip per-SealedSecret labels on condition_info

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -45,6 +45,7 @@ func bindControllerFlags(f *controller.Flags, fs *flag.FlagSet) {
 	fs.StringVar(&f.LabelSelector, "label-selector", "", "Label selector which can be used to filter sealed secrets.")
 	fs.IntVar(&f.RateLimitPerSecond, "rate-limit", 2, "Number of allowed sustained request per second for verify endpoint")
 	fs.IntVar(&f.RateLimitBurst, "rate-limit-burst", 2, "Number of requests allowed to exceed the rate limit per second for verify endpoint")
+	fs.BoolVar(&f.MetricsOmitSecretLabels, "metrics-omit-secret-labels", false, "When true, the sealed_secrets_controller_condition_info metric is not updated, so the metrics endpoint does not expose SealedSecret namespaces and names. Use this if :8081 is reachable by users who should not be able to enumerate SealedSecret inventory.")
 	fs.StringVar(&f.PrivateKeyAnnotations, "privatekey-annotations", "", "Comma-separated list of additional annotations to be put on renewed sealing keys.")
 	fs.StringVar(&f.PrivateKeyLabels, "privatekey-labels", "", "Comma-separated list of additional labels to be put on renewed sealing keys.")
 

--- a/pkg/controller/main.go
+++ b/pkg/controller/main.go
@@ -35,31 +35,32 @@ var (
 
 // Flags to configure the controller.
 type Flags struct {
-	KeyPrefix             string
-	KeySize               int
-	ValidFor              time.Duration
-	MyCN                  string
-	KeyRenewPeriod        time.Duration
-	KeyOrderPriority      string
-	AcceptV1Data          bool
-	KeyCutoffTime         string
-	NamespaceAll          bool
-	AdditionalNamespaces  string
-	LabelSelector         string
-	RateLimitPerSecond    int
-	RateLimitBurst        int
-	OldGCBehavior         bool
-	UpdateStatus          bool
-	SkipRecreate          bool
-	LogInfoToStdout       bool
-	LogLevel              string
-	LogFormat             string
-	PrivateKeyAnnotations string
-	PrivateKeyLabels      string
-	MaxRetries            int
-	WatchForSecrets       bool
-	KubeClientQPS         float32
-	KubeClientBurst       int
+	KeyPrefix               string
+	KeySize                 int
+	ValidFor                time.Duration
+	MyCN                    string
+	KeyRenewPeriod          time.Duration
+	KeyOrderPriority        string
+	AcceptV1Data            bool
+	KeyCutoffTime           string
+	NamespaceAll            bool
+	AdditionalNamespaces    string
+	LabelSelector           string
+	RateLimitPerSecond      int
+	RateLimitBurst          int
+	MetricsOmitSecretLabels bool
+	OldGCBehavior           bool
+	UpdateStatus            bool
+	SkipRecreate            bool
+	LogInfoToStdout         bool
+	LogLevel                string
+	LogFormat               string
+	PrivateKeyAnnotations   string
+	PrivateKeyLabels        string
+	MaxRetries              int
+	WatchForSecrets         bool
+	KubeClientQPS           float32
+	KubeClientBurst         int
 }
 
 func initKeyPrefix(keyPrefix string) (string, error) {
@@ -172,6 +173,7 @@ func initKeyRenewal(ctx context.Context, registry *KeyRegistry, period, validFor
 }
 
 func Main(f *Flags, version string) error {
+	SetMetricsOmitSecretLabels(f.MetricsOmitSecretLabels)
 	registerMetrics(version)
 
 	config, err := rest.InClusterConfig()

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -13,6 +13,17 @@ import (
 // Define Prometheus Exporter namespace (prefix) for all metric names.
 const metricNamespace string = "sealed_secrets_controller"
 
+// metricsOmitSecretLabels controls whether ObserveCondition and
+// UnregisterCondition emit per-SealedSecret labels on condition_info.
+// When true the gauge is not updated at all, so the metrics endpoint
+// no longer exposes an inventory of SealedSecret namespaces and names
+// to anyone who can reach :8081.
+var metricsOmitSecretLabels bool
+
+// SetMetricsOmitSecretLabels wires the controller flag into the metrics
+// package. Called once from controller.Main before registerMetrics.
+func SetMetricsOmitSecretLabels(b bool) { metricsOmitSecretLabels = b }
+
 const (
 	labelNamespace = "namespace"
 	labelName      = "name"
@@ -98,6 +109,9 @@ func registerMetrics(version string) {
 
 // ObserveCondition sets a `condition_info` Gauge according to a SealedSecret status.
 func ObserveCondition(ssecret *v1alpha1.SealedSecret) {
+	if metricsOmitSecretLabels {
+		return
+	}
 	if ssecret.Status == nil {
 		return
 	}
@@ -113,6 +127,9 @@ func ObserveCondition(ssecret *v1alpha1.SealedSecret) {
 
 // UnregisterCondition unregisters Gauges associated to a SealedSecret conditions.
 func UnregisterCondition(ssecret *v1alpha1.SealedSecret) {
+	if metricsOmitSecretLabels {
+		return
+	}
 	if ssecret.Status == nil {
 		return
 	}

--- a/pkg/controller/metrics_test.go
+++ b/pkg/controller/metrics_test.go
@@ -230,3 +230,33 @@ func getLabel(labels []*dto.LabelPair, name string) string {
 	}
 	return ""
 }
+
+func TestObserveConditionRespectsOmitSecretLabels(t *testing.T) {
+	registry := setupTestMetrics()
+	SetMetricsOmitSecretLabels(true)
+	t.Cleanup(func() { SetMetricsOmitSecretLabels(false) })
+
+	ssecret := &ssv1alpha1.SealedSecret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-ns",
+			Name:      "test-secret",
+		},
+		Status: &ssv1alpha1.SealedSecretStatus{
+			Conditions: []ssv1alpha1.SealedSecretCondition{
+				{Type: ssv1alpha1.SealedSecretSynced, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	ObserveCondition(ssecret)
+
+	metricFamilies, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %v", err)
+	}
+	for _, mf := range metricFamilies {
+		if mf.GetName() == "sealed_secrets_controller_condition_info" && len(mf.GetMetric()) > 0 {
+			t.Errorf("Expected condition_info to be empty when omit flag is on, got %d series", len(mf.GetMetric()))
+		}
+	}
+}


### PR DESCRIPTION
### What this does

Adds a new controller flag `--metrics-omit-secret-labels` (default `false`). When enabled, `sealed_secrets_controller_condition_info` is no longer updated, so the metrics endpoint stops emitting one time series per SealedSecret with the `namespace` / `name` labels. All other metrics (`unseal_requests_total`, `unseal_errors_total`, `http_*`) are unaffected.

### Why

The `condition_info` gauge carries `{namespace, name, condition, instance}` labels and is served on `:8081`, which has no auth middleware. The default Helm chart ships with `networkPolicy.enabled: false`, so any pod in the cluster can hit the endpoint and dump a full inventory of SealedSecret names and namespaces, regardless of whether the caller has any RBAC on `sealedsecrets`.

For operators who use descriptive names (`database-credentials`, `payment-api-key`, `stripe-prod-key`) or run multi-tenant clusters, that inventory itself is sensitive — it tells an attacker exactly which namespaces store which credentials. Even with a NetworkPolicy in place, anything authorised to scrape the metrics port can read it.

Discussed in advisory [GHSA-mx74-8fcw-qjrm](https://github.com/bitnami-labs/sealed-secrets/security/advisories/GHSA-mx74-8fcw-qjrm). @alvneiayu closed it as an insecure-config issue rather than a vuln, but agreed there's value in an option to restrict the information surfaced by the endpoint and suggested sending a PR.

### Design

A package-level toggle in `metrics.go` (`metricsOmitSecretLabels`) set by `SetMetricsOmitSecretLabels(...)`, called from `controller.Main` before `registerMetrics`. `ObserveCondition` / `UnregisterCondition` early-return when the toggle is on. Operators who want the labels back simply omit the flag — default behaviour is unchanged.

I considered a few alternatives (hash the labels, drop only `name` and keep `namespace`, etc.) but settled on the simplest restrict option for the first cut. Happy to switch to a `--metrics-secret-labels-mode={full,namespace-only,none}` style flag if you'd prefer that shape.

### Test

Added `TestObserveConditionRespectsOmitSecretLabels` — sets the flag, calls `ObserveCondition`, verifies the gauge has zero series.

```
go test ./pkg/controller/ -run "TestObserveCondition|TestUnregisterCondition" -v
...
--- PASS: TestObserveConditionRespectsOmitSecretLabels (0.00s)
PASS
```

### Notes

- Default `false` — no behaviour change unless the flag is set.
- I re-aligned the `Flags` struct field padding when adding the new field. That's why `pkg/controller/main.go` shows a larger diff than the actual logic change.
- Helm chart docs / values reference for the flag would be a nice follow-up. Happy to send a separate PR for that once the controller flag lands.