### PR TITLE
Allow setting hostUsers on deployment

### DIFF
--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -145,6 +145,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `containerSecurityContext.runAsUser`              | Set Sealed Secret containers' Security Context runAsUser                                                           | `1001`                              |
 | `containerSecurityContext.allowPrivilegeEscalation` | Set Sealed Secret containers' privilege escalation                                                               | `false`                             |
 | `containerSecurityContext.capabilities`           | Adds and removes POSIX capabilities from running containers (see `values.yaml`)                                    |                                     |
+| `hostUsers`                                       | Specifies whether or not host or namespaced users should be used                                                   | `null`                              |
 | `podLabels`                                       | Extra labels for Sealed Secret pods                                                                                | `{}`                                |
 | `podAnnotations`                                  | Annotations for Sealed Secret pods                                                                                 | `{}`                                |
 | `priorityClassName`                               | Sealed Secret pods' priorityClassName                                                                              | `""`                                |

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -54,6 +54,9 @@ spec:
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "sealed-secrets.serviceAccountName" . }}
+      {{- if kindIs "bool" .Values.hostUsers }}
+      hostUsers: {{ .Values.hostUsers }}
+      {{- end }}
       {{- if .Values.hostNetwork }}
       hostNetwork: true
       {{- end }}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -221,6 +221,10 @@ containerSecurityContext:
   capabilities:
     drop:
       - ALL
+## Enable user namespaces
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/
+##
+hostUsers: ~
 
 ## @param podLabels [object] Extra labels for Sealed Secret pods
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -221,7 +221,7 @@ containerSecurityContext:
   capabilities:
     drop:
       - ALL
-## Enable user namespaces
+## @param hostUsers Specifies whether or not host or namespaced users should be used
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/
 ##
 hostUsers: ~


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
As of Kubernetes 1.36, the User Namespaces feature has graduated to stable; see also https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/.

To leverage this on pods, one needs to set the hostUsers flag on a deployment. This MR adds the ability to add such a flag to this chart. See also https://kubernetes.io/docs/tasks/configure-pod-container/user-namespaces/.

**Benefits**

<!-- What benefits will be realized by the code change? -->
Allowing deployment to run with user namespaces, increasing (theoretical) security level.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
None

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
n/a

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
n/a