### PR TITLE
feat: add ppc64le architecture support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
         uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8 # v2.0.0
         with:
           image: tonistiigi/binfmt:latest
-          platforms: arm64,arm
+          platforms: arm64,arm,ppc64le
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # v2.0.0
 
@@ -119,7 +119,7 @@ jobs:
         with:
           context: .
           file: ./docker/controller.Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm
+          platforms: linux/amd64,linux/arm64,linux/arm,linux/ppc64le
           push: true
           tags: ${{ steps.meta_controller.outputs.tags }}
       - name: Extract metadata (tags, labels) for Docker kubeseal image
@@ -138,7 +138,7 @@ jobs:
         with:
           context: .
           file: ./docker/kubeseal.Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm
+          platforms: linux/amd64,linux/arm64,linux/arm,linux/ppc64le
           push: true
           tags: ${{ steps.meta_kubeseal.outputs.tags }}
       - name: Sign controller image with a key in GHCR

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,7 @@ builds:
       - linux_amd64
       - linux_arm64
       - linux_arm
+      - linux_ppc64le
       - windows_amd64
   - binary: kubeseal
     id: kubeseal
@@ -25,6 +26,7 @@ builds:
       - linux_amd64
       - linux_arm64
       - linux_arm
+      - linux_ppc64le
       - windows_amd64
 archives:
   - builds:

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ endef
 $(eval $(call binaries,linux,amd64))
 $(eval $(call binaries,linux,arm64))
 $(eval $(call binaries,linux,arm))
+$(eval $(call binaries,linux,ppc64le))
 $(eval $(call binaries,darwin,amd64))
 $(eval $(call binary,kubeseal,windows,amd64))
 
@@ -100,6 +101,7 @@ endef
 $(eval $(call images,linux,amd64))
 $(eval $(call images,linux,arm64))
 $(eval $(call images,linux,arm))
+$(eval $(call images,linux,ppc64le))
 
 %.yaml: %.jsonnet
 	$(KUBECFG) show -V CONTROLLER_IMAGE=$(CONTROLLER_IMAGE) -V IMAGE_PULL_POLICY=$(IMAGE_PULL_POLICY) -o yaml $< > $@.tmp


### PR DESCRIPTION
## Summary
 
Adds IBM Power (ppc64le) as a supported build and release target for both the `controller` and `kubeseal` binaries.
 
## Changes
 
- **Makefile**: register `linux/ppc64le` binary and container image build targets via the existing `binaries` / `images` macros.
- **.goreleaser.yml**: add `linux_ppc64le` to the `targets` list for both `controller` and `kubeseal` builds so GoReleaser produces and attaches a ppc64le archive to each GitHub release.
- **.github/workflows/release.yaml**:  add `linux/ppc64le` to the Docker `build-push-action` platforms for
    both the controller and kubeseal multi-arch images.
 
No changes to the Dockerfiles were required — they already consume `TARGETARCH` as a build-arg and use a glob copy pattern that picks up any architecture.
 
## Testing
 
CI lint and unit tests pass unchanged (pure build-system additions, no Go source changes). The new targets follow the identical pattern already used for `linux/arm64` and `linux/arm`.
 
Signed-off-by: Gianmarco <me@rogosprojects.it>