### PR TITLE
Update security context defaults to comply with restricted pod securi…

### DIFF
--- a/helm/sealed-secrets/README.md
+++ b/helm/sealed-secrets/README.md
@@ -5,22 +5,24 @@ Sealed Secrets are "one-way" encrypted K8s Secrets that can be created by anyone
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [TL;DR](#tldr)
-- [Introduction](#introduction)
-- [Prerequisites](#prerequisites)
-- [Installing the Chart](#installing-the-chart)
-- [Uninstalling the Chart](#uninstalling-the-chart)
-- [Parameters](#parameters)
-  - [Common parameters](#common-parameters)
-  - [Sealed Secrets Parameters](#sealed-secrets-parameters)
-  - [Traffic Exposure Parameters](#traffic-exposure-parameters)
-  - [Other Parameters](#other-parameters)
-  - [Metrics parameters](#metrics-parameters)
-- [Using kubeseal](#using-kubeseal)
-- [Configuration and installation details](#configuration-and-installation-details)
-- [Troubleshooting](#troubleshooting)
-- [Upgrading](#upgrading)
-  - [To 2.0.0](#to-200)
+- [Sealed Secrets](#sealed-secrets)
+  - [TL;DR](#tldr)
+  - [Introduction](#introduction)
+  - [Prerequisites](#prerequisites)
+  - [Installing the Chart](#installing-the-chart)
+  - [Uninstalling the Chart](#uninstalling-the-chart)
+  - [Parameters](#parameters)
+    - [Common parameters](#common-parameters)
+    - [Sealed Secrets Parameters](#sealed-secrets-parameters)
+    - [Traffic Exposure Parameters](#traffic-exposure-parameters)
+    - [Other Parameters](#other-parameters)
+    - [Metrics parameters](#metrics-parameters)
+    - [PodDisruptionBudget Parameters](#poddisruptionbudget-parameters)
+  - [Using kubeseal](#using-kubeseal)
+  - [Configuration and installation details](#configuration-and-installation-details)
+  - [Troubleshooting](#troubleshooting)
+  - [Upgrading](#upgrading)
+    - [To 2.0.0](#to-200)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto-update -->
 
@@ -136,10 +138,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `resources.requests`                              | The requested resources for the Sealed Secret containers                                                           | `{}`                                |
 | `podSecurityContext.enabled`                      | Enabled Sealed Secret pods' Security Context                                                                       | `true`                              |
 | `podSecurityContext.fsGroup`                      | Set Sealed Secret pod's Security Context fsGroup                                                                   | `65534`                             |
+| `podSecurityContext.seccompProfile.type`          | Set Sealed Secret pod's Security Context seccomp profile type                                                      | `RuntimeDefault`                    |
 | `containerSecurityContext.enabled`                | Enabled Sealed Secret containers' Security Context                                                                 | `true`                              |
 | `containerSecurityContext.readOnlyRootFilesystem` | Whether the Sealed Secret container has a read-only root filesystem                                                | `true`                              |
 | `containerSecurityContext.runAsNonRoot`           | Indicates that the Sealed Secret container must run as a non-root user                                             | `true`                              |
 | `containerSecurityContext.runAsUser`              | Set Sealed Secret containers' Security Context runAsUser                                                           | `1001`                              |
+| `containerSecurityContext.allowPrivilegeEscalation` | Set Sealed Secret containers' privilege escalation                                                               | `false`                             |
 | `containerSecurityContext.capabilities`           | Adds and removes POSIX capabilities from running containers (see `values.yaml`)                                    |                                     |
 | `podLabels`                                       | Extra labels for Sealed Secret pods                                                                                | `{}`                                |
 | `podAnnotations`                                  | Annotations for Sealed Secret pods                                                                                 | `{}`                                |

--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -195,16 +195,20 @@ resources:
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param podSecurityContext.enabled Enabled Sealed Secret pods' Security Context
 ## @param podSecurityContext.fsGroup Set Sealed Secret pod's Security Context fsGroup
+## @param podSecurityContext.seccompProfile.type Set Sealed Secret pod's Security Context seccomp profile type
 ##
 podSecurityContext:
   enabled: true
   fsGroup: 65534
+  seccompProfile:
+    type: RuntimeDefault
 ## Configure Container Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param containerSecurityContext.enabled Enabled Sealed Secret containers' Security Context
 ## @param containerSecurityContext.readOnlyRootFilesystem Whether the Sealed Secret container has a read-only root filesystem
 ## @param containerSecurityContext.runAsNonRoot Indicates that the Sealed Secret container must run as a non-root user
 ## @param containerSecurityContext.runAsUser Set Sealed Secret containers' Security Context runAsUser
+## @param containerSecurityContext.allowPrivilegeEscalation Set Sealed Secret containers' privilege escalation
 ## @extra containerSecurityContext.capabilities Adds and removes POSIX capabilities from running containers (see `values.yaml`)
 ## @skip  containerSecurityContext.capabilities.drop
 ##
@@ -213,6 +217,7 @@ containerSecurityContext:
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 1001
+  allowPrivilegeEscalation: false
   capabilities:
     drop:
       - ALL


### PR DESCRIPTION

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Updates the chart's default security context to comply with the Kubernetes restricted Pod Security Standard (see [Kuberntes Doc](https://kubernetes.io/docs/concepts/security/pod-security-standards/):
  - podSecurityContext.seccompProfile.type is now set to RuntimeDefault (pod-level).
  - containerSecurityContext.allowPrivilegeEscalation is now set to false (container-level).

**Benefits**

- Pods deployed with default values now satisfy the restricted Pod Security Standard, so the chart installs cleanly into namespaces enforcing  `pod-security.kubernetes.io/enforce: restricted` without extra overrides.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
