### PR TITLE
Adding default prometheusRule in helmChart to watch out of sync secrets

### DIFF
--- a/helm/sealed-secrets/templates/prometheusrule.yaml
+++ b/helm/sealed-secrets/templates/prometheusrule.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.metrics.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "sealed-secrets.fullname" . }}
+
+  {{- if .Values.metrics.prometheusRule.namespace }}
+  namespace: {{ .Values.metrics.prometheusRule.namespace }}
+  {{- else }}
+  namespace: {{ include "sealed-secrets.namespace" . }}
+  {{- end }}
+
+  labels:
+    {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.metrics.prometheusRule.labels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.metrics.prometheusRule.labels "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+
+  annotations:
+    {{- if .Values.metrics.prometheusRule.annotations }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.metrics.prometheusRule.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+    {{- end }}
+
+spec:
+  groups:
+    {{- range .Values.metrics.prometheusRule.groups }}
+    - name: {{ .name }}
+      rules:
+        {{- range .rules }}
+        - alert: {{ .alert }}
+          expr: |
+            {{ .expr | nindent 12 }}
+          {{- if .for }}
+          for: {{ .for }}
+          {{- end }}
+
+          {{- if .labels }}
+          labels:
+            {{- toYaml .labels | nindent 12 }}
+          {{- end }}
+
+          {{- if .annotations }}
+          annotations:
+            {{- toYaml .annotations | nindent 12 }}
+          {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -23,7 +23,7 @@ commonAnnotations: {}
 
 ## @param commonLabels [object] Labels to add to all deployed resources
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-## 
+##
 commonLabels: {}
 
 ## @section Sealed Secrets Parameters
@@ -84,7 +84,7 @@ keyrenewperiod: ""
 keyttl: ""
 ## @param keycutofftime Specifies a date at which the controller should generate a new certificate. Useful in early key renewal scenarios.
 ## Takes a date formated according to RFC1123. Can be obtained with the 'date -R' command on a unix system.
-## e.g 
+## e.g
 ## keycutofftime: "Mon, 14 Oct 2024 21:45:30 +0200"
 ##
 keycutofftime: ""
@@ -98,10 +98,10 @@ rateLimitBurst: ""
 ##
 additionalNamespaces: []
 ## @param privateKeyAnnotations Map of annotations to be set on the sealing keypairs
-## 
+##
 privateKeyAnnotations: {}
 ## @param privateKeyLabels Map of labels to be set on the sealing keypairs
-## 
+##
 privateKeyLabels: {}
 ## @param logInfoStdout Specifies whether the Sealed Secrets controller will log info to stdout
 ##
@@ -467,6 +467,37 @@ rbac:
 ## @section Metrics parameters
 
 metrics:
+  prometheusRule:
+    ## @param metrics.prometheusRule.enabled Specify if a PrometheusRule will be deployed for Prometheus Operator
+    ##
+    enabled: false
+
+    ## @param metrics.prometheusRule.namespace Namespace where Prometheus Operator is running in
+    ##
+    namespace: ""
+
+    ## @param metrics.prometheusRule.labels Extra labels for the PrometheusRule
+    ##
+    labels: {}
+
+    ## @param metrics.prometheusRule.annotations Extra annotations for the PrometheusRule
+    ##
+    annotations: {}
+
+    ## @param metrics.prometheusRule.groups Prometheus alerting rule groups
+    ##
+    groups:
+      - name: sealed-secrets-controller.rules
+        rules:
+          - alert: SealedSecretsControllerNotReady
+            expr: |
+              sealed_secrets_controller_condition_info != 1
+            for: 10m
+            labels:
+              severity: critical
+            annotations:
+              summary: "Sealed Secrets controller is not Synced"
+              description: "At least one SealedSecret is in a non-synced state (0 or -1). Check controller logs and secret reconciliation status."
   ## Prometheus Operator ServiceMonitor configuration
   ##
   serviceMonitor:


### PR DESCRIPTION
**Description of the change**

This change adds support for deploying a PrometheusRule resource for the Sealed Secrets Helm chart.
It allows users to define alerting rules for Sealed Secrets via `values.yaml` under `metrics.prometheusRule`.

**Benefits**

- Enables native Prometheus Operator alerting integration
- Allows users to define and customize alert rules via Helm values
- Aligns with existing `ServiceMonitor` pattern in the chart
- Improves observability of Sealed Secrets synchronization state

**Possible drawbacks**

- Introduces additional configuration complexity for users not using Prometheus Operator
- Users must ensure Prometheus Operator CRDs are installed for PrometheusRule to be applied

**Applicable issues**

- fixes #

**Additional information**

PrometheusRule is optional and disabled by default (`enabled: false`) to avoid unintended alerts in new deployments.